### PR TITLE
Add tool call cancellation (tool_cancel frame + AbortSignal)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -140,6 +140,7 @@ Methods:
 | `sessions.revoke` | `{ selector? }` | `{ ok: true }` — closes socket (code 1000), frees alias |
 | `tools.list` | `{ selector? }` | `ToolDescriptor[]` (full schemas + annotations) |
 | `tools.call` | `{ selector?, name, args, timeoutMs? }` | `{ result, callId }` on success — `callId` lets a caller with several in-flight calls match `tool_call_progress`/`tool_call_finished` events back to this call; JSON-RPC error with `data.type` preserving the wire error type on failure |
+| `tools.cancel` | `{ selector?, callId, reason? }` | `{ cancelled: boolean }` — sends `tool_cancel` (§7) to the app for a still-pending call; `false` for an unknown/already-finished `callId` or no active socket (a no-op, not an error) |
 | `events.subscribe` | `{ sessionSelector?, kinds? }` | `{ ok: true }`, then `event` notifications on this connection |
 
 `SessionSummary`: `{ sessionId, alias, state, device: { manufacturer?, model?, os? },
@@ -157,9 +158,9 @@ of `daemon_started`, `link_created`, `link_expired`, `session_claimed`,
 **Error codes** (JSON-RPC `error.data.type`): `no_session`, `ambiguous_session`,
 `unknown_session`, `session_not_active`, `tool_not_found`,
 `tool_input_validation_error`, `tool_output_validation_error`, `tool_execution_error`,
-`tool_serialization_error`, `tool_timeout`, `session_suspended`, `policy_denied`,
-`invalid_request`. App-side error types must be preserved **verbatim** end-to-end
-(daemon → RPC → CLI/MCP output); never re-wrap them under a generic type.
+`tool_serialization_error`, `tool_timeout`, `tool_cancelled`, `session_suspended`,
+`policy_denied`, `invalid_request`. App-side error types must be preserved **verbatim**
+end-to-end (daemon → RPC → CLI/MCP output); never re-wrap them under a generic type.
 
 ## 6. Session state machine
 
@@ -232,6 +233,11 @@ proxies daemon RPC (auto-spawning the daemon like any client):
   `notifications/tools/list_changed`, so an agent's tool list tracks the device.
 - Tool calls, progress frames, errors (with their `type` preserved), and descriptor
   annotations all map through verbatim — the MCP surface adds no semantics of its own.
+- An MCP client's `notifications/cancelled` maps to `tools.cancel` (§5) — only for a call
+  that requested progress (the SDK only assigns a `progressToken`, and only the
+  progress-tracked path opens the dedicated connection that learns `callId` while the
+  call is still in flight; a non-progress call has no `callId` to cancel by until it has
+  already resolved, at which point cancelling it is moot).
 - Two built-in management tools, `cordierite_connect` and `cordierite_wait_for_session`,
   let an agent mint a bootstrap link, deliver it to an emulator/simulator, and wait for the
   claim — without shell access. This is what makes the agent path self-service.
@@ -246,6 +252,11 @@ The per-command reference lives in the [`cordierite` package README](../packages
 which is where it stays current. Global flags: `--json` (machine output, NDJSON for streams),
 `--no-color`, `--state-dir`. The `--scheme` used to compose a deep link comes from the flag,
 else `config.json`, else a clear error.
+
+`cordierite invoke`: a SIGINT while the call is still pending cancels it (§5's
+`tools.cancel`, via the RPC connection dropping) rather than leaving the app-side handler
+running for a caller that has already exited; the process then exits reporting
+`tool_cancelled`.
 
 ## 11. React Native SDK
 
@@ -316,8 +327,21 @@ Client behavior:
   `error` (covers bootstrap parse/connect and socket errors), `sessionChange`.
 - Schema handling: Standard Schema JSON exporter as in v1; when a schema lacks the
   exporter, log a dev warning that agents will see a shapeless tool.
-- App-side handler timeout: if a handler exceeds the call timeout hint, reply
-  `tool_timeout` and ignore the late result.
+- App-side handler timeout: if a handler exceeds the call timeout hint, abort its
+  `AbortSignal`, reply `tool_timeout`, and ignore the late result.
+- Cancellation: `tool.handler(args, context)`'s `context.signal` (`AbortSignal`) aborts on
+  a `tool_cancel` frame (§7) or when the session's transport is lost (suspend) — the
+  latter can't itself deliver `tool_cancel` (there is no socket left), so it aborts every
+  in-flight handler directly instead. A handler that ignores the signal keeps running and
+  replies normally, exactly as it did before cancellation existed; one that observes it
+  and throws/rejects gets its `tool_error` sent as `tool_cancelled` (only for an
+  explicit `tool_cancel` — a handler that throws after its own timeout still reports
+  `tool_timeout`, not `tool_cancelled`). `AbortController`/`AbortSignal` are used directly
+  from the global — RN has polyfilled both since 0.60 (`abort-controller` under
+  `polyfillGlobal`), which covers every RN version this package supports (Expo SDK 52+ /
+  RN 0.76+); only the older WHATWG surface is relied on (`aborted`,
+  `addEventListener("abort", …)`), never `AbortSignal.timeout`/`.abort`/`.any`,
+  `throwIfAborted()`, or `.reason` semantics, which that polyfill predates.
 
 Native layer: iOS `URLSession`, Android OkHttp. Two rules keep the two platforms honest —
 all connection state is serialized (an actor on iOS, a single-thread executor/lock on
@@ -335,7 +359,7 @@ it.
   `policy_denied` and are audited. Interactive prompting is not implemented; the
   policy configuration leaves room for a future `prompt` value.
 - Audit: every `tools.call` appends one JSONL record to `audit/<date>.jsonl`:
-  `{ ts, sessionId, alias, tool, argsSha256, outcome: "ok"|"error"|"denied",
+  `{ ts, sessionId, alias, tool, argsSha256, outcome: "ok"|"error"|"denied"|"cancelled",
   errorType?, durationMs, caller: "cli"|"mcp" }`. Raw args are never logged.
 
 ## 13. Package layout

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -181,11 +181,11 @@ successful result.
   "error": { "type": "tool_execution_error", "message": "Something went wrong", "details": { "stack": "…" } } }
 ```
 
-Guard: `isToolErrorMessage`. `error.type` must be one of the six app-side error types
+Guard: `isToolErrorMessage`. `error.type` must be one of the seven app-side error types
 (§5 in `docs/ARCHITECTURE.md`): `tool_not_found`, `tool_input_validation_error`,
 `tool_output_validation_error`, `tool_execution_error`, `tool_serialization_error`,
-`tool_timeout`. This value is preserved **verbatim** all the way to the CLI/MCP output —
-the daemon never re-wraps it under a generic `"tool_error"` type.
+`tool_timeout`, `tool_cancelled`. This value is preserved **verbatim** all the way to the
+CLI/MCP output — the daemon never re-wraps it under a generic `"tool_error"` type.
 
 ### `tool_call_progress` — app → daemon, optional progress updates during a long-running call
 
@@ -196,6 +196,22 @@ the daemon never re-wraps it under a generic `"tool_error"` type.
 Guard: `isToolCallProgressMessage`. Both `progress` and `message` are optional; the
 daemon maps this to a `tool_call_progress` event (`events.subscribe`) and, over MCP, to
 an MCP progress notification.
+
+### `tool_cancel` — daemon → app, cancels a still-in-flight `tool_call`
+
+```jsonc
+{ "type": "tool_cancel", "session_id": "XzAERP54_Goh74hZ", "id": "call_1", "reason": "client_cancelled" }
+```
+
+Guard: `isToolCancelMessage`. Sent when the caller that issued the matching `tools.call`
+goes away while it is still pending — an MCP client's `notifications/cancelled`, the RPC
+connection that issued `tools.call` dropping (CLI Ctrl-C, MCP client disconnect), or an
+explicit `tools.cancel` RPC call. A cancel for an unknown or already-finished `id` is a
+no-op, not a protocol violation — the daemon never knows for certain which calls the app
+still considers in flight. The app is expected to abort the matching handler (its
+`AbortSignal`, §11) and reply `tool_error` with `error.type: "tool_cancelled"`; a handler
+that ignores the signal keeps running and replies normally, exactly as before this
+message existed.
 
 ### `event` — app → daemon, app-originated telemetry outside the tool-call/result cycle
 
@@ -303,6 +319,11 @@ types also establish these details:
   several in-flight calls (the MCP server proxying concurrent `tools/call` requests) can
   match `tool_call_progress`/`tool_call_finished` events back to the call that produced
   them without guessing from data shape.
+- `tools.cancel({ selector?, callId, reason? })` sends `tool_cancel` (above) to the
+  session's app for a still-pending call; the result is `{ cancelled: boolean }`, `false`
+  for an unknown/already-finished `callId` or when the session has no active socket to
+  send the frame on. The RPC connection that issued a `tools.call` dropping while it is
+  still pending triggers the same cancel automatically.
 - `daemon.status`'s result additionally reports the effective `policy` config and
   `audit: { path, failedWrites }` (ARCHITECTURE.md §12's audit surfacing).
 - `events.subscribe` includes `link_expired` (a pending link's TTL elapsed with no

--- a/packages/cordierite/src/__tests__/e2e/app-client.ts
+++ b/packages/cordierite/src/__tests__/e2e/app-client.ts
@@ -23,6 +23,7 @@ type Ack = {
 };
 
 type ToolCallFrame = { type: "tool_call"; session_id: string; id: string; name: string; args: Record<string, unknown> };
+type ToolCancelFrame = { type: "tool_cancel"; session_id: string; id: string; reason: string };
 
 export type ToolCallHandler = (
   call: ToolCallFrame,
@@ -39,6 +40,8 @@ export class FakeAppClient {
   private socket: WebSocket | undefined;
   private toolCallHandler: ToolCallHandler | undefined;
   private closeWaiters: Array<(info: CloseInfo) => void> = [];
+  private toolCancelWaiters: Array<(frame: ToolCancelFrame) => void> = [];
+  private toolCallWaiters: Array<(frame: ToolCallFrame) => void> = [];
 
   sessionId = "";
   alias = "";
@@ -155,6 +158,21 @@ export class FakeAppClient {
     });
   }
 
+  /** Resolves on the next `tool_cancel` frame (issue #9: daemon -> app cancellation). */
+  waitForToolCancel(): Promise<ToolCancelFrame> {
+    return new Promise((resolve) => {
+      this.toolCancelWaiters.push(resolve);
+    });
+  }
+
+  /** Resolves on the next `tool_call` frame, independent of whether `answerCalls` is set — for
+   * scenarios that need to observe receipt of a call the app deliberately never answers. */
+  waitForToolCall(): Promise<ToolCallFrame> {
+    return new Promise((resolve) => {
+      this.toolCallWaiters.push(resolve);
+    });
+  }
+
   private requireSocket(): WebSocket {
     if (!this.socket) {
       throw new Error("FakeAppClient has no open socket — call claim()/resume() first.");
@@ -184,8 +202,26 @@ export class FakeAppClient {
         return;
       }
 
-      if (message.type === "tool_call" && this.toolCallHandler) {
-        void this.handleToolCall(socket, message as unknown as ToolCallFrame);
+      if (message.type === "tool_call") {
+        const waiters = this.toolCallWaiters;
+        this.toolCallWaiters = [];
+        for (const waiter of waiters) {
+          waiter(message as unknown as ToolCallFrame);
+        }
+
+        if (this.toolCallHandler) {
+          void this.handleToolCall(socket, message as unknown as ToolCallFrame);
+        }
+
+        return;
+      }
+
+      if (message.type === "tool_cancel") {
+        const waiters = this.toolCancelWaiters;
+        this.toolCancelWaiters = [];
+        for (const waiter of waiters) {
+          waiter(message as unknown as ToolCancelFrame);
+        }
       }
     });
 

--- a/packages/cordierite/src/__tests__/e2e/invoke-cancel.e2e.test.ts
+++ b/packages/cordierite/src/__tests__/e2e/invoke-cancel.e2e.test.ts
@@ -1,0 +1,66 @@
+/**
+ * E2E scenario: `cordierite invoke` + SIGINT (issue #9). SIGINT during an in-flight `tools.call`
+ * must cancel the call rather than leave it running unowned in the app — this drives a real CLI
+ * subprocess against a real daemon and fake app-client, the same harness as `events.e2e.test.ts`.
+ */
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { FakeAppClient } from "./app-client.js";
+import {
+  cleanupAfterEach,
+  ensureDaemon,
+  fetchPinnedKeys,
+  makeTempStateDir,
+  mintLink,
+  spawnCli,
+  waitForExit,
+} from "./harness.js";
+
+afterEach(cleanupAfterEach);
+
+describe("e2e: cordierite invoke + SIGINT", () => {
+  test(
+    "SIGINT cancels the in-flight call: the app receives tool_cancel and the CLI exits non-zero as tool_cancelled",
+    async () => {
+      const { stateDir, port } = await makeTempStateDir();
+      await ensureDaemon(stateDir);
+      const pinnedKeys = await fetchPinnedKeys(stateDir);
+
+      const link = await mintLink(stateDir);
+      const app = new FakeAppClient(port, pinnedKeys);
+      const ack = await app.claim(link, { model: "Pixel 8" });
+      const alias = ack.alias;
+
+      app.registerTools([{ name: "slow" }]);
+      // Deliberately never call app.answerCalls(): the point of this scenario is that the app never
+      // gets a chance to answer before the CLI gives up on it.
+
+      const gotToolCall = app.waitForToolCall();
+      const gotToolCancel = app.waitForToolCancel();
+
+      const invokeProcess = spawnCli(["invoke", alias, "slow", "--input", "{}", "--json"], stateDir);
+      // Drain stderr so the child never blocks on a full pipe buffer; stdout is collected below.
+      invokeProcess.stderr.resume();
+      const stdoutChunks: Buffer[] = [];
+      invokeProcess.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+
+      await gotToolCall;
+      invokeProcess.kill("SIGINT");
+
+      const cancelFrame = await gotToolCancel;
+      expect(cancelFrame.reason).toBe("connection_closed");
+
+      const exitCode = await waitForExit(invokeProcess);
+      expect(exitCode).toBe(72); // tool_error sysexits class (errors.ts's EXIT_CODE_BY_ERROR_TYPE)
+
+      const rendered = JSON.parse(Buffer.concat(stdoutChunks).toString("utf8")) as {
+        ok: boolean;
+        error?: { type?: string };
+      };
+      expect(rendered.ok).toBe(false);
+      expect(rendered.error?.type).toBe("tool_cancelled");
+    },
+    15_000,
+  );
+});

--- a/packages/cordierite/src/__tests__/errors.test.ts
+++ b/packages/cordierite/src/__tests__/errors.test.ts
@@ -35,6 +35,7 @@ const EXPECTED_RPC_ERROR_CLASS: Record<ErrorType, number> = {
   tool_execution_error: 72,
   tool_serialization_error: 72,
   tool_timeout: 72,
+  tool_cancelled: 72,
   policy_denied: 77,
   invalid_request: 65,
 };

--- a/packages/cordierite/src/__tests__/mcp-server.integration.test.ts
+++ b/packages/cordierite/src/__tests__/mcp-server.integration.test.ts
@@ -326,6 +326,63 @@ describe("mcp: tools/list and tools/call", () => {
     app.socket.close();
   });
 
+  test("an MCP client's notifications/cancelled forwards to the app as tool_cancel (issue #9)", async () => {
+    const { daemon, stateDir, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+    await snapshotTools(daemon, app, [{ name: "slow" }]);
+
+    const receivedByApp: Record<string, unknown>[] = [];
+    const gotToolCancel = new Promise<Record<string, unknown>>((resolve) => {
+      app.socket.on("message", (data) => {
+        const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
+        receivedByApp.push(msg);
+        // Deliberately never reply to tool_call — the point is that cancellation reaches the app
+        // while the call is still pending.
+        if (msg.type === "tool_cancel") {
+          resolve(msg);
+        }
+      });
+    });
+
+    const handle = await createMcpHandle(stateDir);
+    const client = await connectInMemoryClient(handle);
+
+    const controller = new AbortController();
+    const callPromise = client
+      .request(
+        { method: "tools/call", params: { name: "slow", arguments: {} } },
+        CallToolResultSchema,
+        // `onprogress` is what makes the SDK attach a progressToken — required for the server's
+        // progress-correlation path (mcp/server.ts's callProxiedTool) to ever learn `callId`.
+        { onprogress: () => {}, signal: controller.signal },
+      )
+      .catch(() => {
+        // The SDK rejects the client-side promise locally as soon as it sends the cancellation —
+        // that's the SDK's own behavior, not what this test is verifying.
+      });
+
+    await new Promise<void>((resolve) => {
+      const check = (): void => {
+        if (receivedByApp.some((msg) => msg.type === "tool_call")) {
+          resolve();
+        }
+      };
+      app.socket.on("message", check);
+      check();
+    });
+
+    controller.abort("user cancelled");
+
+    const cancelMessage = await gotToolCancel;
+    expect(cancelMessage).toMatchObject({ type: "tool_cancel", session_id: app.sessionId, reason: "mcp_client_cancelled" });
+
+    const toolCallMessage = receivedByApp.find((msg) => msg.type === "tool_call");
+    expect(cancelMessage.id).toBe(toolCallMessage?.id);
+
+    await callPromise;
+    app.socket.close();
+  });
+
   test("the generated MCP tool list (built-ins + one proxied tool) matches the locked mapping", async () => {
     const { daemon, stateDir, port } = await startTestDaemon();
     const app = await claimApp(daemon, port);

--- a/packages/cordierite/src/__tests__/policy-and-audit.integration.test.ts
+++ b/packages/cordierite/src/__tests__/policy-and-audit.integration.test.ts
@@ -231,7 +231,7 @@ type AuditRecord = {
   alias: string;
   tool: string;
   argsSha256: string;
-  outcome: "ok" | "error" | "denied";
+  outcome: "ok" | "error" | "denied" | "cancelled";
   errorType?: string;
   durationMs: number;
   caller: "cli" | "mcp";
@@ -444,6 +444,46 @@ describe("audit: one line per tools.call attempt", () => {
     const mcpRecord = records.find((record) => record.tool === "echo" && record.caller === "mcp");
     expect(mcpRecord).toBeDefined();
     expect(mcpRecord?.outcome).toBe("ok");
+  });
+});
+
+describe("audit: cancelled outcome", () => {
+  test("tools.cancel followed by the app's tool_cancelled reply audits as cancelled", async () => {
+    const { daemon, port, stateDir } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+    await snapshotTools(daemon, app, [{ name: "slow" }]);
+
+    app.socket.on("message", (data) => {
+      const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
+
+      if (msg.type === "tool_cancel") {
+        app.socket.send(
+          JSON.stringify({
+            type: "tool_error",
+            session_id: app.sessionId,
+            id: msg.id,
+            error: { type: "tool_cancelled", message: "cancelled" },
+          }),
+        );
+      }
+    });
+
+    const started = waitForEvent(daemon, "tool_call_started");
+    const callPromise = rpcCall(daemon.paths.socketPath, "tools.call", { selector: app.alias, name: "slow", args: {} });
+    const startedEvent = await started;
+    const callId = (startedEvent.data as { callId: string }).callId;
+
+    await rpcCall(daemon.paths.socketPath, "tools.cancel", { selector: app.alias, callId });
+
+    await expect(callPromise).rejects.toMatchObject({ data: { type: "tool_cancelled" } });
+
+    app.socket.close();
+    await shutdownNow(daemon);
+
+    const records = await readAuditRecords(stateDir);
+    const cancelledRecord = records.find((record) => record.tool === "slow");
+    expect(cancelledRecord?.outcome).toBe("cancelled");
+    expect(cancelledRecord?.errorType).toBe("tool_cancelled");
   });
 });
 

--- a/packages/cordierite/src/__tests__/tool-invocation.integration.test.ts
+++ b/packages/cordierite/src/__tests__/tool-invocation.integration.test.ts
@@ -529,6 +529,98 @@ describe("tools.call: suspend mid-call", () => {
   }, 10_000);
 });
 
+describe("tools.cancel", () => {
+  test("sends tool_cancel to the app; the app's tool_cancelled reply rejects the pending call", async () => {
+    const { daemon, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+    await snapshotTools(daemon, app, [{ name: "slow" }]);
+
+    const cancelMessages: Record<string, unknown>[] = [];
+    app.socket.on("message", (data) => {
+      const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
+
+      if (msg.type === "tool_cancel") {
+        cancelMessages.push(msg);
+        app.socket.send(
+          JSON.stringify({
+            type: "tool_error",
+            session_id: app.sessionId,
+            id: msg.id,
+            error: { type: "tool_cancelled", message: "cancelled by client" },
+          }),
+        );
+      }
+    });
+
+    const started = waitForEvent(daemon, "tool_call_started");
+    const callPromise = rpcCall(daemon.paths.socketPath, "tools.call", { selector: app.alias, name: "slow", args: {} });
+    const startedEvent = await started;
+    const callId = (startedEvent.data as { callId: string }).callId;
+
+    const cancelResult = await rpcCall(daemon.paths.socketPath, "tools.cancel", { selector: app.alias, callId });
+    expect(cancelResult).toEqual({ cancelled: true });
+
+    await expect(callPromise).rejects.toMatchObject({ data: { type: "tool_cancelled" } });
+
+    expect(cancelMessages).toHaveLength(1);
+    expect(cancelMessages[0]).toMatchObject({ type: "tool_cancel", session_id: app.sessionId, id: callId });
+
+    app.socket.close();
+  });
+
+  test("cancelling an unknown or already-finished callId is a no-op, not an error", async () => {
+    const { daemon, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+
+    const result = await rpcCall(daemon.paths.socketPath, "tools.cancel", {
+      selector: app.alias,
+      callId: "call_does_not_exist",
+    });
+    expect(result).toEqual({ cancelled: false });
+
+    app.socket.close();
+  });
+});
+
+describe("tools.call: cancel on connection drop", () => {
+  test("the connection that issued tools.call dropping mid-flight sends tool_cancel to the app", async () => {
+    const { daemon, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+    await snapshotTools(daemon, app, [{ name: "slow" }]);
+
+    const gotToolCall = new Promise<void>((resolve) => {
+      app.socket.once("message", (data) => {
+        const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
+        if (msg.type === "tool_call") {
+          resolve();
+        }
+      });
+    });
+
+    const gotToolCancel = new Promise<Record<string, unknown>>((resolve) => {
+      app.socket.on("message", (data) => {
+        const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
+        if (msg.type === "tool_cancel") {
+          resolve(msg);
+        }
+      });
+    });
+
+    const issuingConnection = await openRpcConnection(daemon.paths.socketPath);
+    // Fire-and-forget: the connection is about to be dropped, so nothing will ever read this
+    // response — only the app-visible side effect (tool_cancel) is under test here.
+    issuingConnection.call("tools.call", { selector: app.alias, name: "slow", args: {} }).catch(() => {});
+
+    await gotToolCall;
+    issuingConnection.close();
+
+    const cancelMessage = await gotToolCancel;
+    expect(cancelMessage).toMatchObject({ type: "tool_cancel", session_id: app.sessionId });
+
+    app.socket.close();
+  });
+});
+
 describe("events.subscribe", () => {
   test("a subscriber receives session_claimed, tools_changed, app_event, tool_call_started/finished in order", async () => {
     const { daemon, port } = await startTestDaemon();

--- a/packages/cordierite/src/cli/dispatch.ts
+++ b/packages/cordierite/src/cli/dispatch.ts
@@ -156,22 +156,33 @@ export const runCli = async (argv: string[], options: RunCliOptions = {}): Promi
         "invoke [selector] <tool> --input '<json>'",
       );
 
-      return executeCommand(
-        "invoke",
-        () =>
-          handleInvokeCommand(
-            {
-              selector,
-              tool,
-              args: parseJsonInputOption(
-                typeof parsedOptions.input === "string" ? parsedOptions.input : undefined,
-              ),
-              timeoutMs: parsePositiveIntegerOption(parsedOptions.timeout, "--timeout"),
-            },
-            { stateDir },
-          ),
-        io,
-      );
+      // SIGINT cancels the in-flight tools.call rather than leaving it running unowned in the app
+      // (issue #9) — the listener is torn down once the command settles either way.
+      const cancelController = new AbortController();
+      const onSigint = (): void => cancelController.abort();
+      process.once("SIGINT", onSigint);
+
+      try {
+        return await executeCommand(
+          "invoke",
+          () =>
+            handleInvokeCommand(
+              {
+                selector,
+                tool,
+                args: parseJsonInputOption(
+                  typeof parsedOptions.input === "string" ? parsedOptions.input : undefined,
+                ),
+                timeoutMs: parsePositiveIntegerOption(parsedOptions.timeout, "--timeout"),
+              },
+              { stateDir },
+              cancelController.signal,
+            ),
+          io,
+        );
+      } finally {
+        process.off("SIGINT", onSigint);
+      }
     }
 
     case "revoke": {

--- a/packages/cordierite/src/commands/invoke.ts
+++ b/packages/cordierite/src/commands/invoke.ts
@@ -7,7 +7,7 @@
 import { RPC_METHODS, type ToolsCallResult } from "@cordierite/shared";
 
 import type { CliResult, InvokeCommandData } from "../cli/result-types.js";
-import { callDaemon, type SpawnFn } from "../rpc/client.js";
+import { DaemonRpcError, openDaemonStream, type SpawnFn } from "../rpc/client.js";
 
 export type InvokeCommandOptions = {
   selector?: string;
@@ -24,17 +24,48 @@ export type InvokeCommandContext = {
 export const handleInvokeCommand = async (
   options: InvokeCommandOptions,
   context: InvokeCommandContext,
+  /** Aborted on SIGINT (issue #9): closes the RPC connection that issued `tools.call`, which the
+   * daemon treats as a mid-flight cancel and forwards to the app as `tool_cancel`. */
+  signal?: AbortSignal,
 ): Promise<CliResult<InvokeCommandData>> => {
-  const result = await callDaemon<ToolsCallResult>(
-    RPC_METHODS.toolsCall,
-    {
+  const stream = await openDaemonStream({ stateDir: context.stateDir, spawn: context.spawn });
+
+  try {
+    const callPromise = stream.call<ToolsCallResult>(RPC_METHODS.toolsCall, {
       selector: options.selector,
       name: options.tool,
       args: options.args,
       timeoutMs: options.timeoutMs,
-    },
-    { stateDir: context.stateDir, spawn: context.spawn },
-  );
+    });
 
-  return { ok: true, data: result.result };
+    if (!signal) {
+      const result = await callPromise;
+      return { ok: true, data: result.result };
+    }
+
+    const result = await new Promise<ToolsCallResult>((resolve, reject) => {
+      // Attached unconditionally, before the aborted check below — otherwise an already-aborted
+      // signal cancels without ever wiring a handler onto `callPromise`, and the rejection that
+      // follows from closing the stream below becomes an unhandled rejection.
+      callPromise.then(resolve, reject).finally(() => signal.removeEventListener("abort", cancel));
+
+      function cancel(): void {
+        reject(new DaemonRpcError(-32000, `Tool "${options.tool}" was cancelled.`, { type: "tool_cancelled" }));
+        // Dropping the connection is what actually cancels the call daemon-side (calls.ts's
+        // per-connection onClose hook) — this promise settling doesn't wait for that to finish.
+        stream.close();
+      }
+
+      if (signal.aborted) {
+        cancel();
+        return;
+      }
+
+      signal.addEventListener("abort", cancel, { once: true });
+    });
+
+    return { ok: true, data: result.result };
+  } finally {
+    stream.close();
+  }
 };

--- a/packages/cordierite/src/daemon/audit.ts
+++ b/packages/cordierite/src/daemon/audit.ts
@@ -19,7 +19,7 @@ import type { ErrorType } from "@cordierite/shared";
 
 import type { Clock } from "../cli/types.js";
 
-export type AuditOutcome = "ok" | "error" | "denied";
+export type AuditOutcome = "ok" | "error" | "denied" | "cancelled";
 export type AuditCaller = "cli" | "mcp";
 
 export type AuditRecord = {

--- a/packages/cordierite/src/daemon/calls.ts
+++ b/packages/cordierite/src/daemon/calls.ts
@@ -18,6 +18,7 @@ import { randomBytes } from "node:crypto";
 import type {
   ToolCallMessage,
   ToolCallProgressMessage,
+  ToolCancelMessage,
   ToolErrorMessage,
   ToolResultMessage,
 } from "@cordierite/shared";
@@ -42,8 +43,12 @@ export type CallSession = {
  * the resulting rejection comes from the `session_suspended` transition below, not this return). */
 export type SendToolCall = (sessionId: string, message: ToolCallMessage) => boolean;
 
+/** Sends a `tool_cancel` frame to the session's active socket; `false` if there is none. */
+export type SendToolCancel = (sessionId: string, message: ToolCancelMessage) => boolean;
+
 export type CallsManagerOptions = {
   send: SendToolCall;
+  sendCancel: SendToolCancel;
   eventBus: EventBus;
   timers?: TimerFns;
 };
@@ -70,6 +75,12 @@ export type CallsManager = {
   /** Routes a validated `tool_call_progress` frame to the event bus; unknown correlation ids are
    * dropped (no event is emitted). */
   handleToolCallProgress: (message: ToolCallProgressMessage) => void;
+  /** Sends `tool_cancel` for a still-pending call. Does not itself resolve/reject the pending
+   * call — the app's eventual `tool_error` (`tool_cancelled`) or a late `tool_result` still wins
+   * normally, and the existing timeout remains a backstop if the app never replies. Returns
+   * `false` (a no-op, not an error) when `callId` is unknown/already finished, or when the
+   * session has no active socket to send the frame on right now. */
+  cancel: (sessionId: string, callId: string, reason: string) => boolean;
   /** Rejects every pending call for a session immediately (suspend/revoke/expiry transitions). */
   rejectSession: (sessionId: string, errorType: "session_suspended" | "unknown_session") => void;
   /** Rejects and clears every pending call across every session (daemon shutdown). */
@@ -206,6 +217,17 @@ export const createCallsManager = (options: CallsManagerOptions): CallsManager =
     });
   };
 
+  const cancel = (sessionId: string, callId: string, reason: string): boolean => {
+    const pending = pendingBySession.get(sessionId)?.get(callId);
+
+    if (!pending) {
+      return false;
+    }
+
+    const message: ToolCancelMessage = { type: "tool_cancel", session_id: sessionId, id: callId, reason };
+    return options.sendCancel(sessionId, message);
+  };
+
   const rejectSession = (sessionId: string, errorType: "session_suspended" | "unknown_session"): void => {
     const sessionMap = pendingBySession.get(sessionId);
 
@@ -239,5 +261,5 @@ export const createCallsManager = (options: CallsManagerOptions): CallsManager =
     }
   };
 
-  return { call, handleToolResult, handleToolError, handleToolCallProgress, rejectSession, disposeAll };
+  return { call, handleToolResult, handleToolError, handleToolCallProgress, cancel, rejectSession, disposeAll };
 };

--- a/packages/cordierite/src/daemon/daemon.ts
+++ b/packages/cordierite/src/daemon/daemon.ts
@@ -30,6 +30,8 @@ import {
   type ToolCallProgressMessage,
   type ToolsCallParams,
   type ToolsCallResult,
+  type ToolsCancelParams,
+  type ToolsCancelResult,
   type ToolsListResult,
 } from "@cordierite/shared";
 
@@ -188,6 +190,32 @@ const asToolsCallParams = (params: unknown): ToolsCallParams => {
   };
 };
 
+const asToolsCancelParams = (params: unknown): ToolsCancelParams => {
+  const record = asRecordParams(params);
+
+  const selector = record.selector;
+
+  if (selector !== undefined && typeof selector !== "string") {
+    throw new RpcApplicationError("invalid_request", '"selector" must be a string.');
+  }
+
+  if (typeof record.callId !== "string" || record.callId.length === 0) {
+    throw new RpcApplicationError("invalid_request", '"callId" must be a non-empty string.');
+  }
+
+  const reason = record.reason;
+
+  if (reason !== undefined && typeof reason !== "string") {
+    throw new RpcApplicationError("invalid_request", '"reason" must be a string.');
+  }
+
+  return {
+    selector: selector as string | undefined,
+    callId: record.callId,
+    reason: reason as string | undefined,
+  };
+};
+
 const asEventsSubscribeParams = (params: unknown): EventsSubscribeParams => {
   const record = asRecordParams(params);
 
@@ -332,6 +360,7 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
 
     callsManager = createCallsManager({
       send: (sessionId, message) => activeSessionManager.sendToolCall(sessionId, message),
+      sendCancel: (sessionId, message) => activeSessionManager.sendToolCancel(sessionId, message),
       eventBus: activeEventBus,
     });
 
@@ -426,13 +455,13 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
         // This handler is the single seam every `tools.call` passes through: policy (ARCHITECTURE.md
         // §12) is evaluated once the target tool descriptor is known, and one audit record is
         // written for every attempt that reaches a resolved session, across ok/error/denied.
-        [RPC_METHODS.toolsCall]: async (params): Promise<ToolsCallResult> => {
+        [RPC_METHODS.toolsCall]: async (params, context): Promise<ToolsCallResult> => {
           const { selector, name, args, timeoutMs, caller } = asToolsCallParams(params);
           const effectiveCaller = caller ?? "cli";
           const resolved = activeSessionManager.resolveForTools(selector);
           const auditStartedAt = clock.now().getTime();
 
-          const writeAudit = (outcome: "ok" | "error" | "denied", errorType?: ErrorType): void => {
+          const writeAudit = (outcome: "ok" | "error" | "denied" | "cancelled", errorType?: ErrorType): void => {
             auditLogger.record({
               sessionId: resolved.sessionId,
               alias: resolved.alias,
@@ -487,6 +516,15 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
           // notifications by this id, unambiguous under concurrent calls.
           const { callId, result: callResult } = activeCallsManager.call(session, name, args, timeoutMs);
 
+          // If the connection that issued this tools.call drops while the call is still pending
+          // (CLI Ctrl-C, MCP client disconnect), tell the app to stop rather than leaving an
+          // orphaned handler running for a caller nobody is waiting on anymore. Unregistered once
+          // this call settles either way — otherwise a long-lived connection issuing many calls
+          // (e.g. the MCP server's persistent stream) leaks one closure per call for its lifetime.
+          const unregisterOnClose = context.onClose(() => {
+            activeCallsManager.cancel(resolved.sessionId, callId, "connection_closed");
+          });
+
           activeEventBus.emit({
             kind: "tool_call_started",
             sessionId: resolved.sessionId,
@@ -508,17 +546,27 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
             return { result, callId };
           } catch (error) {
             const errorType = error instanceof RpcApplicationError ? error.type : "tool_execution_error";
+            const outcome = errorType === "tool_cancelled" ? "cancelled" : "error";
 
             activeEventBus.emit({
               kind: "tool_call_finished",
               sessionId: resolved.sessionId,
               alias: resolved.alias,
-              data: { name, callId, durationMs: clock.now().getTime() - startedAt, outcome: "error", errorType },
+              data: { name, callId, durationMs: clock.now().getTime() - startedAt, outcome, errorType },
             });
-            writeAudit("error", errorType);
+            writeAudit(outcome, errorType);
 
             throw error;
+          } finally {
+            unregisterOnClose();
           }
+        },
+        [RPC_METHODS.toolsCancel]: (params): ToolsCancelResult => {
+          const { selector, callId, reason } = asToolsCancelParams(params);
+          const resolved = activeSessionManager.resolveForTools(selector);
+          const cancelled = activeCallsManager.cancel(resolved.sessionId, callId, reason ?? "client_cancelled");
+
+          return { cancelled };
         },
         [RPC_METHODS.eventsSubscribe]: (params, context): EventsSubscribeResult => {
           const { sessionSelector, kinds } = asEventsSubscribeParams(params);

--- a/packages/cordierite/src/daemon/rpc-server.ts
+++ b/packages/cordierite/src/daemon/rpc-server.ts
@@ -40,6 +40,12 @@ export type RpcHandlerContext = {
   connection: RpcConnection;
   /** Registers a callback to run once the in-flight response has been flushed to the socket. */
   afterSend: (callback: () => void) => void;
+  /** Registers a callback to run once this connection closes — e.g. auto-cancelling a `tools.call`
+   * still in flight when the connection that issued it drops. Callbacks run at most once. Returns
+   * an unregister function — callers whose call already settled must use it, or the callback (and
+   * whatever it closed over) leaks for the lifetime of a long-lived connection (e.g. the MCP
+   * server's persistent stream, which issues many `tools.call`s over one connection). */
+  onClose: (callback: () => void) => () => void;
 };
 
 export type RpcHandler = (params: unknown, context: RpcHandlerContext) => unknown | Promise<unknown>;
@@ -105,6 +111,7 @@ const handleLine = async (
   line: string,
   connection: RpcConnection,
   dispatch: RpcDispatchTable,
+  registerOnClose: (callback: () => void) => () => void,
 ): Promise<void> => {
   const { socket } = connection;
   let request: JsonRpcRequest;
@@ -143,6 +150,7 @@ const handleLine = async (
     afterSend: (callback) => {
       afterSendCallbacks.push(callback);
     },
+    onClose: registerOnClose,
   };
 
   try {
@@ -185,6 +193,14 @@ export const startRpcServer = async (options: RpcServerOptions): Promise<RpcServ
     const connection: RpcConnection = { id, socket, state: {} };
     connections.set(id, connection);
 
+    const closeCallbacks = new Set<() => void>();
+    const registerOnClose = (callback: () => void): (() => void) => {
+      closeCallbacks.add(callback);
+      return () => {
+        closeCallbacks.delete(callback);
+      };
+    };
+
     let buffer = "";
 
     socket.on("data", (chunk: Buffer) => {
@@ -214,7 +230,7 @@ export const startRpcServer = async (options: RpcServerOptions): Promise<RpcServ
             return;
           }
 
-          void handleLine(line, connection, options.dispatch);
+          void handleLine(line, connection, options.dispatch, registerOnClose);
         }
 
         newlineIndex = buffer.indexOf("\n");
@@ -223,6 +239,17 @@ export const startRpcServer = async (options: RpcServerOptions): Promise<RpcServ
 
     socket.on("close", () => {
       connections.delete(id);
+
+      const callbacks = Array.from(closeCallbacks);
+      closeCallbacks.clear();
+
+      for (const callback of callbacks) {
+        try {
+          callback();
+        } catch {
+          // A close callback must never crash the daemon.
+        }
+      }
     });
   });
 

--- a/packages/cordierite/src/daemon/sessions.ts
+++ b/packages/cordierite/src/daemon/sessions.ts
@@ -30,6 +30,7 @@ import {
   type SessionSummary,
   type ToolCallMessage,
   type ToolCallProgressMessage,
+  type ToolCancelMessage,
   type ToolErrorMessage,
   type ToolResultMessage,
 } from "@cordierite/shared";
@@ -183,6 +184,10 @@ export type SessionManager = {
    * active socket right now (caller has typically already checked ACTIVE state via
    * {@link resolveForTools}, but the socket can still disappear between check and send). */
   sendToolCall: (sessionId: string, message: ToolCallMessage) => boolean;
+  /** Sends a `tool_cancel` frame to the session's active socket; `false` if the session has no
+   * active socket right now. A cancel for an unknown/finished call is the app's problem to
+   * no-op on — the daemon never knows which calls the app still considers in flight. */
+  sendToolCancel: (sessionId: string, message: ToolCancelMessage) => boolean;
   /** Closes every live socket with the given code (daemon shutdown) and clears all timers. */
   disposeAll: (code: number, reason: string) => void;
 };
@@ -596,7 +601,7 @@ export const createSessionManager = (options: SessionManagerOptions): SessionMan
     return { sessionId: session.sessionId, alias: session.alias, state: session.state, registry: session.registry };
   };
 
-  const sendToolCall = (sessionId: string, message: ToolCallMessage): boolean => {
+  const sendToApp = (sessionId: string, message: ToolCallMessage | ToolCancelMessage): boolean => {
     const session = sessions.get(sessionId);
 
     if (!session || session.state !== "active" || !session.socket) {
@@ -625,7 +630,8 @@ export const createSessionManager = (options: SessionManagerOptions): SessionMan
     describe: (selector) => toSummary(resolveSession(selector)),
     revoke,
     resolveForTools,
-    sendToolCall,
+    sendToolCall: sendToApp,
+    sendToolCancel: sendToApp,
     disposeAll,
   };
 };

--- a/packages/cordierite/src/errors.ts
+++ b/packages/cordierite/src/errors.ts
@@ -40,6 +40,7 @@ const RPC_ERROR_EXIT_CLASS: Record<ErrorType, CliErrorType> = {
   tool_execution_error: "tool_error",
   tool_serialization_error: "tool_error",
   tool_timeout: "tool_error",
+  tool_cancelled: "tool_error",
   policy_denied: "permission_error",
   invalid_request: "validation_error",
 };

--- a/packages/cordierite/src/mcp/server.ts
+++ b/packages/cordierite/src/mcp/server.ts
@@ -129,6 +129,11 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
     args: Record<string, unknown>,
     progressToken: string | number | undefined,
     sendNotification: (notification: unknown) => Promise<void>,
+    // The MCP SDK aborts this automatically on an inbound `notifications/cancelled` for this
+    // request (ARCHITECTURE.md §9). Only honored on the progress-tracked path below, which is the
+    // only one that learns `callId` while the call is still in flight — a non-progress call has no
+    // `callId` to cancel by until it has already resolved.
+    signal: AbortSignal,
   ): Promise<unknown> => {
     if (progressToken === undefined) {
       const result = await stream.call<ToolsCallResult>(RPC_METHODS.toolsCall, {
@@ -154,6 +159,26 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
       });
 
       let callId: string | undefined;
+      let cancelRequested = signal.aborted;
+
+      const maybeCancel = (): void => {
+        if (callId === undefined || !cancelRequested) {
+          return;
+        }
+
+        progressStream
+          .call(RPC_METHODS.toolsCancel, { selector: tool.selector, callId, reason: "mcp_client_cancelled" })
+          .catch((error: unknown) => {
+            console.error("cordierite mcp: failed to cancel a proxied tool call:", error);
+          });
+      };
+
+      const onAbort = (): void => {
+        cancelRequested = true;
+        maybeCancel();
+      };
+
+      signal.addEventListener("abort", onAbort);
 
       const unsubscribe = progressStream.onNotification((payload) => {
         const event = payload as EventNotification;
@@ -163,6 +188,7 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
 
           if (data.name === tool.descriptor.name) {
             callId = data.callId;
+            maybeCancel();
           }
 
           return;
@@ -193,6 +219,7 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
         return result.result;
       } finally {
         unsubscribe();
+        signal.removeEventListener("abort", onAbort);
       }
     } finally {
       progressStream.close();
@@ -238,6 +265,7 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
           args,
           progressToken,
           extra.sendNotification as (notification: unknown) => Promise<void>,
+          extra.signal,
         ),
       );
     } catch (error) {

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -161,6 +161,15 @@ export function CordieriteBootstrap() {
 
 Mount that component near app startup, or register from another module that loads on startup. The host can only list and invoke tools that your app has already registered.
 
+**Cancellation:** `handler(args, context)`'s `context.signal` (an `AbortSignal`) aborts if the caller cancels the call, or if the session's connection is lost mid-call. Forward it into anything that accepts one (`fetch(url, { signal: context.signal })`) or check `context.signal.aborted`/listen for `"abort"` to stop early. Ignoring it is fine — the handler just keeps running and replies normally, as it always has.
+
+```ts
+handler: async ({ url }, { signal }) => {
+  const response = await fetch(url, { signal });
+  return { body: await response.text() };
+},
+```
+
 **Gating a tool by build variant:** `useCordieriteTool` takes a third `options` argument, `{ enabled?: boolean }` (default `true`). `enabled: false` never registers the tool, and removing it (or a hook that was already mounted) leaves no registration behind. Toggling `enabled` at runtime registers/unregisters cleanly — this is the supported way to make registration conditional, so put the condition in the argument instead of wrapping the hook call in an `if`, which is a rules-of-hooks violation:
 
 ```ts

--- a/packages/react-native/src/Cordierite.types.ts
+++ b/packages/react-native/src/Cordierite.types.ts
@@ -224,6 +224,9 @@ export type CordieriteToolExecutionContext = {
   invocationId: string;
   receivedAt: string;
   reportProgress: CordieriteReportProgress;
+  /** Aborted when the daemon sends `tool_cancel` for this call, or when the session suspends
+   * mid-call. Handlers may ignore it — they then run to completion as before. */
+  signal: AbortSignal;
 };
 
 export type CordieriteToolHandler<TArgs = unknown, TResult = unknown> = (

--- a/packages/react-native/src/__tests__/tool-invocation.test.ts
+++ b/packages/react-native/src/__tests__/tool-invocation.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { CordieriteRegisteredTool } from "../Cordierite.types";
+import type { ClientTimerHandle, ClientTimers } from "../client/timers";
+import { createToolMessageHandler } from "../client/tool-invocation";
+
+/** Real timers, but exposed through the `ClientTimers` DI seam the module under test expects. */
+const realTimers: ClientTimers = {
+  setTimeout: (callback, ms) =>
+    setTimeout(callback, ms) as unknown as ClientTimerHandle,
+  clearTimeout: (handle) => clearTimeout(handle as unknown as NodeJS.Timeout),
+  now: () => Date.now(),
+  random: () => Math.random(),
+};
+
+const SESSION_ID = "session-1";
+
+const registerTool = (
+  registry: Map<string, CordieriteRegisteredTool>,
+  name: string,
+  handler: CordieriteRegisteredTool["handler"],
+  timeoutMs = 1000,
+): void => {
+  registry.set(name, {
+    id: Symbol(name),
+    descriptor: { name, description: "A test tool." },
+    handler,
+    timeoutMs,
+  });
+};
+
+const createHarness = () => {
+  const registry = new Map<string, CordieriteRegisteredTool>();
+  const sent: Record<string, unknown>[] = [];
+  const errors: unknown[] = [];
+
+  const handlerApi = createToolMessageHandler({
+    getSessionId: () => SESSION_ID,
+    getRegistry: () => registry,
+    sendWire: async (json) => {
+      sent.push(JSON.parse(json));
+    },
+    timers: realTimers,
+    onError: (event) => {
+      errors.push(event);
+    },
+  });
+
+  return { registry, sent, errors, ...handlerApi };
+};
+
+const toolCallMessage = (
+  id: string,
+  name: string,
+  args: Record<string, unknown> = {},
+) => ({
+  type: "tool_call",
+  session_id: SESSION_ID,
+  id,
+  name,
+  args,
+});
+
+const toolCancelMessage = (id: string, reason = "client_cancelled") => ({
+  type: "tool_cancel",
+  session_id: SESSION_ID,
+  id,
+  reason,
+});
+
+describe("createToolMessageHandler: cancellation", () => {
+  test("tool_cancel aborts the handler's signal, and an observing handler's throw is reported as tool_cancelled", async () => {
+    const { registry, sent, handleMessage } = createHarness();
+
+    let observedAborted = false;
+    let resolveHandler!: () => void;
+    const handlerStarted = new Promise<void>((resolve) => {
+      resolveHandler = resolve;
+    });
+
+    registerTool(registry, "slow", (_args, { signal }) => {
+      return new Promise((_resolve, reject) => {
+        resolveHandler();
+        signal.addEventListener("abort", () => {
+          observedAborted = true;
+          reject(new Error("aborted"));
+        });
+      });
+    });
+
+    const callPromise = handleMessage(toolCallMessage("call-1", "slow"));
+    await handlerStarted;
+    await handleMessage(toolCancelMessage("call-1"));
+    await callPromise;
+
+    expect(observedAborted).toBe(true);
+    expect(sent).toEqual([
+      {
+        type: "tool_error",
+        session_id: SESSION_ID,
+        id: "call-1",
+        error: { type: "tool_cancelled", message: expect.any(String) },
+      },
+    ]);
+  });
+
+  test("a handler that ignores the signal still completes normally (backwards compatible)", async () => {
+    const { registry, sent, handleMessage } = createHarness();
+
+    let resolveHandler!: (value: undefined) => void;
+    const handlerCalled = new Promise<void>((resolve) => {
+      registerTool(registry, "stubborn", () => {
+        resolve();
+        return new Promise<undefined>((res) => {
+          resolveHandler = res;
+        });
+      });
+    });
+
+    const callPromise = handleMessage(toolCallMessage("call-2", "stubborn"));
+    await handlerCalled;
+    await handleMessage(toolCancelMessage("call-2"));
+    resolveHandler(undefined);
+    await callPromise;
+
+    expect(sent).toEqual([
+      {
+        type: "tool_result",
+        session_id: SESSION_ID,
+        id: "call-2",
+        result: null,
+      },
+    ]);
+  });
+
+  test("tool_cancel for an unknown or already-finished id is a silent no-op", async () => {
+    const { sent, handleMessage } = createHarness();
+
+    await handleMessage(toolCancelMessage("call-does-not-exist"));
+
+    expect(sent).toEqual([]);
+  });
+
+  test("abortAllInFlight aborts every currently-registered call's signal", async () => {
+    const { registry, handleMessage, abortAllInFlight } = createHarness();
+
+    const aborted: string[] = [];
+    let started = 0;
+    let resolveStarted!: () => void;
+    const bothStarted = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+
+    for (const name of ["a", "b"]) {
+      registerTool(registry, name, (_args, { signal }) => {
+        return new Promise((_resolve, reject) => {
+          started += 1;
+          if (started === 2) {
+            resolveStarted();
+          }
+          signal.addEventListener("abort", () => {
+            aborted.push(name);
+            reject(new Error("aborted"));
+          });
+        });
+      });
+    }
+
+    const callA = handleMessage(toolCallMessage("call-a", "a"));
+    const callB = handleMessage(toolCallMessage("call-b", "b"));
+    await bothStarted;
+
+    abortAllInFlight();
+    await Promise.all([callA, callB]);
+
+    expect(aborted.sort()).toEqual(["a", "b"]);
+  });
+
+  test("abortAllInFlight reports tool_cancelled (not a generic execution error) and never fires onError", async () => {
+    const { registry, sent, errors, handleMessage, abortAllInFlight } = createHarness();
+
+    let handlerStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      handlerStarted = resolve;
+    });
+
+    registerTool(registry, "loses-transport", (_args, { signal }) => {
+      return new Promise((_resolve, reject) => {
+        handlerStarted();
+        signal.addEventListener("abort", () => reject(new Error("aborted")));
+      });
+    });
+
+    const callPromise = handleMessage(toolCallMessage("call-4", "loses-transport"));
+    await started;
+
+    abortAllInFlight();
+    await callPromise;
+
+    expect(sent).toEqual([
+      {
+        type: "tool_error",
+        session_id: SESSION_ID,
+        id: "call-4",
+        error: { type: "tool_cancelled", message: expect.any(String) },
+      },
+    ]);
+    // The client initiated this abort itself (transport loss) — it must not also surface it to
+    // the app's own error listeners as if something unexpected happened.
+    expect(errors).toEqual([]);
+  });
+
+  test("a timeout also aborts the signal, distinctly from an explicit tool_cancel", async () => {
+    const { registry, sent, handleMessage } = createHarness();
+
+    let observedAborted = false;
+    registerTool(
+      registry,
+      "hangs",
+      (_args, { signal }) => {
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => {
+            observedAborted = true;
+            reject(new Error("aborted"));
+          });
+        });
+      },
+      10,
+    );
+
+    await handleMessage(toolCallMessage("call-3", "hangs"));
+    await vi.waitFor(() => expect(observedAborted).toBe(true));
+
+    expect(sent).toEqual([
+      {
+        type: "tool_error",
+        session_id: SESSION_ID,
+        id: "call-3",
+        error: { type: "tool_timeout", message: expect.any(String) },
+      },
+    ]);
+  });
+});

--- a/packages/react-native/src/client/index.ts
+++ b/packages/react-native/src/client/index.ts
@@ -177,7 +177,7 @@ export const createCordieriteClient = (
       fireAndForget(sendDelta(delta), "sync the tool registry", emitError),
   });
 
-  const invokeRegisteredTool = createToolMessageHandler({
+  const { handleMessage: invokeRegisteredTool, abortAllInFlight } = createToolMessageHandler({
     getSessionId,
     getRegistry: () => registry.entries,
     sendWire: rawSend,
@@ -372,6 +372,11 @@ export const createCordieriteClient = (
     if (destroyed) {
       return;
     }
+
+    // The socket is gone, so no `tool_cancel` frame could ever be delivered for whatever was
+    // still in flight — abort it directly rather than leaving handlers running with no owner.
+    abortAllInFlight();
+
     const myEpoch = epoch;
 
     if (!heldSession) {
@@ -797,6 +802,9 @@ export const createCordieriteClient = (
         ok: false,
         error: new Error("Cordierite client was destroyed."),
       });
+      // Same reasoning as above, for tool handlers: once listeners are removed below, no
+      // `tool_cancel` frame or transport-loss signal will ever reach an in-flight handler again.
+      abortAllInFlight();
       messageSubscription.remove();
       errorSubscription.remove();
       closeSubscription.remove();

--- a/packages/react-native/src/client/tool-invocation.ts
+++ b/packages/react-native/src/client/tool-invocation.ts
@@ -1,4 +1,4 @@
-import { isToolCallMessage } from "@cordierite/shared";
+import { isToolCallMessage, isToolCancelMessage } from "@cordierite/shared";
 
 import type {
   CordieriteRegisteredTool,
@@ -39,7 +39,7 @@ export type ToolInvocationDeps = {
 const sendWireSafely = async (
   sendWire: (json: string) => Promise<void>,
   json: string,
-  onError: ToolInvocationDeps["onError"]
+  onError: ToolInvocationDeps["onError"],
 ): Promise<void> => {
   try {
     await sendWire(json);
@@ -53,13 +53,43 @@ const sendWireSafely = async (
   }
 };
 
-export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
+export type ToolMessageHandler = {
+  handleMessage: (rawMessage: unknown) => Promise<void>;
+  /** Aborts every in-flight handler's signal without waiting for a `tool_cancel` frame per call —
+   * used when the transport itself is gone (session suspended), so nothing could deliver one. */
+  abortAllInFlight: () => void;
+};
+
+type InFlightCall = {
+  controller: AbortController;
+  /** Set only by an explicit `tool_cancel` frame, distinct from a timeout-driven abort — the two
+   * report different `tool_error.error.type` values. */
+  cancelled: boolean;
+};
+
+export const createToolMessageHandler = (
+  deps: ToolInvocationDeps,
+): ToolMessageHandler => {
   const { getSessionId, getRegistry, sendWire, timers, onError } = deps;
   const send = (json: string) => sendWireSafely(sendWire, json, onError);
+  const inFlight = new Map<string, InFlightCall>();
 
-  return async (rawMessage: unknown): Promise<void> => {
+  const handleMessage = async (rawMessage: unknown): Promise<void> => {
     const currentSessionId = getSessionId();
-    if (!currentSessionId || !isToolCallMessage(rawMessage)) {
+    if (!currentSessionId) {
+      return;
+    }
+
+    if (isToolCancelMessage(rawMessage)) {
+      const entry = inFlight.get(rawMessage.id);
+      if (entry) {
+        entry.cancelled = true;
+        entry.controller.abort();
+      }
+      return;
+    }
+
+    if (!isToolCallMessage(rawMessage)) {
       return;
     }
 
@@ -68,7 +98,7 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
 
     if (!tool) {
       logger.warn(
-        `tool call for unregistered tool "${rawMessage.name}" (id ${rawMessage.id})`
+        `tool call for unregistered tool "${rawMessage.name}" (id ${rawMessage.id})`,
       );
       await send(
         JSON.stringify({
@@ -79,10 +109,16 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
             type: "tool_not_found",
             message: `Tool "${rawMessage.name}" is not registered in the app.`,
           },
-        })
+        }),
       );
       return;
     }
+
+    const inFlightCall: InFlightCall = {
+      controller: new AbortController(),
+      cancelled: false,
+    };
+    inFlight.set(rawMessage.id, inFlightCall);
 
     const context: CordieriteToolExecutionContext = {
       sessionId: currentSessionId,
@@ -96,8 +132,9 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
             id: rawMessage.id,
             ...(progress !== undefined ? { progress } : {}),
             ...(message !== undefined ? { message } : {}),
-          })
+          }),
         ),
+      signal: inFlightCall.controller.signal,
     };
 
     logger.debug("tool call", rawMessage.name, "id", rawMessage.id);
@@ -106,18 +143,18 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
       const parsedArgs = tool.inputSchema
         ? await validateStandardSchema(tool.inputSchema, rawMessage.args)
         : Object.keys(rawMessage.args).length === 0
-        ? {
-            ok: true as const,
-            value: undefined,
-          }
-        : {
-            ok: false as const,
-            issues: [
-              {
-                message: `Tool "${rawMessage.name}" does not accept input arguments.`,
-              },
-            ],
-          };
+          ? {
+              ok: true as const,
+              value: undefined,
+            }
+          : {
+              ok: false as const,
+              issues: [
+                {
+                  message: `Tool "${rawMessage.name}" does not accept input arguments.`,
+                },
+              ],
+            };
 
       if (!parsedArgs.ok) {
         await send(
@@ -132,7 +169,7 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
                 issues: parsedArgs.issues,
               },
             },
-          })
+          }),
         );
         return;
       }
@@ -140,6 +177,7 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
       let timedOut = false;
       const timeoutHandle = timers.setTimeout(() => {
         timedOut = true;
+        inFlightCall.controller.abort();
         void send(
           JSON.stringify({
             type: "tool_error",
@@ -149,7 +187,7 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
               type: "tool_timeout",
               message: `Tool "${rawMessage.name}" did not respond within ${tool.timeoutMs}ms.`,
             },
-          })
+          }),
         );
       }, tool.timeoutMs);
 
@@ -158,9 +196,23 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
         result = await tool.handler(parsedArgs.value, context);
       } catch (error) {
         timers.clearTimeout(timeoutHandle);
+        if (inFlightCall.cancelled) {
+          await send(
+            JSON.stringify({
+              type: "tool_error",
+              session_id: currentSessionId,
+              id: rawMessage.id,
+              error: {
+                type: "tool_cancelled",
+                message: `Tool "${rawMessage.name}" was cancelled.`,
+              },
+            }),
+          );
+          return;
+        }
         if (timedOut) {
           logger.devWarn(
-            `tool "${rawMessage.name}" threw after its ${tool.timeoutMs}ms timeout (id ${rawMessage.id}); ignoring the late result.`
+            `tool "${rawMessage.name}" threw after its ${tool.timeoutMs}ms timeout (id ${rawMessage.id}); ignoring the late result.`,
           );
           return;
         }
@@ -170,7 +222,7 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
       timers.clearTimeout(timeoutHandle);
       if (timedOut) {
         logger.devWarn(
-          `tool "${rawMessage.name}" resolved after its ${tool.timeoutMs}ms timeout (id ${rawMessage.id}); ignoring the late result.`
+          `tool "${rawMessage.name}" resolved after its ${tool.timeoutMs}ms timeout (id ${rawMessage.id}); ignoring the late result.`,
         );
         return;
       }
@@ -178,18 +230,18 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
       const parsedResult = tool.outputSchema
         ? await validateStandardSchema(tool.outputSchema, result)
         : result === undefined
-        ? {
-            ok: true as const,
-            value: null,
-          }
-        : {
-            ok: false as const,
-            issues: [
-              {
-                message: `Tool "${rawMessage.name}" must not return a result when outputSchema is omitted.`,
-              },
-            ],
-          };
+          ? {
+              ok: true as const,
+              value: null,
+            }
+          : {
+              ok: false as const,
+              issues: [
+                {
+                  message: `Tool "${rawMessage.name}" must not return a result when outputSchema is omitted.`,
+                },
+              ],
+            };
 
       if (!parsedResult.ok) {
         await send(
@@ -204,7 +256,7 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
                 issues: parsedResult.issues,
               },
             },
-          })
+          }),
         );
         return;
       }
@@ -214,7 +266,7 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
       } catch (error) {
         logger.warn(
           `tool "${rawMessage.name}" result not JSON-serializable (id ${rawMessage.id})`,
-          error
+          error,
         );
         await send(
           JSON.stringify({
@@ -226,7 +278,7 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
               message: "Cordierite tool result is not JSON-serializable.",
               details: normalizeThrownError(error),
             },
-          })
+          }),
         );
         return;
       }
@@ -237,12 +289,12 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
           session_id: currentSessionId,
           id: rawMessage.id,
           result: parsedResult.value,
-        })
+        }),
       );
     } catch (error) {
       logger.warn(
         `tool "${rawMessage.name}" handler threw (id ${rawMessage.id})`,
-        error
+        error,
       );
       onError({
         phase: "tool",
@@ -257,8 +309,22 @@ export const createToolMessageHandler = (deps: ToolInvocationDeps) => {
           session_id: currentSessionId,
           id: rawMessage.id,
           error: normalizeThrownError(error),
-        })
+        }),
       );
+    } finally {
+      inFlight.delete(rawMessage.id);
     }
   };
+
+  const abortAllInFlight = (): void => {
+    for (const entry of inFlight.values()) {
+      // Marked `cancelled` for the same reason an explicit `tool_cancel` is: a handler that
+      // observes the signal and throws should report `tool_cancelled`, not fall through to a
+      // generic `tool_execution_error` and fire a spurious app-visible error event.
+      entry.cancelled = true;
+      entry.controller.abort();
+    }
+  };
+
+  return { handleMessage, abortAllInFlight };
 };

--- a/packages/shared/src/__tests__/messages.test.ts
+++ b/packages/shared/src/__tests__/messages.test.ts
@@ -8,6 +8,7 @@ import {
   isSessionResumeMessage,
   isToolCallMessage,
   isToolCallProgressMessage,
+  isToolCancelMessage,
   isToolErrorMessage,
   isToolRegistryDeltaMessage,
   isToolRegistrySnapshotMessage,
@@ -20,6 +21,7 @@ import {
   type SessionResumeMessage,
   type ToolCallMessage,
   type ToolCallProgressMessage,
+  type ToolCancelMessage,
   type ToolErrorMessage,
   type ToolRegistryRemoveDeltaMessage,
   type ToolRegistrySnapshotMessage,
@@ -99,6 +101,13 @@ const validProgress = (): ToolCallProgressMessage => ({
   id: "call-1",
   progress: 0.5,
   message: "halfway",
+});
+
+const validCancel = (): ToolCancelMessage => ({
+  type: "tool_cancel",
+  session_id: "session-1",
+  id: "call-1",
+  reason: "client_cancelled",
 });
 
 const validEvent = (): EventMessage => ({
@@ -368,6 +377,29 @@ describe("tool_call_progress", () => {
   });
 });
 
+describe("tool_cancel", () => {
+  test("accepts a valid message", () => {
+    expect(isToolCancelMessage(validCancel())).toBe(true);
+  });
+
+  test("rejects the wrong type", () => {
+    expect(isToolCancelMessage({ ...validCancel(), type: "tool_call" })).toBe(false);
+  });
+
+  test("rejects a missing field", () => {
+    const { reason: _reason, ...rest } = validCancel();
+    expect(isToolCancelMessage(rest)).toBe(false);
+  });
+
+  test("rejects a wrong field type", () => {
+    expect(isToolCancelMessage({ ...validCancel(), id: 123 })).toBe(false);
+  });
+
+  test("rejects an oversized reason", () => {
+    expect(isToolCancelMessage({ ...validCancel(), reason: "x".repeat(MAX_WIRE_STRING_LENGTH + 1) })).toBe(false);
+  });
+});
+
 describe("event", () => {
   test("accepts a valid message", () => {
     expect(isEventMessage(validEvent())).toBe(true);
@@ -404,6 +436,7 @@ describe("isKnownWireMessageType / isWireMessage", () => {
       validToolResult(),
       validToolError(),
       validProgress(),
+      validCancel(),
       validEvent(),
     ]) {
       expect(isKnownWireMessageType(message.type)).toBe(true);

--- a/packages/shared/src/domains/errors.ts
+++ b/packages/shared/src/domains/errors.ts
@@ -15,6 +15,7 @@ export const ERROR_TYPES = [
   "tool_execution_error",
   "tool_serialization_error",
   "tool_timeout",
+  "tool_cancelled",
   "session_suspended",
   "policy_denied",
   "invalid_request",
@@ -36,6 +37,7 @@ export const TOOL_ERROR_TYPES = [
   "tool_execution_error",
   "tool_serialization_error",
   "tool_timeout",
+  "tool_cancelled",
 ] as const satisfies readonly ErrorType[];
 
 export type ToolErrorType = (typeof TOOL_ERROR_TYPES)[number];

--- a/packages/shared/src/domains/messages.ts
+++ b/packages/shared/src/domains/messages.ts
@@ -132,6 +132,13 @@ export type ToolCallProgressMessage = {
   message?: string;
 };
 
+export type ToolCancelMessage = {
+  type: "tool_cancel";
+  session_id: SessionId;
+  id: string;
+  reason: string;
+};
+
 export type EventMessage = {
   type: "event";
   session_id: SessionId;
@@ -151,6 +158,7 @@ export type WireMessage =
   | ToolResultMessage
   | ToolErrorMessage
   | ToolCallProgressMessage
+  | ToolCancelMessage
   | EventMessage;
 
 // --- shared field validators ---
@@ -343,6 +351,18 @@ export const isToolCallProgressMessage = (value: unknown): value is ToolCallProg
   return true;
 };
 
+export const isToolCancelMessage = (value: unknown): value is ToolCancelMessage => {
+  if (!isRecord(value) || value.type !== "tool_cancel") {
+    return false;
+  }
+
+  return (
+    isBoundedNonEmptySessionId(value.session_id) &&
+    isBoundedString(value.id, MAX_WIRE_ID_LENGTH) &&
+    isBoundedString(value.reason, MAX_WIRE_STRING_LENGTH)
+  );
+};
+
 export const isEventMessage = (value: unknown): value is EventMessage => {
   if (!isRecord(value) || value.type !== "event") {
     return false;
@@ -365,6 +385,7 @@ const WIRE_MESSAGE_TYPES = [
   "tool_result",
   "tool_error",
   "tool_call_progress",
+  "tool_cancel",
   "event",
 ] as const;
 
@@ -387,6 +408,7 @@ const WIRE_MESSAGE_GUARDS: {
   tool_result: isToolResultMessage,
   tool_error: isToolErrorMessage,
   tool_call_progress: isToolCallProgressMessage,
+  tool_cancel: isToolCancelMessage,
   event: isEventMessage,
 };
 

--- a/packages/shared/src/domains/rpc.ts
+++ b/packages/shared/src/domains/rpc.ts
@@ -12,6 +12,7 @@ export const RPC_METHODS = {
   sessionsRevoke: "sessions.revoke",
   toolsList: "tools.list",
   toolsCall: "tools.call",
+  toolsCancel: "tools.cancel",
   eventsSubscribe: "events.subscribe",
 } as const;
 
@@ -136,6 +137,19 @@ export type ToolsCallResult = {
    * server proxying concurrent `tools/call` requests) can match its own call to the progress events
    * it sees on `events.subscribe` without guessing from data shape. */
   callId: string;
+};
+
+// --- tools.cancel ---
+
+export type ToolsCancelParams = SessionSelectorParams & {
+  /** The `callId` returned by the `tools.call` this cancels. */
+  callId: string;
+  reason?: string;
+};
+
+export type ToolsCancelResult = {
+  /** `false` when `callId` was unknown or already finished — a no-op, not an error. */
+  cancelled: boolean;
 };
 
 // --- events.subscribe ---


### PR DESCRIPTION
## Summary
- Closes #9. Tool calls could not be cancelled once sent — the app-side handler ran to completion even after an MCP client's `notifications/cancelled` or a CLI Ctrl-C walked away from the call.
- New `tool_cancel` daemon→app wire message and `tool_cancelled` error type; a `tools.cancel` RPC that sends it, plus automatic cancellation when the RPC connection that issued `tools.call` drops mid-flight.
- Handlers get an `AbortSignal` via `CordieriteToolExecutionContext`, aborted on `tool_cancel` or when the transport is lost; a handler that ignores it keeps working exactly as before (backwards compatible).
- MCP's `notifications/cancelled` maps onto `tools.cancel` for progress-tracked calls (the only ones that learn `callId` while still in flight).
- `cordierite invoke` cancels its in-flight call on SIGINT instead of leaving it running.
- Audit outcome gains `"cancelled"` alongside `ok`/`error`/`denied`.
- `docs/PROTOCOL.md` and `docs/ARCHITECTURE.md` updated to document the new message/RPC/error type.

Reviewed by an independent Opus pass; all must-fix and should-fix findings (unhandled rejection on an already-aborted SIGINT, an `onClose` callback leak on long-lived connections, `destroy()` not aborting in-flight handlers, transport-loss aborts misreporting as generic errors, `tools.cancel`'s return value, and formatting churn) were addressed.

## Test plan
- [x] `pnpm typecheck` clean across `@cordierite/shared`, `cordierite`, `@cordierite/react-native`
- [x] `pnpm build` clean across all packages
- [x] `pnpm test`: 242/242 passing in `cordierite` (incl. new integration + e2e coverage for `tools.cancel`, connection-drop auto-cancel, and SIGINT-during-`invoke`), 204/204 passing in `@cordierite/react-native` (incl. new unit coverage for the `AbortSignal` wiring), shared package tests passing