### PR TITLE
Add cordierite/client programmatic API for test runners

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -336,7 +336,7 @@ it.
   policy configuration leaves room for a future `prompt` value.
 - Audit: every `tools.call` appends one JSONL record to `audit/<date>.jsonl`:
   `{ ts, sessionId, alias, tool, argsSha256, outcome: "ok"|"error"|"denied",
-  errorType?, durationMs, caller: "cli"|"mcp" }`. Raw args are never logged.
+  errorType?, durationMs, caller: "cli"|"mcp"|"client" }`. Raw args are never logged.
 
 ## 13. Package layout
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -166,15 +166,15 @@ not as the mechanism that keeps a destructive tool out of reach of a hostile one
 
 - **Policy.** Set `config.json`'s `policy.default` / `policy.destructive` (and per-tool
   `policy.tools["<alias>/<name>"]` overrides) to `"deny"` for anything you don't want an
-  arbitrary caller invoking against a production build. Every `tools.call` — CLI and MCP
-  alike — is evaluated against this before it ever reaches the app; a denial returns
-  `policy_denied` and never sends a `tool_call` frame. Interactive consent prompting is
-  not implemented (the policy configuration reserves a future `"prompt"` value);
+  arbitrary caller invoking against a production build. Every `tools.call` — CLI, MCP, and
+  `cordierite/client` alike — is evaluated against this before it ever reaches the app;
+  a denial returns `policy_denied` and never sends a `tool_call` frame. Interactive consent
+  prompting is not implemented (the policy configuration reserves a future `"prompt"` value);
   until then, `"deny"` is the only way to gate a tool that needs human sign-off.
 - **Audit.** Every `tools.call` attempt — regardless of outcome — appends one line to
   `audit/<YYYY-MM-DD>.jsonl`: timestamp, session, alias, tool name, a sha256 of the
   canonicalized args (never the raw args), outcome, error type if any, duration, and
-  caller (`cli`/`mcp`). This is on unconditionally; there's no flag to disable it. Check
+  caller (`cli`/`mcp`/`client`). This is on unconditionally; there's no flag to disable it. Check
   `daemon.status`'s `audit.failedWrites` if you need to confirm the log is actually
   landing on disk (e.g. under a read-only or full filesystem).
 - **Inclusion defaults to dev builds only — not a compiled-in build-type check.** On iOS,

--- a/packages/cordierite/README.md
+++ b/packages/cordierite/README.md
@@ -108,7 +108,53 @@ Signals 2 and 3 are retained as fallbacks for artifacts built before the marker 
 
 ## Programmatic use
 
-The package exports `runCli` and command handlers from [`src/index.ts`](src/index.ts) so you can embed the same behavior in Node or Bun scripts that need to drive Cordierite without shelling out.
+### Test runners: `cordierite/client`
+
+A thin typed wrapper over the same daemon RPC the CLI and MCP server use — for a Jest/Vitest/Detox spec that wants to drive a running app without spawning `cordierite invoke ... --json` and parsing stdout:
+
+```ts
+import { connect } from "cordierite/client";
+
+// auto-spawns the daemon and picks the single session, or pass { selector: "pixel-8" } to target one explicitly
+const app = await connect();
+
+await app.tools();                                  // ToolDescriptor[]
+const { total } = await app.call("sum", { a: 2, b: 3 });
+const { payload } = await app.waitForEvent("checkout_done", { timeoutMs: 5_000 });
+app.close();
+```
+
+Errors surface as a `CordieriteError` whose `type` preserves the daemon's wire error type verbatim, so a test can assert on it directly instead of string-matching stderr:
+
+```ts
+await expect(app.call("checkout", {})).rejects.toMatchObject({ type: "policy_denied" });
+```
+
+Pair a simulator/emulator in a `globalSetup` without shelling out via `link`/`waitForSession`:
+
+```ts
+import { link, waitForSession } from "cordierite/client";
+
+const { sessionId } = await link({ target: "ios-sim" });
+const app = await waitForSession(sessionId, { timeoutMs: 60_000 });
+```
+
+`app.call`'s tool name and args/result types can't be inferred automatically (tools are registered by the connected app at runtime) — declare your own tool map once for typed calls throughout a suite:
+
+```ts
+type Tools = {
+  sum: { args: { a: number; b: number }; result: { total: number } };
+};
+
+const app = await connect<Tools>();
+const { total } = await app.call("sum", { a: 2, b: 3 }); // typed
+```
+
+`waitForEvent` subscribes live and has no visibility into events emitted before the call lands — call it before triggering the action that emits the event, not after ([#6](https://github.com/callstackincubator/cordierite/issues/6) tracks daemon-side event retention to remove this race).
+
+### Everything else: `runCli`
+
+The package also exports `runCli` and command handlers from [`src/index.ts`](src/index.ts) so you can embed the same behavior in Node or Bun scripts that need to drive Cordierite without shelling out.
 
 ## Related packages
 

--- a/packages/cordierite/package.json
+++ b/packages/cordierite/package.json
@@ -12,6 +12,11 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "import": "./dist/client/index.js",
+      "default": "./dist/client/index.js"
+    },
     "./package.json": "./package.json"
   },
   "bin": {

--- a/packages/cordierite/src/__tests__/e2e/client-bootstrap.e2e.test.ts
+++ b/packages/cordierite/src/__tests__/e2e/client-bootstrap.e2e.test.ts
@@ -1,0 +1,80 @@
+/**
+ * E2E scenario: the `cordierite/client` bootstrap half — `link()`/`waitForSession()` (issue #8) —
+ * against a real daemon and a fake app client, exercising: the already-claimed fast path, the
+ * claim racing the subscribe (regression coverage for the listener-must-register-before-subscribe
+ * ordering fix), and the timeout path.
+ */
+import { afterEach, describe, expect, test } from "vitest";
+
+import { link, waitForSession, CordieriteError } from "../../client/index.js";
+import { FakeAppClient } from "./app-client.js";
+import { cleanupAfterEach, decodeDeepLink, ensureDaemon, fetchPinnedKeys, makeTempStateDir } from "./harness.js";
+
+afterEach(cleanupAfterEach);
+
+describe("e2e: cordierite/client bootstrap", () => {
+  test("link() mints a claimable deep link, and waitForSession() resolves once a fake app claims it concurrently with the subscribe", async () => {
+    const { stateDir, port } = await makeTempStateDir();
+    await ensureDaemon(stateDir);
+    const pinnedKeys = await fetchPinnedKeys(stateDir);
+
+    const minted = await link({ stateDir, ttlSeconds: 60 });
+    expect(minted.sessionId).toBeTruthy();
+    expect(minted.deepLink).toContain("cordierite=");
+
+    const decoded = decodeDeepLink(minted.deepLink);
+    const fakeApp = new FakeAppClient(port, pinnedKeys);
+
+    // No artificial delay between starting the wait and claiming — this is exactly the window
+    // where a `session_claimed` notification can land in the same TCP chunk as the
+    // `events.subscribe` response, which the listener-registration-order fix in bootstrap.ts
+    // exists to handle correctly.
+    const [app] = await Promise.all([
+      waitForSession(minted.sessionId, { stateDir, timeoutMs: 10_000 }),
+      fakeApp.claim(decoded, { model: "Pixel 8" }),
+    ]);
+
+    expect(app.sessionId).toBe(minted.sessionId);
+
+    app.close();
+    fakeApp.close();
+  });
+
+  test("waitForSession() resolves immediately when the session is already claimed", async () => {
+    const { stateDir, port } = await makeTempStateDir();
+    await ensureDaemon(stateDir);
+    const pinnedKeys = await fetchPinnedKeys(stateDir);
+
+    const minted = await link({ stateDir });
+    const decoded = decodeDeepLink(minted.deepLink);
+    const fakeApp = new FakeAppClient(port, pinnedKeys);
+    await fakeApp.claim(decoded, { model: "Pixel 8" });
+
+    const app = await waitForSession(minted.sessionId, { stateDir, timeoutMs: 5_000 });
+    expect(app.sessionId).toBe(minted.sessionId);
+
+    app.close();
+    fakeApp.close();
+  });
+
+  test("waitForSession() rejects with a client-only \"timeout\" CordieriteError if nothing ever claims it", async () => {
+    const { stateDir } = await makeTempStateDir();
+    await ensureDaemon(stateDir);
+
+    const minted = await link({ stateDir });
+
+    await expect(waitForSession(minted.sessionId, { stateDir, timeoutMs: 300 })).rejects.toBeInstanceOf(
+      CordieriteError,
+    );
+    await expect(waitForSession(minted.sessionId, { stateDir, timeoutMs: 300 })).rejects.toMatchObject({
+      type: "timeout",
+    });
+  });
+
+  test("link() rejects with a client_error CordieriteError when no scheme is configured or available", async () => {
+    const { stateDir } = await makeTempStateDir({ scheme: undefined });
+    await ensureDaemon(stateDir);
+
+    await expect(link({ stateDir })).rejects.toMatchObject({ type: "client_error" });
+  });
+});

--- a/packages/cordierite/src/__tests__/e2e/client.e2e.test.ts
+++ b/packages/cordierite/src/__tests__/e2e/client.e2e.test.ts
@@ -1,0 +1,192 @@
+/**
+ * E2E scenario: the `cordierite/client` programmatic API (issue #8). Drives a full session
+ * lifecycle — claim, register tools, call a tool, wait for an app-pushed event, and a policy-denied
+ * call — entirely through `connect()`/`AppClient`, never through a CLI subprocess, and asserts the
+ * audit trail attributes these calls to `caller: "client"`.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { connect, CordieriteError } from "../../client/index.js";
+import { getStateDirPaths } from "../../daemon/state-dir.js";
+import { FakeAppClient } from "./app-client.js";
+import { cleanupAfterEach, ensureDaemon, fetchPinnedKeys, makeTempStateDir, mintLink, subscribeToEvents } from "./harness.js";
+
+afterEach(cleanupAfterEach);
+
+type AuditRecord = {
+  sessionId: string;
+  alias: string;
+  tool: string;
+  outcome: "ok" | "error" | "denied";
+  caller: "cli" | "mcp" | "client";
+};
+
+const readTodaysAuditRecords = async (stateDir: string): Promise<AuditRecord[]> => {
+  const paths = getStateDirPaths(stateDir);
+  const dateStamp = new Date().toISOString().slice(0, 10);
+  const raw = await readFile(path.join(paths.auditDir, `${dateStamp}.jsonl`), "utf8");
+
+  return raw
+    .trim()
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as AuditRecord);
+};
+
+/** A caller-declared tool map, `interface`-style (not a `type` alias) — regression coverage for
+ * `AppClient<TTools>` being unconstrained so both forms type-check (a `Record<string, ...>`-bound
+ * generic would reject this: TS only infers an implicit index signature for `type` aliases, not for
+ * `interface`s). */
+interface Tools {
+  sum: { args: { a: number; b: number }; result: { total: number } };
+  deleteAll: { args: Record<string, never>; result: string };
+}
+
+describe("e2e: cordierite/client", () => {
+  test(
+    "connect() -> tools() -> call() -> waitForEvent() round-trips against a real daemon and app, audited as caller \"client\"",
+    async () => {
+      const { stateDir, port } = await makeTempStateDir({ policy: { destructive: "deny" } });
+      await ensureDaemon(stateDir);
+      const pinnedKeys = await fetchPinnedKeys(stateDir);
+
+      const events = await subscribeToEvents(stateDir);
+      const link = await mintLink(stateDir);
+      const fakeApp = new FakeAppClient(port, pinnedKeys);
+      const ack = await fakeApp.claim(link, { model: "Pixel 8" });
+
+      const toolsChanged = events.waitFor("tools_changed");
+      fakeApp.registerTools([
+        { name: "sum" },
+        { name: "deleteAll", annotations: { destructiveHint: true } },
+      ]);
+      await toolsChanged;
+      events.close();
+
+      fakeApp.answerCalls((call) => {
+        if (call.name === "sum") {
+          const { a, b } = call.args as { a: number; b: number };
+          return { result: { total: a + b } };
+        }
+
+        return { result: "ok" };
+      });
+
+      const app = await connect<Tools>({ stateDir, selector: link.sessionId });
+      expect(app.sessionId).toBe(link.sessionId);
+
+      const tools = await app.tools();
+      expect(tools.map((tool) => tool.name).sort()).toEqual(["deleteAll", "sum"]);
+
+      // Typed end to end: no cast needed for `.total` (regression coverage for the default
+      // `ToolMap`'s `result: any` and the interface-based `Tools` map above).
+      const { total } = await app.call("sum", { a: 2, b: 3 });
+      expect(total).toBe(5);
+
+      const waitingForEvent = app.waitForEvent<{ orderId: string }>("checkout_done", { timeoutMs: 5000 });
+      fakeApp.emitEvent("checkout_done", { orderId: "42" });
+      const event = await waitingForEvent;
+      expect(event).toMatchObject({ name: "checkout_done", payload: { orderId: "42" } });
+
+      await expect(app.call("no_such_tool" as never, {})).rejects.toMatchObject({ type: "tool_not_found" });
+      await expect(app.call("deleteAll", {})).rejects.toMatchObject({ type: "policy_denied" });
+
+      const records = (await readTodaysAuditRecords(stateDir)).filter((record) => record.alias === ack.alias);
+
+      expect(records).toContainEqual(
+        expect.objectContaining({ tool: "sum", outcome: "ok", caller: "client" }),
+      );
+      expect(records).toContainEqual(
+        expect.objectContaining({ tool: "no_such_tool", outcome: "error", caller: "client" }),
+      );
+      expect(records).toContainEqual(
+        expect.objectContaining({ tool: "deleteAll", outcome: "denied", caller: "client" }),
+      );
+
+      app.close();
+      fakeApp.close();
+    },
+    15_000,
+  );
+
+  test(
+    "call()'s transport timeout never fires before the daemon's own tool_timeout, even for a timeoutMs above the transport default",
+    async () => {
+      const { stateDir, port } = await makeTempStateDir();
+      await ensureDaemon(stateDir);
+      const pinnedKeys = await fetchPinnedKeys(stateDir);
+
+      const events = await subscribeToEvents(stateDir);
+      const link = await mintLink(stateDir);
+      const fakeApp = new FakeAppClient(port, pinnedKeys);
+      await fakeApp.claim(link, { model: "Pixel 8" });
+
+      const toolsChanged = events.waitFor("tools_changed");
+      fakeApp.registerTools([{ name: "neverResponds" }]);
+      await toolsChanged;
+      events.close();
+      // Deliberately never calls `answerCalls` — the daemon's own clamped tool_timeout must be
+      // what ends this call, not this client's transport-level request timeout.
+
+      const app = await connect({ stateDir, selector: link.sessionId });
+
+      // Above the old hardcoded 10s transport default: before the fix this reliably surfaced as
+      // `connection_error` ("Timed out waiting for a response to tools.call") instead of the
+      // daemon's own `tool_timeout`.
+      await expect(app.call("neverResponds", {}, { timeoutMs: 12_000 })).rejects.toMatchObject({
+        type: "tool_timeout",
+      });
+
+      app.close();
+      fakeApp.close();
+    },
+    20_000,
+  );
+
+  test("waitForEvent() rejects (rather than crashing the connection) when its match predicate throws", async () => {
+    const { stateDir, port } = await makeTempStateDir();
+    await ensureDaemon(stateDir);
+    const pinnedKeys = await fetchPinnedKeys(stateDir);
+
+    const events = await subscribeToEvents(stateDir);
+    const link = await mintLink(stateDir);
+    const fakeApp = new FakeAppClient(port, pinnedKeys);
+    await fakeApp.claim(link, { model: "Pixel 8" });
+
+    const toolsChanged = events.waitFor("tools_changed");
+    fakeApp.registerTools([{ name: "echo" }]);
+    await toolsChanged;
+    events.close();
+    fakeApp.answerCalls(() => ({ result: "ok" }));
+
+    const app = await connect({ stateDir, selector: link.sessionId });
+
+    const waiting = app.waitForEvent("boom", {
+      timeoutMs: 5000,
+      match: () => {
+        throw new Error("predicate exploded");
+      },
+    });
+
+    fakeApp.emitEvent("boom", { anything: true });
+    await expect(waiting).rejects.toThrow("predicate exploded");
+
+    // The connection must still be usable afterwards — a throwing listener must not have taken
+    // down the socket's data handler for every other in-flight/future call.
+    const result = await app.call("echo", {});
+    expect(result).toBe("ok");
+
+    app.close();
+    fakeApp.close();
+  });
+
+  test("connect() rejects with a connection_error CordieriteError when the daemon is unreachable and auto-spawn is disabled", async () => {
+    const { stateDir } = await makeTempStateDir();
+
+    await expect(connect({ stateDir, autoSpawn: false })).rejects.toBeInstanceOf(CordieriteError);
+    await expect(connect({ stateDir, autoSpawn: false })).rejects.toMatchObject({ type: "connection_error" });
+  });
+});

--- a/packages/cordierite/src/client/app-client.ts
+++ b/packages/cordierite/src/client/app-client.ts
@@ -1,0 +1,217 @@
+/**
+ * The typed client handle (issue #8) returned by {@link connect}/{@link waitForSession}: a thin
+ * wrapper over the same `tools.list`/`tools.call`/`events.subscribe` RPC the CLI and MCP server use
+ * (`rpc/client.ts`'s `DaemonStream`), bound to one resolved session. No new privilege or transport —
+ * every call is attributed `caller: "client"` for the audit log (ARCHITECTURE.md §12).
+ */
+import { RPC_METHODS, type EventNotification, type ToolDescriptor, type ToolsCallResult, type ToolsListResult } from "@cordierite/shared";
+
+import type { DaemonStream } from "../rpc/client.js";
+import { CordieriteError, toCordieriteError } from "./errors.js";
+
+/** A project's own tool map — declared once, e.g. `type Tools = { sum: { args: { a: number; b:
+ * number }; result: { total: number } } }` — to get typed {@link AppClient.call} throughout a test
+ * suite. Tool names and arg/result types can't be statically known here (they're registered by the
+ * connected app at runtime): the default `result` is `any` so the untyped form (`connect()` with no
+ * generic) still lets a caller destructure a call's result without a cast, e.g. `const { total } =
+ * await app.call("sum", { a: 2, b: 3 })`. `AppClient` itself is deliberately unconstrained (no
+ * `extends Record<string, ...>`) so both `type` aliases and plain `interface`s work here — TS only
+ * infers an implicit index signature for the former, so a constrained generic would silently reject
+ * the latter. */
+export type ToolMap = Record<string, { args: Record<string, unknown>; result: any }>;
+
+type ToolArgs<TTools, K extends keyof TTools> = TTools[K] extends { args: infer TArgs } ? TArgs : Record<string, unknown>;
+type ToolResult<TTools, K extends keyof TTools> = TTools[K] extends { result: infer TResult } ? TResult : unknown;
+
+export type CallOptions = {
+  /** Forwarded to the daemon as the tool's own deadline (clamped server-side to [1s, 600s],
+   * default 10s) — NOT this call's transport timeout, which is derived from it automatically so a
+   * `tool_timeout` from the daemon always arrives before this client's own transport timeout would
+   * otherwise fire and misreport it as `connection_error`. */
+  timeoutMs?: number;
+};
+
+export type WaitForEventOptions = {
+  /** Defaults to 30s. */
+  timeoutMs?: number;
+  /** Extra filter over the event's payload; the event still must match `name` first. A predicate
+   * that throws rejects the wait with that error rather than crashing the connection. */
+  match?: (payload: unknown) => boolean;
+};
+
+/** An app-pushed event (`postEvent(name, payload)`), narrowed from the daemon's generic
+ * `EventNotification` envelope to the shape a `waitForEvent` caller actually wants. */
+export type AppEvent<TPayload = unknown> = {
+  name: string;
+  payload: TPayload;
+  /** Unix ms. */
+  ts: number;
+  sessionId: string;
+  alias?: string;
+};
+
+export type AppClient<TTools = ToolMap> = {
+  readonly sessionId: string;
+
+  /** `tools.list` for this session. */
+  tools(): Promise<ToolDescriptor[]>;
+
+  /** `tools.call`; rejects with a {@link CordieriteError} whose `type` preserves the wire error
+   * type verbatim (e.g. `"tool_timeout"`, `"policy_denied"`, `"session_suspended"`). */
+  call<K extends keyof TTools & string>(
+    name: K,
+    args: ToolArgs<TTools, K>,
+    options?: CallOptions,
+  ): Promise<ToolResult<TTools, K>>;
+
+  /**
+   * Waits for the next `app_event` (as pushed by the connected app's `postEvent(name, payload)`)
+   * matching `name`. **Races**: this subscribes live and has no visibility into events emitted
+   * before the subscription lands (there is no daemon-side retention yet — see
+   * https://github.com/callstackincubator/cordierite/issues/6). Call it before triggering the
+   * action that emits the event, not after.
+   *
+   * This shares the connection's single `events.subscribe` filter (the daemon keeps one per
+   * connection, replaced — not merged — on each call); concurrent `waitForEvent` calls on the same
+   * `AppClient` all see every `app_event`, so this is safe today, but it means the connection stays
+   * subscribed to `app_event` for its lifetime once any `waitForEvent` has run.
+   */
+  waitForEvent<TPayload = unknown>(name: string, options?: WaitForEventOptions): Promise<AppEvent<TPayload>>;
+
+  /** Closes the underlying connection. Safe to call more than once. */
+  close(): void;
+};
+
+const DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MS = 30_000;
+
+/** Mirrors `daemon/calls.ts`'s `DEFAULT_CALL_TIMEOUT_MS`/`MIN_CALL_TIMEOUT_MS`/
+ * `MAX_CALL_TIMEOUT_MS` clamp so this client can compute a transport timeout that always exceeds
+ * whatever server-side deadline the daemon will actually enforce for a given `timeoutMs` — not
+ * imported directly to keep `cordierite/client` from pulling in daemon-internal modules. */
+const DAEMON_DEFAULT_CALL_TIMEOUT_MS = 10_000;
+const DAEMON_MIN_CALL_TIMEOUT_MS = 1_000;
+const DAEMON_MAX_CALL_TIMEOUT_MS = 600_000;
+/** Extra headroom so the daemon's own `tool_timeout` always wins the race against this client's
+ * transport timeout, even accounting for RPC round-trip and event-loop scheduling delay. */
+const CALL_TRANSPORT_TIMEOUT_SLACK_MS = 5_000;
+
+const transportTimeoutForToolCall = (timeoutMs: number | undefined): number => {
+  const clamped =
+    timeoutMs === undefined || !Number.isFinite(timeoutMs)
+      ? DAEMON_DEFAULT_CALL_TIMEOUT_MS
+      : Math.min(Math.max(Math.trunc(timeoutMs), DAEMON_MIN_CALL_TIMEOUT_MS), DAEMON_MAX_CALL_TIMEOUT_MS);
+
+  return clamped + CALL_TRANSPORT_TIMEOUT_SLACK_MS;
+};
+
+export const makeAppClient = <TTools = ToolMap>(stream: DaemonStream, sessionId: string): AppClient<TTools> => {
+  const client = {
+    sessionId,
+
+    tools: async (): Promise<ToolDescriptor[]> => {
+      try {
+        return await stream.call<ToolsListResult>(RPC_METHODS.toolsList, { selector: sessionId });
+      } catch (error) {
+        throw toCordieriteError(error);
+      }
+    },
+
+    call: async (name: string, args: Record<string, unknown>, options?: CallOptions): Promise<unknown> => {
+      try {
+        const result = await stream.call<ToolsCallResult>(
+          RPC_METHODS.toolsCall,
+          {
+            selector: sessionId,
+            name,
+            args,
+            timeoutMs: options?.timeoutMs,
+            caller: "client",
+          },
+          transportTimeoutForToolCall(options?.timeoutMs),
+        );
+
+        return result.result;
+      } catch (error) {
+        throw toCordieriteError(error);
+      }
+    },
+
+    waitForEvent: (name: string, options: WaitForEventOptions = {}): Promise<AppEvent> => {
+      const timeoutMs = options.timeoutMs ?? DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MS;
+
+      return new Promise<AppEvent>((resolve, reject) => {
+        let settled = false;
+
+        const settle = (fn: () => void): void => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timer);
+          unsubscribeNotification();
+          unsubscribeClose();
+          fn();
+        };
+
+        const timer = setTimeout(() => {
+          settle(() =>
+            reject(new CordieriteError("timeout", `Timed out after ${timeoutMs}ms waiting for event "${name}".`)),
+          );
+        }, timeoutMs);
+
+        const unsubscribeClose = stream.onClose(() => {
+          settle(() =>
+            reject(
+              new CordieriteError(
+                "connection_error",
+                `The connection to the Cordierite daemon closed while waiting for event "${name}".`,
+              ),
+            ),
+          );
+        });
+
+        const unsubscribeNotification = stream.onNotification((payload) => {
+          if (settled) {
+            return;
+          }
+
+          const event = payload as EventNotification;
+
+          if (event.kind !== "app_event" || event.sessionId !== sessionId) {
+            return;
+          }
+
+          const data = event.data as { name?: unknown; payload?: unknown };
+
+          if (data.name !== name) {
+            return;
+          }
+
+          try {
+            if (options.match && !options.match(data.payload)) {
+              return;
+            }
+          } catch (error) {
+            settle(() => reject(toCordieriteError(error)));
+            return;
+          }
+
+          settle(() =>
+            resolve({ name, payload: data.payload, ts: event.ts, sessionId: event.sessionId!, alias: event.alias }),
+          );
+        });
+
+        stream.call(RPC_METHODS.eventsSubscribe, { sessionSelector: sessionId, kinds: ["app_event"] }).catch((error) => {
+          settle(() => reject(toCordieriteError(error)));
+        });
+      });
+    },
+
+    close: (): void => {
+      stream.close();
+    },
+  };
+
+  return client as unknown as AppClient<TTools>;
+};

--- a/packages/cordierite/src/client/bootstrap.ts
+++ b/packages/cordierite/src/client/bootstrap.ts
@@ -1,0 +1,162 @@
+/**
+ * `link()`/`waitForSession()` (issue #8): the bootstrap half of the client, so a test's
+ * `globalSetup` can pair a simulator/emulator without shelling out to `cordierite link --open`.
+ * `link()` delegates to the same `mintLink` core `commands/link.ts` uses (`../link.js`) so the
+ * deep-link shape can't drift between the CLI and this package; `waitForSession()` mirrors
+ * `mcp/connect-tool.ts`'s `handleWaitForSessionTool`.
+ */
+import { RPC_METHODS, type EventNotification, type SessionsDescribeResult } from "@cordierite/shared";
+
+import { type ExecFn, type OpenTarget } from "../cli/open-target.js";
+import { resolveStateDir } from "../daemon/state-dir.js";
+import { mintLink, type MintLinkResult } from "../link.js";
+import { openDaemonStream, DaemonRpcError, type DaemonStream, type SpawnFn } from "../rpc/client.js";
+import { makeAppClient, type AppClient, type ToolMap } from "./app-client.js";
+import { CordieriteError, toCordieriteError } from "./errors.js";
+
+const DEFAULT_WAIT_FOR_SESSION_TIMEOUT_MS = 120_000;
+
+export type LinkOptions = {
+  stateDir?: string;
+  spawn?: SpawnFn;
+  /** Auto-spawn a daemon on a missing connection. Defaults to `true`. */
+  autoSpawn?: boolean;
+  ttlSeconds?: number;
+  /** Delivers the link directly to a booted Android emulator/device or iOS simulator instead of
+   * just minting it (the CI/agent path — no human needed to scan a QR). */
+  target?: OpenTarget;
+  /** `--device` equivalent; only valid with `target: "android"`. */
+  device?: string;
+  /** Overrides `config.json`'s `scheme`. */
+  scheme?: string;
+  exec?: ExecFn;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type LinkResult = MintLinkResult;
+
+/** Mints a session link via `link.create` and composes the deep link. With `target` set, delivers
+ * it directly to a booted emulator/simulator instead of leaving delivery to the caller. */
+export const link = async (options: LinkOptions = {}): Promise<LinkResult> => {
+  try {
+    return await mintLink({
+      stateDir: resolveStateDir(options.stateDir),
+      spawn: options.spawn,
+      autoSpawn: options.autoSpawn,
+      ttlSeconds: options.ttlSeconds,
+      target: options.target,
+      device: options.device,
+      scheme: options.scheme,
+      exec: options.exec,
+      env: options.env,
+    });
+  } catch (error) {
+    throw toCordieriteError(error);
+  }
+};
+
+export type WaitForSessionOptions = {
+  stateDir?: string;
+  spawn?: SpawnFn;
+  /** Auto-spawn a daemon on a missing connection. Defaults to `true`. */
+  autoSpawn?: boolean;
+  /** Defaults to 120s. */
+  timeoutMs?: number;
+};
+
+/** Waits for `sessionId` (from {@link link}) to be claimed by a device, then returns a connected
+ * {@link AppClient} for it — resolves immediately if it's already claimed. */
+export const waitForSession = async <TTools = ToolMap>(
+  sessionId: string,
+  options: WaitForSessionOptions = {},
+): Promise<AppClient<TTools>> => {
+  const stateDir = resolveStateDir(options.stateDir);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_WAIT_FOR_SESSION_TIMEOUT_MS;
+
+  let stream: DaemonStream;
+
+  try {
+    stream = await openDaemonStream({ stateDir, spawn: options.spawn, autoSpawn: options.autoSpawn });
+  } catch (error) {
+    throw toCordieriteError(error);
+  }
+
+  try {
+    // The session may already be claimed by the time this runs — resolve immediately rather than
+    // waiting for an event that already happened.
+    try {
+      await stream.call<SessionsDescribeResult>(RPC_METHODS.sessionsDescribe, { selector: sessionId });
+      return makeAppClient<TTools>(stream, sessionId);
+    } catch (error) {
+      if (!(error instanceof DaemonRpcError) || error.data?.type !== "unknown_session") {
+        throw error;
+      }
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+
+      const settle = (fn: () => void): void => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        clearTimeout(timer);
+        unsubscribeNotification();
+        unsubscribeClose();
+        fn();
+      };
+
+      const timer = setTimeout(() => {
+        settle(() =>
+          reject(
+            new CordieriteError(
+              "timeout",
+              `Timed out after ${timeoutMs}ms waiting for session "${sessionId}" to be claimed.`,
+            ),
+          ),
+        );
+      }, timeoutMs);
+
+      const unsubscribeClose = stream.onClose(() => {
+        settle(() =>
+          reject(
+            new CordieriteError(
+              "connection_error",
+              `The connection to the Cordierite daemon closed while waiting for session "${sessionId}" to be claimed.`,
+            ),
+          ),
+        );
+      });
+
+      // Registered *before* `events.subscribe` is sent (not after awaiting it) — a
+      // `session_claimed` notification that arrives in the same TCP chunk as the subscribe
+      // response is dispatched synchronously within that chunk's processing, before an `await`
+      // continuation below would get a chance to run; registering the listener first means it's
+      // always in place in time to see it.
+      const unsubscribeNotification = stream.onNotification((payload) => {
+        if (settled) {
+          return;
+        }
+
+        const event = payload as EventNotification;
+
+        if (event.kind === "session_claimed" && event.sessionId === sessionId) {
+          settle(resolve);
+        }
+      });
+
+      stream
+        .call(RPC_METHODS.eventsSubscribe, { sessionSelector: sessionId, kinds: ["session_claimed"] })
+        .catch((error) => {
+          settle(() => reject(toCordieriteError(error)));
+        });
+    });
+
+    return makeAppClient<TTools>(stream, sessionId);
+  } catch (error) {
+    stream.close();
+    throw toCordieriteError(error);
+  }
+};

--- a/packages/cordierite/src/client/connect.ts
+++ b/packages/cordierite/src/client/connect.ts
@@ -1,0 +1,57 @@
+/**
+ * `connect()` (issue #8): the entry point for a test runner that wants to drive an already-claimed
+ * session without shelling out to the CLI. Auto-spawns the daemon (same seam `rpc/client.ts` gives
+ * the CLI/MCP server) and resolves `selector` up front via `sessions.describe` so a bad/ambiguous
+ * selector fails fast with a typed {@link CordieriteError} rather than surfacing on the first
+ * `call()`.
+ */
+import { RPC_METHODS, type SessionsDescribeResult } from "@cordierite/shared";
+
+import { resolveStateDir } from "../daemon/state-dir.js";
+import { openDaemonStream, type DaemonStream, type SpawnFn } from "../rpc/client.js";
+import { makeAppClient, type AppClient, type ToolMap } from "./app-client.js";
+import { toCordieriteError } from "./errors.js";
+
+export type ConnectOptions = {
+  /** Session id or alias; omitted selects the sole active/suspended session (rejects with
+   * `"no_session"`/`"ambiguous_session"` otherwise — the same rule the CLI/MCP surfaces use). */
+  selector?: string;
+  /** Defaults to `CORDIERITE_STATE_DIR`, else `~/.cordierite` — the same resolution the CLI uses. */
+  stateDir?: string;
+  /** Injectable daemon-spawn seam (tests only); real callers never need this. */
+  spawn?: SpawnFn;
+  /** Auto-spawn a daemon on a missing connection. Defaults to `true`. */
+  autoSpawn?: boolean;
+  requestTimeoutMs?: number;
+};
+
+/** Opens a persistent connection to the daemon and resolves `options.selector` to one session. */
+export const connect = async <TTools = ToolMap>(
+  options: ConnectOptions = {},
+): Promise<AppClient<TTools>> => {
+  const stateDir = resolveStateDir(options.stateDir);
+
+  let stream: DaemonStream;
+
+  try {
+    stream = await openDaemonStream({
+      stateDir,
+      spawn: options.spawn,
+      autoSpawn: options.autoSpawn,
+      requestTimeoutMs: options.requestTimeoutMs,
+    });
+  } catch (error) {
+    throw toCordieriteError(error);
+  }
+
+  try {
+    const detail = await stream.call<SessionsDescribeResult>(RPC_METHODS.sessionsDescribe, {
+      selector: options.selector,
+    });
+
+    return makeAppClient<TTools>(stream, detail.sessionId);
+  } catch (error) {
+    stream.close();
+    throw toCordieriteError(error);
+  }
+};

--- a/packages/cordierite/src/client/errors.ts
+++ b/packages/cordierite/src/client/errors.ts
@@ -1,0 +1,71 @@
+/**
+ * Client-facing error type (issue #8): the wire `error.data.type` (ARCHITECTURE.md §5) surfaced as
+ * a typed exception instead of a `DaemonRpcError`/stderr string a test would have to pattern-match.
+ * `type` preserves the wire value verbatim — the same non-rewrapping rule `errors.ts`'s
+ * `toCliError` already enforces for the CLI — so `expect(...).rejects.toMatchObject({ type:
+ * "policy_denied" })` works without this package's internal error classes leaking into test code.
+ */
+import type { ErrorType } from "@cordierite/shared";
+
+import { isCordieriteCliError } from "../errors.js";
+import { DaemonRpcError, isDaemonUnreachableError } from "../rpc/client.js";
+
+/** The wire `ErrorType` union, plus three client-only buckets for conditions the daemon never
+ * produced: `"connection_error"` (daemon unreachable/unspawnable, or the connection dropped mid-
+ * wait), `"timeout"` (a client-side wait — `waitForEvent`, `waitForSession` — gave up; distinct
+ * from the wire `"tool_timeout"` so a test can tell "the app's tool timed out" apart from "my wait
+ * gave up"), and `"client_error"` (anything else, e.g. a failed emulator/simulator delivery from
+ * {@link link}, or a malformed JSON-RPC error with no `data.type`). */
+export type CordieriteErrorType = ErrorType | "connection_error" | "timeout" | "client_error";
+
+export class CordieriteError extends Error {
+  readonly type: CordieriteErrorType;
+  readonly details?: unknown;
+  /** The JSON-RPC error code, when this wraps a `DaemonRpcError`. */
+  readonly code?: number;
+
+  constructor(type: CordieriteErrorType, message: string, details?: unknown, code?: number) {
+    super(message);
+    this.name = "CordieriteError";
+    this.type = type;
+    this.details = details;
+    this.code = code;
+  }
+}
+
+/** Converts any error thrown by the RPC layer into a {@link CordieriteError}, preserving the wire
+ * `data.type` verbatim when present. Idempotent on an already-converted error. */
+export const toCordieriteError = (error: unknown): CordieriteError => {
+  if (error instanceof CordieriteError) {
+    return error;
+  }
+
+  const withCause = (result: CordieriteError): CordieriteError => {
+    result.cause = error;
+    return result;
+  };
+
+  if (error instanceof DaemonRpcError) {
+    const type = error.data?.type ?? "client_error";
+    return withCause(new CordieriteError(type, error.message, error.data?.details, error.code));
+  }
+
+  if (isDaemonUnreachableError(error)) {
+    return withCause(
+      new CordieriteError(
+        "connection_error",
+        error instanceof Error ? error.message : "The Cordierite daemon is unreachable.",
+      ),
+    );
+  }
+
+  if (isCordieriteCliError(error)) {
+    return withCause(new CordieriteError("client_error", error.message, error.details));
+  }
+
+  if (error instanceof Error) {
+    return withCause(new CordieriteError("client_error", error.message));
+  }
+
+  return new CordieriteError("client_error", "An unexpected error occurred.", error);
+};

--- a/packages/cordierite/src/client/index.ts
+++ b/packages/cordierite/src/client/index.ts
@@ -1,0 +1,18 @@
+/**
+ * `cordierite/client` (issue #8): a first-class programmatic client for test runners — a thin typed
+ * wrapper over the same daemon RPC the CLI and MCP server use, so a Jest/Vitest/Detox spec can
+ * `connect()`/`call()` instead of spawning `cordierite invoke ... --json` and parsing stdout.
+ *
+ * ```ts
+ * import { connect } from "cordierite/client";
+ *
+ * const app = await connect();
+ * const { total } = await app.call("sum", { a: 2, b: 3 });
+ * await app.close();
+ * ```
+ */
+export { connect, type ConnectOptions } from "./connect.js";
+export { link, waitForSession, type LinkOptions, type LinkResult, type WaitForSessionOptions } from "./bootstrap.js";
+export { CordieriteError, type CordieriteErrorType } from "./errors.js";
+export type { AppClient, AppEvent, CallOptions, ToolMap, WaitForEventOptions } from "./app-client.js";
+export type { AgentEndpoint, ErrorType, ToolDescriptor } from "@cordierite/shared";

--- a/packages/cordierite/src/commands/link.ts
+++ b/packages/cordierite/src/commands/link.ts
@@ -1,35 +1,14 @@
 /**
- * `cordierite link` (ARCHITECTURE.md §10, §8): mints a pending session via `link.create`, then
- * composes the deep link `<scheme>:///?cordierite=<payload>&pin=<spki-pin>`. The scheme comes
- * from `--scheme`, else `config.json`'s `scheme` field, else the command errors with a clear
- * message.
- *
- * The `pin` param (opt-in hardening dev-mode) is separate from the `cordierite` bootstrap blob —
- * it is never part of that binary v2 payload, so old apps that don't know about it simply ignore
- * it. It carries the daemon's SPKI pin (same value as `daemon.status`'s `pinnedKeys[0]` /
- * `cordierite keygen`'s output) so a debug build with no build-time `cliPins` configured can trust
- * it for this one connection instead of requiring a native rebuild just to test locally. The pin
- * is standard (non-URL-safe) base64 (`sha256/<44-char-base64>`, may contain `+`/`/`/`=`), so it is
- * percent-encoded here; native/JS parsers use `URLSearchParams`, which decodes it back.
- *
- * `--open android|ios-sim` additionally forces the advertised address to `127.0.0.1`
- * (the simulator/emulator reaches the daemon over localhost — the wss listener already binds all
- * interfaces) and delivers the link via adb/xcrun instead of just printing it.
+ * `cordierite link` (ARCHITECTURE.md §10, §8): CLI-flag validation (`--open`/`--device`'s
+ * CLI-specific error wording) around the shared `mintLink` core (`../link.ts`), which both this
+ * command and `cordierite/client`'s `link()` use so the deep-link shape can't drift between them.
  */
 
-import { RPC_METHODS, type LinkCreateResult } from "@cordierite/shared";
-
 import type { CliResult, LinkCommandData } from "../cli/result-types.js";
-import { loadConfig } from "../daemon/config.js";
-import { getStateDirPaths } from "../daemon/state-dir.js";
+import { isOpenTarget, type ExecFn, type OpenTarget } from "../cli/open-target.js";
+import { mintLink } from "../link.js";
 import { usageError } from "../errors.js";
-import { callDaemon, type SpawnFn } from "../rpc/client.js";
-import { deliverToOpenTarget, isOpenTarget, type ExecFn, type OpenTarget } from "../cli/open-target.js";
-
-/** The emulator/simulator fast path forces `127.0.0.1`: the daemon's wss listener already binds
- * all interfaces, and both delivery mechanisms (adb reverse, the iOS simulator's shared host
- * network) make the daemon reachable there regardless of the machine's real LAN address. */
-const OPEN_TARGET_ADDRESS_OVERRIDE = "127.0.0.1";
+import type { SpawnFn } from "../rpc/client.js";
 
 export type LinkCommandOptions = {
   ttlSeconds?: number;
@@ -63,47 +42,16 @@ export const handleLinkCommand = async (
     throw usageError('"--device" only applies with "--open android".');
   }
 
-  const paths = getStateDirPaths(context.stateDir);
-  const config = await loadConfig(paths);
-  const scheme = options.scheme ?? config.scheme;
+  const result = await mintLink({
+    stateDir: context.stateDir,
+    spawn: context.spawn,
+    ttlSeconds: options.ttlSeconds,
+    scheme: options.scheme,
+    target: openTarget,
+    device: options.device,
+    exec: context.exec,
+    env: context.env,
+  });
 
-  if (!scheme) {
-    throw usageError(
-      'A deep-link scheme is required: pass --scheme, or set "scheme" in config.json.',
-    );
-  }
-
-  const result = await callDaemon<LinkCreateResult>(
-    RPC_METHODS.linkCreate,
-    {
-      ttlSeconds: options.ttlSeconds,
-      addressOverride: openTarget ? OPEN_TARGET_ADDRESS_OVERRIDE : undefined,
-    },
-    { stateDir: context.stateDir, spawn: context.spawn },
-  );
-
-  const deepLink = `${scheme}:///?cordierite=${result.deepLinkPayload}&pin=${encodeURIComponent(result.pin)}`;
-
-  if (openTarget) {
-    await deliverToOpenTarget({
-      target: openTarget,
-      deepLink,
-      wssPort: result.endpoint.port,
-      device: options.device,
-      exec: context.exec,
-      env: context.env,
-    });
-  }
-
-  return {
-    ok: true,
-    data: {
-      sessionId: result.sessionId,
-      deepLink,
-      endpoint: result.endpoint,
-      expiresAt: result.expiresAt,
-      pin: result.pin,
-      ...(openTarget ? { delivered: true as const, target: openTarget } : {}),
-    },
-  };
+  return { ok: true, data: result };
 };

--- a/packages/cordierite/src/daemon/audit.ts
+++ b/packages/cordierite/src/daemon/audit.ts
@@ -20,7 +20,7 @@ import type { ErrorType } from "@cordierite/shared";
 import type { Clock } from "../cli/types.js";
 
 export type AuditOutcome = "ok" | "error" | "denied";
-export type AuditCaller = "cli" | "mcp";
+export type AuditCaller = "cli" | "mcp" | "client";
 
 export type AuditRecord = {
   /** ISO 8601. */

--- a/packages/cordierite/src/daemon/daemon.ts
+++ b/packages/cordierite/src/daemon/daemon.ts
@@ -175,8 +175,8 @@ const asToolsCallParams = (params: unknown): ToolsCallParams => {
 
   const caller = record.caller;
 
-  if (caller !== undefined && caller !== "cli" && caller !== "mcp") {
-    throw new RpcApplicationError("invalid_request", '"caller" must be "cli" or "mcp".');
+  if (caller !== undefined && caller !== "cli" && caller !== "mcp" && caller !== "client") {
+    throw new RpcApplicationError("invalid_request", '"caller" must be "cli", "mcp", or "client".');
   }
 
   return {
@@ -184,7 +184,7 @@ const asToolsCallParams = (params: unknown): ToolsCallParams => {
     name: record.name,
     args: args as Record<string, unknown>,
     timeoutMs: timeoutMs as number | undefined,
-    caller: caller as "cli" | "mcp" | undefined,
+    caller: caller as "cli" | "mcp" | "client" | undefined,
   };
 };
 

--- a/packages/cordierite/src/link.ts
+++ b/packages/cordierite/src/link.ts
@@ -1,0 +1,119 @@
+/**
+ * Shared core of `link.create` + deep-link composition + optional emulator/simulator delivery
+ * (ARCHITECTURE.md §8, §10): mints a pending session via `link.create`, then composes
+ * `<scheme>:///?cordierite=<payload>&pin=<spki-pin>` and optionally delivers it to a booted
+ * Android emulator/device or iOS simulator. Used by `commands/link.ts` (`cordierite link`) and
+ * `client/bootstrap.ts` (`cordierite/client`'s `link()`) so this shape — scheme resolution, the
+ * `pin` query param, the `127.0.0.1` emulator/simulator address override — can't drift between the
+ * CLI and the programmatic client.
+ *
+ * The `pin` param is separate from the `cordierite` bootstrap blob (opt-in hardening dev-mode) — it
+ * is never part of that binary v2 payload, so old apps that don't know about it simply ignore it.
+ * It carries the daemon's SPKI pin (same value as `daemon.status`'s `pinnedKeys[0]` / `cordierite
+ * keygen`'s output) so a debug build with no build-time `cliPins` configured can trust it for this
+ * one connection instead of requiring a native rebuild just to test locally. The pin is standard
+ * (non-URL-safe) base64 (`sha256/<44-char-base64>`, may contain `+`/`/`/`=`), so it is percent-
+ * encoded here; native/JS parsers use `URLSearchParams`, which decodes it back.
+ */
+import { RPC_METHODS, type AgentEndpoint, type LinkCreateResult } from "@cordierite/shared";
+
+import { deliverToOpenTarget, isOpenTarget, type ExecFn, type OpenTarget } from "./cli/open-target.js";
+import { loadConfig } from "./daemon/config.js";
+import { getStateDirPaths } from "./daemon/state-dir.js";
+import { usageError } from "./errors.js";
+import { callDaemon, type SpawnFn } from "./rpc/client.js";
+
+/** The emulator/simulator fast path forces `127.0.0.1`: the daemon's wss listener already binds
+ * all interfaces, and both delivery mechanisms (adb reverse, the iOS simulator's shared host
+ * network) make the daemon reachable there regardless of the machine's real LAN address. */
+const OPEN_TARGET_ADDRESS_OVERRIDE = "127.0.0.1";
+
+export type MintLinkOptions = {
+  stateDir: string;
+  spawn?: SpawnFn;
+  autoSpawn?: boolean;
+  ttlSeconds?: number;
+  /** Delivers the link directly to a booted Android emulator/device or iOS simulator instead of
+   * leaving delivery to the caller. */
+  target?: OpenTarget;
+  /** Only valid with `target: "android"`. */
+  device?: string;
+  /** Overrides `config.json`'s `scheme`. */
+  scheme?: string;
+  exec?: ExecFn;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type MintLinkResult = {
+  sessionId: string;
+  deepLink: string;
+  endpoint: AgentEndpoint;
+  /** Unix seconds. */
+  expiresAt: number;
+  pin: string;
+  delivered?: true;
+  target?: OpenTarget;
+};
+
+/** Throws `usageError`/`CordieriteCliError` on validation failure — `commands/link.ts` renders
+ * that straight through the CLI's own error path; `client/bootstrap.ts` converts it to a
+ * `CordieriteError` via `toCordieriteError` (which already understands `CordieriteCliError`). */
+export const mintLink = async (options: MintLinkOptions): Promise<MintLinkResult> => {
+  if (options.target !== undefined && !isOpenTarget(options.target)) {
+    throw usageError(`"target" must be "android" or "ios-sim" (got "${options.target}").`);
+  }
+
+  if (options.device !== undefined && options.target !== "android") {
+    throw usageError('"device" only applies with target "android".');
+  }
+
+  const paths = getStateDirPaths(options.stateDir);
+  const config = await loadConfig(paths);
+  const scheme = options.scheme ?? config.scheme;
+
+  if (!scheme) {
+    throw usageError(
+      'A deep-link scheme is required: pass a "scheme" option (`--scheme` on the CLI), or set "scheme" in config.json.',
+    );
+  }
+
+  const result = await callDaemon<LinkCreateResult>(
+    RPC_METHODS.linkCreate,
+    {
+      ttlSeconds: options.ttlSeconds,
+      addressOverride: options.target ? OPEN_TARGET_ADDRESS_OVERRIDE : undefined,
+    },
+    { stateDir: options.stateDir, spawn: options.spawn, autoSpawn: options.autoSpawn },
+  );
+
+  const deepLink = `${scheme}:///?cordierite=${result.deepLinkPayload}&pin=${encodeURIComponent(result.pin)}`;
+
+  if (options.target) {
+    await deliverToOpenTarget({
+      target: options.target,
+      deepLink,
+      wssPort: result.endpoint.port,
+      device: options.device,
+      exec: options.exec,
+      env: options.env,
+    });
+
+    return {
+      sessionId: result.sessionId,
+      deepLink,
+      endpoint: result.endpoint,
+      expiresAt: result.expiresAt,
+      pin: result.pin,
+      delivered: true,
+      target: options.target,
+    };
+  }
+
+  return {
+    sessionId: result.sessionId,
+    deepLink,
+    endpoint: result.endpoint,
+    expiresAt: result.expiresAt,
+    pin: result.pin,
+  };
+};

--- a/packages/cordierite/src/rpc/client.ts
+++ b/packages/cordierite/src/rpc/client.ts
@@ -302,8 +302,11 @@ export const callDaemon = async <TResult>(
 };
 
 export type DaemonStream = {
-  /** Sends a request over the persistent connection and awaits its response. */
-  call: <TResult>(method: string, params?: unknown) => Promise<TResult>;
+  /** Sends a request over the persistent connection and awaits its response. `timeoutMs`
+   * overrides this stream's default transport timeout for this call only — needed when a
+   * request's own server-side deadline (e.g. `tools.call`'s `timeoutMs` param) can exceed the
+   * stream's default, so the transport timeout never fires before the server-side one does. */
+  call: <TResult>(method: string, params?: unknown, timeoutMs?: number) => Promise<TResult>;
   /** Subscribes to server→client `"event"` notifications; returns an unsubscribe function. */
   onNotification: (callback: (payload: unknown) => void) => () => void;
   /** Fires once when the underlying socket closes (daemon gone, stop(), etc.); returns an
@@ -403,7 +406,13 @@ export const openDaemonStream = async (
 
       if (message.method === "event") {
         for (const listener of notificationListeners) {
-          listener(message.params);
+          try {
+            listener(message.params);
+          } catch {
+            // A misbehaving subscriber (e.g. a throwing `waitForEvent` match predicate) must never
+            // crash this loop — it would drop every other listener's notification, and any RPC
+            // response batched in the same chunk, for the rest of this connection's lifetime.
+          }
         }
         continue;
       }
@@ -439,7 +448,7 @@ export const openDaemonStream = async (
   });
 
   return {
-    call: <TResult>(method: string, params?: unknown) => {
+    call: <TResult>(method: string, params?: unknown, timeoutMs?: number) => {
       return new Promise<TResult>((resolve, reject) => {
         const id = nextRequestId;
         nextRequestId += 1;
@@ -447,7 +456,7 @@ export const openDaemonStream = async (
         const timeout = setTimeout(() => {
           pendingCalls.delete(id);
           reject(new DaemonUnavailableError(`Timed out waiting for a response to "${method}".`));
-        }, requestTimeoutMs);
+        }, timeoutMs ?? requestTimeoutMs);
 
         pendingCalls.set(id, {
           resolve: resolve as (value: unknown) => void,

--- a/packages/shared/src/domains/rpc.ts
+++ b/packages/shared/src/domains/rpc.ts
@@ -125,8 +125,9 @@ export type ToolsCallParams = SessionSelectorParams & {
   args: Record<string, unknown>;
   timeoutMs?: number;
   /** Attribution for the audit log (ARCHITECTURE.md §12): who issued this call. The MCP server
-   * always sets `"mcp"`; omitted (the CLI's case) defaults to `"cli"` at the daemon. */
-  caller?: "cli" | "mcp";
+   * always sets `"mcp"`, the `cordierite/client` package always sets `"client"`; omitted (the
+   * CLI's case) defaults to `"cli"` at the daemon. */
+  caller?: "cli" | "mcp" | "client";
 };
 
 export type ToolsCallResult = {


### PR DESCRIPTION
## Summary

Closes #8. Adds `cordierite/client`, a thin typed wrapper over the daemon's existing JSON-RPC-over-UDS surface (the same `rpc/client.ts` the CLI and MCP server use), so a Jest/Vitest/Detox spec can drive a connected app without shelling out to `cordierite invoke ... --json` and parsing stdout.

```ts
import { connect } from "cordierite/client";

const app = await connect();
const { total } = await app.call("sum", { a: 2, b: 3 });
await expect(app.call("checkout", {})).rejects.toMatchObject({ type: "policy_denied" });
```

- **`connect()` / `AppClient`** — `tools()`, `call(name, args, opts)`, `waitForEvent(name, opts)`, `close()`, bound to one resolved session. Generic over a caller-declared tool map (`type` alias or `interface`) for typed calls.
- **`link()` / `waitForSession()`** — bootstrap half, for pairing a simulator/emulator in a test's `globalSetup` without shelling out. `link()` now shares its deep-link-composition core (new `src/link.ts`) with `cordierite link` so the two surfaces can't drift.
- **`CordieriteError`** — the daemon's wire error type (`tool_timeout`, `policy_denied`, `session_suspended`, …) surfaces verbatim as a typed exception instead of stderr text, plus two client-only buckets (`connection_error`, `timeout`) for conditions the daemon never produced.
- **`caller: "client"`** added to the wire `ToolsCallParams`/`AuditCaller` union alongside `"cli"`/`"mcp"`, threaded through daemon validation and the audit log, for attribution.

No new privilege or transport — same UDS RPC, same policy/audit path.

`waitForEvent` intentionally has no daemon-side event buffer yet (that's #6, still open) — it subscribes live and documents the resulting race in its own doc comment; call it before triggering the event, not after.

## Review

Had an independent Opus review pass on the initial implementation. Fixed everything it flagged as must-fix or should-fix, plus the may-fix items worth the churn:

- **Must-fix:** a tool's own `timeoutMs` could exceed this client's fixed 10s transport timeout, so a real `tool_timeout` would misreport as `connection_error` — `DaemonStream.call()` now takes a per-call timeout override, computed from the daemon's own clamp plus slack. A throwing `waitForEvent` `match` predicate could crash the shared socket read loop and drop other in-flight calls — notification listeners are now individually guarded.
- **Should-fix:** the generic tool-map typing didn't actually give the typed-call ergonomics the issue asked for (broke on `interface`s, and the untyped default didn't compile the README's own example) — fixed and covered by a test using an `interface`-declared map; `waitForSession`'s subscribe/listen ordering had a same-TCP-chunk race — fixed and covered; added `onClose` handling so a mid-wait daemon disappearance doesn't sit until a misleading timeout; `waitForEvent` now returns a typed `AppEvent` instead of the raw wire envelope; re-exported the types (`ToolDescriptor`, `AgentEndpoint`, etc.) `cordierite/client`'s own signatures reference; extracted `link()`'s duplicate deep-link-composition logic into a shared `src/link.ts` core used by both the CLI and the client.
- **May-fix:** fixed the README's broken example snippet, preserved the JSON-RPC error code and original error as `cause` on `CordieriteError`, documented the shared-subscription caveat, tightened a redundant test matcher, rewrapped a doc line.

## Test plan

- [x] `pnpm typecheck` — clean (both `cordierite` and `@cordierite/shared`)
- [x] `pnpm build` — clean
- [x] Full `cordierite` + `@cordierite/shared` test suites pass (242 + 115 tests), including two new e2e files: `client.e2e.test.ts` (connect/tools/call/waitForEvent/error-mapping/audit-attribution against a real daemon + fake app, plus regression tests for both must-fix bugs) and `client-bootstrap.e2e.test.ts` (link/waitForSession round trip, already-claimed fast path, claim-races-subscribe ordering, timeout path)
- [x] Pre-existing `link-open.integration.test.ts` still passes unchanged after the `commands/link.ts` → shared `mintLink()` refactor