### PR TITLE
feat: minimal policy: "prompt" via anthropic/requiresUserInteraction

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -329,14 +329,25 @@ it.
 ## 12. Policy & audit
 
 - Policy applies at the daemon on every `tools.call` (CLI and MCP alike), keyed on the
-  descriptor's `annotations`: `policy.default` (`allow`/`deny`) for tools without
-  `destructiveHint`, `policy.destructive` (`allow`/`deny`) for tools with it, plus
-  per-tool overrides `policy.tools["<alias>/<name>"]`. Denied calls return
-  `policy_denied` and are audited. Interactive prompting is not implemented; the
-  policy configuration leaves room for a future `prompt` value.
+  descriptor's `annotations`: `policy.default`/`policy.destructive`/per-tool overrides
+  `policy.tools["<alias>/<name>"]`, each `"allow" | "deny" | "prompt"`. `allow`/`deny`
+  behave as before; denied calls return `policy_denied` and are audited.
+- `"prompt"` means "a human gate is required; if one cannot be guaranteed, deny" — it
+  fails closed rather than silently behaving like `allow`. The only implemented gate
+  today is MCP: `tools/list` emits `_meta["anthropic/requiresUserInteraction"] = true`
+  for a `"prompt"` tool when the connected client's `initialize` `clientInfo` is known
+  to enforce it (Claude Code ≥ v2.1.199 — every other client ignores the flag). The MCP
+  server then sets `consent: "client"` on that tool's `tools.call`, which is the
+  daemon's sole evidence a human gate exists; every other caller (CLI, an older or
+  non-compliant MCP client, a forged `consent`) is denied with `policy_denied`, reason
+  `no_consent_channel`. `clientInfo` is self-reported — not a defense against a hostile
+  client, only against silent auto-approval by compliant ones.
 - Audit: every `tools.call` appends one JSONL record to `audit/<date>.jsonl`:
   `{ ts, sessionId, alias, tool, argsSha256, outcome: "ok"|"error"|"denied",
-  errorType?, durationMs, caller: "cli"|"mcp" }`. Raw args are never logged.
+  errorType?, durationMs, caller: "cli"|"mcp", consent?: "client" }`. `consent` is set
+  only when a `"prompt"` call proceeded on the MCP client-gate channel above — kept
+  distinct from a plain `"ok"` since the daemon never observes the consent decision
+  itself, only that the call arrived carrying this marker. Raw args are never logged.
 
 ## 13. Package layout
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,8 +138,8 @@ Methods:
 | `sessions.list` | — | `SessionSummary[]` |
 | `sessions.describe` | `{ selector? }` | full session detail incl. device metadata, state timestamps, tool count |
 | `sessions.revoke` | `{ selector? }` | `{ ok: true }` — closes socket (code 1000), frees alias |
-| `tools.list` | `{ selector? }` | `ToolDescriptor[]` (full schemas + annotations) |
-| `tools.call` | `{ selector?, name, args, timeoutMs? }` | `{ result, callId }` on success — `callId` lets a caller with several in-flight calls match `tool_call_progress`/`tool_call_finished` events back to this call; JSON-RPC error with `data.type` preserving the wire error type on failure |
+| `tools.list` | `{ selector? }` | `ToolsListEntry[]` — `ToolDescriptor` (full schema + annotations) plus the tool's effective `policy: "allow" \| "deny" \| "prompt"` (§12), resolved daemon-side |
+| `tools.call` | `{ selector?, name, args, timeoutMs?, caller?: "cli" \| "mcp", consent?: "client" }` | `{ result, callId }` on success — `callId` lets a caller with several in-flight calls match `tool_call_progress`/`tool_call_finished` events back to this call; JSON-RPC error with `data.type` preserving the wire error type on failure. `caller` attributes the audit record (§12); `consent` is the MCP server's evidence of a `"prompt"`-policy human gate (§12) — absent for the CLI. |
 | `events.subscribe` | `{ sessionSelector?, kinds? }` | `{ ok: true }`, then `event` notifications on this connection |
 
 `SessionSummary`: `{ sessionId, alias, state, device: { manufacturer?, model?, os? },
@@ -231,7 +231,12 @@ proxies daemon RPC (auto-spawning the daemon like any client):
   several → namespaced `<alias>__<name>`. Registry and session changes emit
   `notifications/tools/list_changed`, so an agent's tool list tracks the device.
 - Tool calls, progress frames, errors (with their `type` preserved), and descriptor
-  annotations all map through verbatim — the MCP surface adds no semantics of its own.
+  annotations all map through verbatim. The one semantic the MCP surface does add is
+  `"prompt"`-policy consent (§12): `tools/list` emits
+  `_meta["anthropic/requiresUserInteraction"]` for a tool whose effective policy is
+  `"prompt"`, gated on the connected client's `initialize` `clientInfo`, and `tools/call`
+  echoes that gate back to the daemon as `consent: "client"` — only for a tool this same
+  connection's most recent listing actually flagged.
 - Two built-in management tools, `cordierite_connect` and `cordierite_wait_for_session`,
   let an agent mint a bootstrap link, deliver it to an emulator/simulator, and wait for the
   claim — without shell access. This is what makes the agent path self-service.
@@ -335,13 +340,31 @@ it.
 - `"prompt"` means "a human gate is required; if one cannot be guaranteed, deny" — it
   fails closed rather than silently behaving like `allow`. The only implemented gate
   today is MCP: `tools/list` emits `_meta["anthropic/requiresUserInteraction"] = true`
-  for a `"prompt"` tool when the connected client's `initialize` `clientInfo` is known
-  to enforce it (Claude Code ≥ v2.1.199 — every other client ignores the flag). The MCP
-  server then sets `consent: "client"` on that tool's `tools.call`, which is the
-  daemon's sole evidence a human gate exists; every other caller (CLI, an older or
-  non-compliant MCP client, a forged `consent`) is denied with `policy_denied`, reason
-  `no_consent_channel`. `clientInfo` is self-reported — not a defense against a hostile
-  client, only against silent auto-approval by compliant ones.
+  for a `"prompt"` tool, per connection, only when the connected client's `initialize`
+  `clientInfo` is known to enforce it (Claude Code ≥ v2.1.199 — every other client
+  ignores the flag). `tools/call` then sets `consent: "client"` only for a tool this
+  same connection's most recent `tools/list` actually flagged that way — not merely a
+  tool whose live policy happens to be `"prompt"` on a client that happens to qualify —
+  so a call can't ride on a stale or hypothetical listing. Every other caller (CLI, an
+  older or non-compliant MCP client) is denied with `policy_denied`, reason
+  `no_consent_channel`.
+  - This is evidence the flag was *emitted*, not that a human answered a prompt: the
+    daemon never observes the client's own permission-prompt UI or its answer, only
+    that the call arrived carrying the marker. `clientInfo` is self-reported, and
+    `consent` is an ordinary RPC param on `daemon.sock` — any local process that can
+    reach the socket (the CLI, or an agent with shell access, which is the typical
+    Claude Code setup this feature targets) can set it directly, same as it could send
+    any other RPC call. `"prompt"` guards against a compliant client silently
+    auto-approving on the caller's behalf; it is not a defense against a hostile
+    process on the operator's own machine — see `docs/SECURITY.md`'s threat model,
+    which already treats socket access as full daemon control.
+  - Two client-observable behaviors worth documenting rather than filing as bugs:
+    non-interactive Claude Code (`--permission-prompt-tool`) converts an `allow` result
+    for a flagged tool into a denial (`MCP tool requires user interaction; not
+    supported via --permission-prompt-tool`) — that conversion is the client's, not
+    the daemon's. And `"prompt"` denies unconditionally in any unattended pipeline
+    (CI has no consent channel at all); pipelines that need a tool to run
+    unattended must set `allow`/`deny` explicitly for it rather than `"prompt"`.
 - Audit: every `tools.call` appends one JSONL record to `audit/<date>.jsonl`:
   `{ ts, sessionId, alias, tool, argsSha256, outcome: "ok"|"error"|"denied",
   errorType?, durationMs, caller: "cli"|"mcp", consent?: "client" }`. `consent` is set

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -168,15 +168,25 @@ not as the mechanism that keeps a destructive tool out of reach of a hostile one
   `policy.tools["<alias>/<name>"]` overrides) to `"deny"` for anything you don't want an
   arbitrary caller invoking against a production build. Every `tools.call` — CLI and MCP
   alike — is evaluated against this before it ever reaches the app; a denial returns
-  `policy_denied` and never sends a `tool_call` frame. Interactive consent prompting is
-  not implemented (the policy configuration reserves a future `"prompt"` value);
-  until then, `"deny"` is the only way to gate a tool that needs human sign-off.
+  `policy_denied` and never sends a `tool_call` frame. `"prompt"` requires a human gate
+  and fails closed everywhere one can't be guaranteed: today the only implemented gate
+  is an MCP client that enforces `_meta["anthropic/requiresUserInteraction"]` (Claude
+  Code ≥ v2.1.199); the CLI and every other client are denied outright
+  (`policy_denied`, reason `no_consent_channel`) rather than silently treated as
+  `"allow"`. `clientInfo` is self-reported by the client, so `"prompt"` is not a defense
+  against a hostile client claiming to be a compliant one — only against a compliant
+  client's own auto-approval. Until a non-MCP consent channel ships (see the project's
+  issue tracker), `"deny"` remains the only way to hard-block a tool for CLI callers.
 - **Audit.** Every `tools.call` attempt — regardless of outcome — appends one line to
   `audit/<YYYY-MM-DD>.jsonl`: timestamp, session, alias, tool name, a sha256 of the
-  canonicalized args (never the raw args), outcome, error type if any, duration, and
-  caller (`cli`/`mcp`). This is on unconditionally; there's no flag to disable it. Check
-  `daemon.status`'s `audit.failedWrites` if you need to confirm the log is actually
-  landing on disk (e.g. under a read-only or full filesystem).
+  canonicalized args (never the raw args), outcome, error type if any, duration, caller
+  (`cli`/`mcp`), and — only for a `"prompt"` call that proceeded — `consent: "client"`.
+  That marker is the weakest form of evidence recorded here: the daemon never observes
+  the actual consent decision, only that the call arrived already gated, so it's kept
+  distinct from a plain `"ok"` rather than folded into it. This is on unconditionally;
+  there's no flag to disable it. Check `daemon.status`'s `audit.failedWrites` if you
+  need to confirm the log is actually landing on disk (e.g. under a read-only or full
+  filesystem).
 - **Inclusion defaults to dev builds only — not a compiled-in build-type check.** On iOS,
   `react-native.config.js` sets CocoaPods' `:configurations` so the `Debug` configuration
   links Cordierite and `Release` doesn't, by default: a real per-variant linking decision.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -173,10 +173,24 @@ not as the mechanism that keeps a destructive tool out of reach of a hostile one
   is an MCP client that enforces `_meta["anthropic/requiresUserInteraction"]` (Claude
   Code ≥ v2.1.199); the CLI and every other client are denied outright
   (`policy_denied`, reason `no_consent_channel`) rather than silently treated as
-  `"allow"`. `clientInfo` is self-reported by the client, so `"prompt"` is not a defense
-  against a hostile client claiming to be a compliant one — only against a compliant
-  client's own auto-approval. Until a non-MCP consent channel ships (see the project's
-  issue tracker), `"deny"` remains the only way to hard-block a tool for CLI callers.
+  `"allow"`. That gate is *not* a defense within this feature's own trust boundary: the
+  daemon trusts the MCP server's `consent: "client"` param verbatim rather than
+  re-deriving it, so any local process that can reach `daemon.sock` — including the CLI,
+  or an agent with shell access, which is the typical Claude Code setup this feature
+  targets — could send that param directly, the same way it could send any other RPC
+  call. This is consistent with, not an exception to, the trust boundary above: anything
+  that can reach the socket already has full daemon control. `"prompt"` guards against a
+  compliant MCP client silently auto-approving on the caller's behalf, not against a
+  hostile process on the operator's own machine. `clientInfo` is also self-reported, so
+  it's not a defense against a hostile client claiming to be a compliant one either —
+  only against a compliant client's own auto-approval. Two behaviors worth knowing about
+  rather than filing as bugs: non-interactive Claude Code (`--permission-prompt-tool`)
+  converts an `allow` result for a flagged tool into a denial — that conversion is the
+  client's, not the daemon's; and `"prompt"` denies unconditionally in CI or any other
+  unattended pipeline (there is no consent channel there at all), so a pipeline that
+  needs a tool to run unattended must set `allow`/`deny` for it explicitly. Until a
+  non-MCP consent channel ships (see the project's issue tracker), `"deny"` remains the
+  only way to hard-block a tool for CLI callers.
 - **Audit.** Every `tools.call` attempt — regardless of outcome — appends one line to
   `audit/<YYYY-MM-DD>.jsonl`: timestamp, session, alias, tool name, a sha256 of the
   canonicalized args (never the raw args), outcome, error type if any, duration, caller

--- a/packages/cordierite/src/__tests__/policy-and-audit.integration.test.ts
+++ b/packages/cordierite/src/__tests__/policy-and-audit.integration.test.ts
@@ -15,7 +15,7 @@ import WebSocket from "ws";
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { CallToolResultSchema, ListToolsResultSchema } from "@modelcontextprotocol/sdk/types.js";
 
 import { decodeBootstrap, type EventKind, type EventNotification } from "@cordierite/shared";
 
@@ -235,6 +235,7 @@ type AuditRecord = {
   errorType?: string;
   durationMs: number;
   caller: "cli" | "mcp";
+  consent?: "client";
 };
 
 const readAuditRecords = async (stateDir: string): Promise<AuditRecord[]> => {
@@ -321,7 +322,7 @@ describe("policy: evaluate", () => {
 });
 
 describe("policy: config validation", () => {
-  test('policy.destructive: "prompt" fails to load with the documented error', async () => {
+  test('policy.destructive: "prompt" loads successfully', async () => {
     const stateDir = await mkdtemp(path.join(tmpdir(), "cordierite-policy-config-"));
     stateDirs.push(stateDir);
     const paths = getStateDirPaths(stateDir);
@@ -330,10 +331,10 @@ describe("policy: config validation", () => {
     await mkdir(stateDir, { recursive: true });
     await writeFile(paths.configPath, JSON.stringify({ policy: { destructive: "prompt" } }));
 
-    await expect(loadConfig(paths)).rejects.toThrow(/prompt/u);
+    await expect(loadConfig(paths)).resolves.toMatchObject({ policy: { destructive: "prompt" } });
   });
 
-  test('policy.tools entries reject "prompt" the same way', async () => {
+  test('policy.tools entries accept "prompt" the same way', async () => {
     const stateDir = await mkdtemp(path.join(tmpdir(), "cordierite-policy-config-"));
     stateDirs.push(stateDir);
     const paths = getStateDirPaths(stateDir);
@@ -342,7 +343,153 @@ describe("policy: config validation", () => {
     await mkdir(stateDir, { recursive: true });
     await writeFile(paths.configPath, JSON.stringify({ policy: { tools: { "pixel-8/echo": "prompt" } } }));
 
-    await expect(loadConfig(paths)).rejects.toThrow(/prompt/u);
+    await expect(loadConfig(paths)).resolves.toMatchObject({ policy: { tools: { "pixel-8/echo": "prompt" } } });
+  });
+
+  test("an unknown policy value is still rejected", async () => {
+    const stateDir = await mkdtemp(path.join(tmpdir(), "cordierite-policy-config-"));
+    stateDirs.push(stateDir);
+    const paths = getStateDirPaths(stateDir);
+
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(paths.configPath, JSON.stringify({ policy: { destructive: "maybe" } }));
+
+    await expect(loadConfig(paths)).rejects.toThrow(/"allow", "deny", or "prompt"/u);
+  });
+});
+
+describe("policy: prompt via MCP requiresUserInteraction", () => {
+  /** A minimal `Client` that reports `clientInfo` the daemon/MCP server should recognize as
+   * honoring `_meta["anthropic/requiresUserInteraction"]` (ARCHITECTURE.md §12 / issue #14). */
+  const connectCompliantClient = async (mcpHandle: McpServerHandle): Promise<Client> => {
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    await mcpHandle.connect(serverTransport);
+    const client = new Client({ name: "claude-code", version: "2.1.199" });
+    await client.connect(clientTransport);
+    return client;
+  };
+
+  test('tools/list emits _meta["anthropic/requiresUserInteraction"] for a "prompt" tool only for a compliant client', async () => {
+    const { daemon, port, stateDir } = await startTestDaemon({ policy: { tools: { "pixel-8/echo": "prompt" } } });
+    const app = await claimApp(daemon, port, "Pixel 8");
+    await snapshotTools(daemon, app, [{ name: "echo" }, { name: "other" }]);
+
+    const compliantHandle = await createMcpServer({
+      stateDir,
+      spawn: () => {
+        throw new Error("must not auto-spawn");
+      },
+    });
+    mcpHandles.push(compliantHandle);
+    const compliantClient = await connectCompliantClient(compliantHandle);
+    const compliantList = await compliantClient.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+    const compliantEcho = compliantList.tools.find((tool) => tool.name === "echo");
+    expect(compliantEcho?._meta).toEqual({ "anthropic/requiresUserInteraction": true });
+    const compliantOther = compliantList.tools.find((tool) => tool.name === "other");
+    expect(compliantOther?._meta).toBeUndefined();
+
+    const nonCompliantHandle = await createMcpServer({
+      stateDir,
+      spawn: () => {
+        throw new Error("must not auto-spawn");
+      },
+    });
+    mcpHandles.push(nonCompliantHandle);
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    await nonCompliantHandle.connect(serverTransport);
+    const nonCompliantClient = new Client({ name: "some-other-client", version: "9.9.9" });
+    await nonCompliantClient.connect(clientTransport);
+    const nonCompliantList = await nonCompliantClient.request(
+      { method: "tools/list", params: {} },
+      ListToolsResultSchema,
+    );
+    const nonCompliantEcho = nonCompliantList.tools.find((tool) => tool.name === "echo");
+    expect(nonCompliantEcho?._meta).toBeUndefined();
+
+    app.socket.close();
+  });
+
+  test('a "prompt" tool call from a compliant MCP client proceeds and is audited with consent: "client"', async () => {
+    const { daemon, port, stateDir } = await startTestDaemon({ policy: { tools: { "pixel-8/echo": "prompt" } } });
+    const app = await claimApp(daemon, port, "Pixel 8");
+    await snapshotTools(daemon, app, [{ name: "echo" }]);
+
+    app.socket.on("message", (data) => {
+      const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
+      if (msg.type === "tool_call") {
+        app.socket.send(JSON.stringify({ type: "tool_result", session_id: app.sessionId, id: msg.id, result: "ok" }));
+      }
+    });
+
+    const mcpHandle = await createMcpServer({
+      stateDir,
+      spawn: () => {
+        throw new Error("must not auto-spawn");
+      },
+    });
+    mcpHandles.push(mcpHandle);
+    const client = await connectCompliantClient(mcpHandle);
+
+    const result = await client.request(
+      { method: "tools/call", params: { name: "echo", arguments: {} } },
+      CallToolResultSchema,
+    );
+    expect(result.isError).not.toBe(true);
+
+    app.socket.close();
+    await shutdownNow(daemon);
+
+    const records = await readAuditRecords(stateDir);
+    const record = records.find((r) => r.tool === "echo" && r.caller === "mcp");
+    expect(record?.outcome).toBe("ok");
+    expect(record?.consent).toBe("client");
+  });
+
+  test('a "prompt" tool call from a non-compliant MCP client is denied with reason no_consent_channel', async () => {
+    const { daemon, port, stateDir } = await startTestDaemon({ policy: { tools: { "pixel-8/echo": "prompt" } } });
+    const app = await claimApp(daemon, port, "Pixel 8");
+    await snapshotTools(daemon, app, [{ name: "echo" }]);
+
+    const mcpHandle = await createMcpServer({
+      stateDir,
+      spawn: () => {
+        throw new Error("must not auto-spawn");
+      },
+    });
+    mcpHandles.push(mcpHandle);
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    await mcpHandle.connect(serverTransport);
+    const client = new Client({ name: "some-other-client", version: "9.9.9" });
+    await client.connect(clientTransport);
+
+    const result = await client.request(
+      { method: "tools/call", params: { name: "echo", arguments: {} } },
+      CallToolResultSchema,
+    );
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("policy_denied");
+
+    await shutdownNow(daemon);
+    const records = await readAuditRecords(stateDir);
+    const record = records.find((r) => r.tool === "echo" && r.caller === "mcp");
+    expect(record?.outcome).toBe("denied");
+    expect(record?.consent).toBeUndefined();
+
+    app.socket.close();
+  });
+
+  test('a "prompt" tool call from the CLI (no consent channel) is denied with reason no_consent_channel', async () => {
+    const { daemon, port } = await startTestDaemon({ policy: { tools: { "pixel-8/echo": "prompt" } } });
+    const app = await claimApp(daemon, port, "Pixel 8");
+    await snapshotTools(daemon, app, [{ name: "echo" }]);
+
+    await expect(
+      rpcCall(daemon.paths.socketPath, "tools.call", { selector: app.alias, name: "echo", args: {} }),
+    ).rejects.toMatchObject({ data: { type: "policy_denied", details: { reason: "no_consent_channel" } } });
+
+    app.socket.close();
   });
 });
 

--- a/packages/cordierite/src/__tests__/policy-and-audit.integration.test.ts
+++ b/packages/cordierite/src/__tests__/policy-and-audit.integration.test.ts
@@ -233,6 +233,7 @@ type AuditRecord = {
   argsSha256: string;
   outcome: "ok" | "error" | "denied";
   errorType?: string;
+  deniedReason?: "policy" | "no_consent_channel";
   durationMs: number;
   caller: "cli" | "mcp";
   consent?: "client";
@@ -431,6 +432,15 @@ describe("policy: prompt via MCP requiresUserInteraction", () => {
     mcpHandles.push(mcpHandle);
     const client = await connectCompliantClient(mcpHandle);
 
+    // `consent: "client"` requires this connection to have actually listed the tool with
+    // `_meta["anthropic/requiresUserInteraction"]` set first — a call is never gated purely on the
+    // tool's live policy plus a qualifying `clientInfo` (see `server.ts`'s
+    // `emittedRequiresUserInteraction`).
+    const listed = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+    expect(listed.tools.find((tool) => tool.name === "echo")?._meta).toEqual({
+      "anthropic/requiresUserInteraction": true,
+    });
+
     const result = await client.request(
       { method: "tools/call", params: { name: "echo", arguments: {} } },
       CallToolResultSchema,
@@ -481,7 +491,7 @@ describe("policy: prompt via MCP requiresUserInteraction", () => {
   });
 
   test('a "prompt" tool call from the CLI (no consent channel) is denied with reason no_consent_channel', async () => {
-    const { daemon, port } = await startTestDaemon({ policy: { tools: { "pixel-8/echo": "prompt" } } });
+    const { daemon, port, stateDir } = await startTestDaemon({ policy: { tools: { "pixel-8/echo": "prompt" } } });
     const app = await claimApp(daemon, port, "Pixel 8");
     await snapshotTools(daemon, app, [{ name: "echo" }]);
 
@@ -489,7 +499,189 @@ describe("policy: prompt via MCP requiresUserInteraction", () => {
       rpcCall(daemon.paths.socketPath, "tools.call", { selector: app.alias, name: "echo", args: {} }),
     ).rejects.toMatchObject({ data: { type: "policy_denied", details: { reason: "no_consent_channel" } } });
 
+    await shutdownNow(daemon);
+    const records = await readAuditRecords(stateDir);
+    const record = records.find((r) => r.tool === "echo" && r.caller === "cli");
+    expect(record?.outcome).toBe("denied");
+    expect(record?.deniedReason).toBe("no_consent_channel");
+    expect(record?.consent).toBeUndefined();
+
     app.socket.close();
+  });
+
+  test('a client one patch version below the minimum ("2.1.198") is treated as non-compliant', async () => {
+    const { daemon, port, stateDir } = await startTestDaemon({ policy: { tools: { "pixel-8/echo": "prompt" } } });
+    const app = await claimApp(daemon, port, "Pixel 8");
+    await snapshotTools(daemon, app, [{ name: "echo" }]);
+
+    const mcpHandle = await createMcpServer({
+      stateDir,
+      spawn: () => {
+        throw new Error("must not auto-spawn");
+      },
+    });
+    mcpHandles.push(mcpHandle);
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    await mcpHandle.connect(serverTransport);
+    const client = new Client({ name: "claude-code", version: "2.1.198" });
+    await client.connect(clientTransport);
+
+    const listed = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+    expect(listed.tools.find((tool) => tool.name === "echo")?._meta).toBeUndefined();
+
+    const result = await client.request(
+      { method: "tools/call", params: { name: "echo", arguments: {} } },
+      CallToolResultSchema,
+    );
+    expect(result.isError).toBe(true);
+
+    app.socket.close();
+  });
+
+  test("a compliant client that never called tools/list on this connection is still denied (no fabricated consent)", async () => {
+    const { daemon, port, stateDir } = await startTestDaemon({ policy: { tools: { "pixel-8/echo": "prompt" } } });
+    const app = await claimApp(daemon, port, "Pixel 8");
+    await snapshotTools(daemon, app, [{ name: "echo" }]);
+
+    const mcpHandle = await createMcpServer({
+      stateDir,
+      spawn: () => {
+        throw new Error("must not auto-spawn");
+      },
+    });
+    mcpHandles.push(mcpHandle);
+    const client = await connectCompliantClient(mcpHandle);
+
+    // Deliberately no `tools/list` call before `tools/call` — a real compliant client would never
+    // have been shown the `_meta` flag for "echo" on this connection, so no consent can exist yet.
+    const result = await client.request(
+      { method: "tools/call", params: { name: "echo", arguments: {} } },
+      CallToolResultSchema,
+    );
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("no_consent_channel");
+
+    app.socket.close();
+    await shutdownNow(daemon);
+    const records = await readAuditRecords(stateDir);
+    const record = records.find((r) => r.tool === "echo" && r.caller === "mcp");
+    expect(record?.outcome).toBe("denied");
+    expect(record?.consent).toBeUndefined();
+  });
+
+  test('policy "deny" is still denied for a compliant client, and no _meta is emitted for a "deny" tool', async () => {
+    const { daemon, port, stateDir } = await startTestDaemon({ policy: { tools: { "pixel-8/echo": "deny" } } });
+    const app = await claimApp(daemon, port, "Pixel 8");
+    await snapshotTools(daemon, app, [{ name: "echo" }]);
+
+    const mcpHandle = await createMcpServer({
+      stateDir,
+      spawn: () => {
+        throw new Error("must not auto-spawn");
+      },
+    });
+    mcpHandles.push(mcpHandle);
+    const client = await connectCompliantClient(mcpHandle);
+
+    const listed = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+    expect(listed.tools.find((tool) => tool.name === "echo")?._meta).toBeUndefined();
+
+    const result = await client.request(
+      { method: "tools/call", params: { name: "echo", arguments: {} } },
+      CallToolResultSchema,
+    );
+    expect(result.isError).toBe(true);
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain("policy_denied");
+    expect(text).not.toContain("no_consent_channel");
+
+    app.socket.close();
+    await shutdownNow(daemon);
+    const records = await readAuditRecords(stateDir);
+    const record = records.find((r) => r.tool === "echo" && r.caller === "mcp");
+    expect(record?.deniedReason).toBe("policy");
+  });
+
+  test('policy "allow" for a compliant client never fabricates consent in the audit record', async () => {
+    const { daemon, port, stateDir } = await startTestDaemon();
+    const app = await claimApp(daemon, port, "Pixel 8");
+    await snapshotTools(daemon, app, [{ name: "echo" }]);
+
+    app.socket.on("message", (data) => {
+      const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
+      if (msg.type === "tool_call") {
+        app.socket.send(JSON.stringify({ type: "tool_result", session_id: app.sessionId, id: msg.id, result: "ok" }));
+      }
+    });
+
+    const mcpHandle = await createMcpServer({
+      stateDir,
+      spawn: () => {
+        throw new Error("must not auto-spawn");
+      },
+    });
+    mcpHandles.push(mcpHandle);
+    const client = await connectCompliantClient(mcpHandle);
+
+    const listed = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+    expect(listed.tools.find((tool) => tool.name === "echo")?._meta).toBeUndefined();
+
+    const result = await client.request(
+      { method: "tools/call", params: { name: "echo", arguments: {} } },
+      CallToolResultSchema,
+    );
+    expect(result.isError).not.toBe(true);
+
+    app.socket.close();
+    await shutdownNow(daemon);
+    const records = await readAuditRecords(stateDir);
+    const record = records.find((r) => r.tool === "echo" && r.caller === "mcp");
+    expect(record?.outcome).toBe("ok");
+    expect(record?.consent).toBeUndefined();
+  });
+
+  test('a "prompt" call from a compliant, gated client that errors still records consent: "client"', async () => {
+    const { daemon, port, stateDir } = await startTestDaemon({ policy: { tools: { "pixel-8/boom": "prompt" } } });
+    const app = await claimApp(daemon, port, "Pixel 8");
+    await snapshotTools(daemon, app, [{ name: "boom" }]);
+
+    app.socket.on("message", (data) => {
+      const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
+      if (msg.type === "tool_call") {
+        app.socket.send(
+          JSON.stringify({
+            type: "tool_error",
+            session_id: app.sessionId,
+            id: msg.id,
+            error: { type: "tool_execution_error", message: "boom" },
+          }),
+        );
+      }
+    });
+
+    const mcpHandle = await createMcpServer({
+      stateDir,
+      spawn: () => {
+        throw new Error("must not auto-spawn");
+      },
+    });
+    mcpHandles.push(mcpHandle);
+    const client = await connectCompliantClient(mcpHandle);
+    await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+
+    const result = await client.request(
+      { method: "tools/call", params: { name: "boom", arguments: {} } },
+      CallToolResultSchema,
+    );
+    expect(result.isError).toBe(true);
+
+    app.socket.close();
+    await shutdownNow(daemon);
+    const records = await readAuditRecords(stateDir);
+    const record = records.find((r) => r.tool === "boom" && r.caller === "mcp");
+    expect(record?.outcome).toBe("error");
+    expect(record?.consent).toBe("client");
   });
 });
 

--- a/packages/cordierite/src/cli/result-types.ts
+++ b/packages/cordierite/src/cli/result-types.ts
@@ -146,9 +146,9 @@ export type DaemonStatusCommandData = {
   };
   /** Effective policy + audit surfacing (ARCHITECTURE.md §12). */
   policy: {
-    default: "allow" | "deny";
-    destructive: "allow" | "deny";
-    tools?: Record<string, "allow" | "deny">;
+    default: "allow" | "deny" | "prompt";
+    destructive: "allow" | "deny" | "prompt";
+    tools?: Record<string, "allow" | "deny" | "prompt">;
   };
   audit: {
     path: string;

--- a/packages/cordierite/src/cli/result-types.ts
+++ b/packages/cordierite/src/cli/result-types.ts
@@ -4,7 +4,13 @@
  * the thin-client shapes for the v2 command table.
  */
 
-import type { AgentEndpoint, EventNotification, SessionSummary, ToolDescriptor } from "@cordierite/shared";
+import type {
+  AgentEndpoint,
+  EffectivePolicyDecision,
+  EventNotification,
+  SessionSummary,
+  ToolDescriptor,
+} from "@cordierite/shared";
 
 /**
  * CLI-domain error classes, used only to pick a sysexits-style exit code (see `errors.ts`).
@@ -146,9 +152,9 @@ export type DaemonStatusCommandData = {
   };
   /** Effective policy + audit surfacing (ARCHITECTURE.md §12). */
   policy: {
-    default: "allow" | "deny" | "prompt";
-    destructive: "allow" | "deny" | "prompt";
-    tools?: Record<string, "allow" | "deny" | "prompt">;
+    default: EffectivePolicyDecision;
+    destructive: EffectivePolicyDecision;
+    tools?: Record<string, EffectivePolicyDecision>;
   };
   audit: {
     path: string;

--- a/packages/cordierite/src/daemon/audit.ts
+++ b/packages/cordierite/src/daemon/audit.ts
@@ -34,6 +34,14 @@ export type AuditRecord = {
   errorType?: ErrorType;
   durationMs: number;
   caller: AuditCaller;
+  /**
+   * Set only when a `"prompt"`-policy call actually proceeded because the MCP server confirmed a
+   * client-side consent gate (ARCHITECTURE.md §12). Deliberately distinct from a plain `"ok"`:
+   * the daemon never observed the consent decision itself, only that the call arrived carrying
+   * this marker — this is the weakest form of evidence (issue #14), and the audit record should
+   * read as such rather than folding it into an ordinary allow.
+   */
+  consent?: "client";
 };
 
 export type AuditLogger = {

--- a/packages/cordierite/src/daemon/audit.ts
+++ b/packages/cordierite/src/daemon/audit.ts
@@ -32,6 +32,14 @@ export type AuditRecord = {
   argsSha256: string;
   outcome: AuditOutcome;
   errorType?: ErrorType;
+  /**
+   * Set only when `outcome === "denied"`: `"policy"` for an ordinary `policy.*: "deny"` denial,
+   * `"no_consent_channel"` for a `"prompt"`-policy call that had no confirmed human gate
+   * (ARCHITECTURE.md §12). Without this an operator reading `audit/*.jsonl` can't tell a
+   * misconfigured `"deny"` from a `"prompt"` tool nobody has gated yet — both otherwise look like
+   * an identical `{ outcome: "denied" }` line.
+   */
+  deniedReason?: "policy" | "no_consent_channel";
   durationMs: number;
   caller: AuditCaller;
   /**

--- a/packages/cordierite/src/daemon/config.ts
+++ b/packages/cordierite/src/daemon/config.ts
@@ -8,14 +8,16 @@ import { readFile } from "node:fs/promises";
 
 import type { StateDirPaths } from "./state-dir.js";
 
-export type PolicyDecision = "allow" | "deny";
+export type PolicyDecision = "allow" | "deny" | "prompt";
 
 /**
  * `config.json`'s `policy` shape (ARCHITECTURE.md §12): `default` applies to tools whose
  * descriptor has no `annotations.destructiveHint`; `destructive` applies when it is `true`;
  * `tools["<alias>/<name>"]` overrides both for one specific tool on one specific session alias.
- * Values are `"allow" | "deny"` only — the enum deliberately leaves room for a future `"prompt"`
- * value, which is rejected at load time with a message that says so (see `requirePolicyDecision`).
+ * `"prompt"` means "a human gate is required; if one cannot be guaranteed, deny" — today the only
+ * such gate is an MCP client that honors `_meta["anthropic/requiresUserInteraction"]`
+ * (ARCHITECTURE.md §9/§12); every other caller (CLI, a non-compliant MCP client) gets
+ * `policy_denied` with reason `no_consent_channel`.
  */
 export type CordieritePolicyConfig = {
   default: PolicyDecision;
@@ -55,7 +57,7 @@ const KNOWN_TOP_LEVEL_KEYS = new Set<string>([
 
 const KNOWN_POLICY_KEYS = new Set<string>(["default", "destructive", "tools"]);
 
-const POLICY_DECISIONS = new Set<string>(["allow", "deny"]);
+const POLICY_DECISIONS = new Set<string>(["allow", "deny", "prompt"]);
 
 export class CordieriteConfigError extends Error {
   constructor(
@@ -89,10 +91,7 @@ const requireNonEmptyString = (value: unknown, key: string): string => {
 
 const requirePolicyDecision = (value: unknown, key: string): PolicyDecision => {
   if (typeof value !== "string" || !POLICY_DECISIONS.has(value)) {
-    throw configError(
-      key,
-      'must be "allow" or "deny" ("prompt" is reserved for a future release and is not yet supported).',
-    );
+    throw configError(key, 'must be "allow", "deny", or "prompt".');
   }
 
   return value as PolicyDecision;

--- a/packages/cordierite/src/daemon/daemon.ts
+++ b/packages/cordierite/src/daemon/daemon.ts
@@ -451,6 +451,7 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
             outcome: "ok" | "error" | "denied",
             errorType?: ErrorType,
             grantedConsent?: "client",
+            deniedReason?: "policy" | "no_consent_channel",
           ): void => {
             auditLogger.record({
               sessionId: resolved.sessionId,
@@ -459,6 +460,7 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
               argsSha256: argsSha256(args),
               outcome,
               errorType,
+              deniedReason,
               durationMs: clock.now().getTime() - auditStartedAt,
               caller: effectiveCaller,
               consent: grantedConsent,
@@ -481,10 +483,19 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
 
           const policyDecision = evaluatePolicy(tool, { alias: resolved.alias }, config.policy);
           // "prompt" fails closed (ARCHITECTURE.md §12 / issue #14): it proceeds only when the
-          // caller carried `consent: "client"`, which the MCP server sets only after confirming
-          // both that it emitted `_meta["anthropic/requiresUserInteraction"]` for this tool and
-          // that the connected client is known to enforce it. Every other caller — CLI, a
-          // non-compliant MCP client, a forged param — is denied.
+          // caller carried `consent: "client"`. This is trusted verbatim once present — the daemon
+          // does not and cannot re-derive whether an MCP client's `_meta` was actually honored, the
+          // same way it doesn't re-verify any other RPC param. `consent` is only ever justified
+          // when set by this codebase's own MCP server (mcp/server.ts), which sets it solely after
+          // confirming both that it emitted `_meta["anthropic/requiresUserInteraction"]` for this
+          // exact tool on this connection's most recent listing, and that the connected client is
+          // known to enforce it. Any other local process with access to `daemon.sock` — including
+          // the CLI, or an agent with shell access, which is the typical setup this feature targets
+          // — could send `consent: "client"` directly; that is not a bypass of this feature so much
+          // as a restatement of this codebase's existing trust boundary (docs/SECURITY.md: anything
+          // that can reach the socket already has full daemon control). "prompt" guards against a
+          // compliant MCP client silently auto-approving on the caller's behalf, not against a
+          // hostile process on the operator's own machine.
           const grantedConsent: "client" | undefined =
             policyDecision === "prompt" && consent === "client" ? "client" : undefined;
 
@@ -496,19 +507,22 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
               alias: resolved.alias,
               data: { name, outcome: "denied" },
             });
-            writeAudit("denied");
 
             if (policyDecision === "prompt") {
+              writeAudit("denied", undefined, undefined, "no_consent_channel");
+
               throw new RpcApplicationError(
                 "policy_denied",
                 `Policy requires prompt consent to call "${name}" on session "${resolved.alias}", but no consent channel confirmed it.`,
                 -32000,
                 {
                   reason: "no_consent_channel",
-                  hint: `This caller did not confirm human consent for "${name}" (ARCHITECTURE.md §12). Claude Code ≥ v2.1.199 confirms it automatically over MCP; every other caller (including the CLI) is denied by design until another consent channel is implemented.`,
+                  hint: `This caller did not confirm human consent for "${name}". Claude Code ≥ v2.1.199 confirms it automatically over MCP; every other caller (including the CLI) is denied by design until another consent channel is implemented. To change this tool's policy, edit "policy.tools[\"${resolved.alias}/${name}\"]" (or policy.default/policy.destructive) in ${paths.configPath}.`,
                 },
               );
             }
+
+            writeAudit("denied", undefined, undefined, "policy");
 
             throw new RpcApplicationError(
               "policy_denied",

--- a/packages/cordierite/src/daemon/daemon.ts
+++ b/packages/cordierite/src/daemon/daemon.ts
@@ -179,12 +179,19 @@ const asToolsCallParams = (params: unknown): ToolsCallParams => {
     throw new RpcApplicationError("invalid_request", '"caller" must be "cli" or "mcp".');
   }
 
+  const consent = record.consent;
+
+  if (consent !== undefined && consent !== "client") {
+    throw new RpcApplicationError("invalid_request", '"consent" must be "client".');
+  }
+
   return {
     selector: selector as string | undefined,
     name: record.name,
     args: args as Record<string, unknown>,
     timeoutMs: timeoutMs as number | undefined,
     caller: caller as "cli" | "mcp" | undefined,
+    consent: consent as "client" | undefined,
   };
 };
 
@@ -421,18 +428,30 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
           const { selector } = asSelectorParams(params);
           // ARCHITECTURE.md §5: tools.list works for ACTIVE and SUSPENDED sessions alike (the
           // retained registry survives suspend); only tools.call requires ACTIVE.
-          return activeSessionManager.resolveForTools(selector).registry.list();
+          const resolved = activeSessionManager.resolveForTools(selector);
+
+          // Each entry carries its effective policy decision (ARCHITECTURE.md §12) so the MCP
+          // server can emit `_meta["anthropic/requiresUserInteraction"]` for "prompt" tools
+          // without a second round trip (issue #14).
+          return resolved.registry.list().map((descriptor) => ({
+            ...descriptor,
+            policy: evaluatePolicy(descriptor, { alias: resolved.alias }, config.policy),
+          }));
         },
         // This handler is the single seam every `tools.call` passes through: policy (ARCHITECTURE.md
         // §12) is evaluated once the target tool descriptor is known, and one audit record is
         // written for every attempt that reaches a resolved session, across ok/error/denied.
         [RPC_METHODS.toolsCall]: async (params): Promise<ToolsCallResult> => {
-          const { selector, name, args, timeoutMs, caller } = asToolsCallParams(params);
+          const { selector, name, args, timeoutMs, caller, consent } = asToolsCallParams(params);
           const effectiveCaller = caller ?? "cli";
           const resolved = activeSessionManager.resolveForTools(selector);
           const auditStartedAt = clock.now().getTime();
 
-          const writeAudit = (outcome: "ok" | "error" | "denied", errorType?: ErrorType): void => {
+          const writeAudit = (
+            outcome: "ok" | "error" | "denied",
+            errorType?: ErrorType,
+            grantedConsent?: "client",
+          ): void => {
             auditLogger.record({
               sessionId: resolved.sessionId,
               alias: resolved.alias,
@@ -442,6 +461,7 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
               errorType,
               durationMs: clock.now().getTime() - auditStartedAt,
               caller: effectiveCaller,
+              consent: grantedConsent,
             });
           };
 
@@ -460,8 +480,15 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
           }
 
           const policyDecision = evaluatePolicy(tool, { alias: resolved.alias }, config.policy);
+          // "prompt" fails closed (ARCHITECTURE.md §12 / issue #14): it proceeds only when the
+          // caller carried `consent: "client"`, which the MCP server sets only after confirming
+          // both that it emitted `_meta["anthropic/requiresUserInteraction"]` for this tool and
+          // that the connected client is known to enforce it. Every other caller — CLI, a
+          // non-compliant MCP client, a forged param — is denied.
+          const grantedConsent: "client" | undefined =
+            policyDecision === "prompt" && consent === "client" ? "client" : undefined;
 
-          if (policyDecision === "deny") {
+          if (policyDecision === "deny" || (policyDecision === "prompt" && grantedConsent === undefined)) {
             // Denied → no frame reaches the app, and the call never starts.
             activeEventBus.emit({
               kind: "tool_call_finished",
@@ -470,6 +497,18 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
               data: { name, outcome: "denied" },
             });
             writeAudit("denied");
+
+            if (policyDecision === "prompt") {
+              throw new RpcApplicationError(
+                "policy_denied",
+                `Policy requires prompt consent to call "${name}" on session "${resolved.alias}", but no consent channel confirmed it.`,
+                -32000,
+                {
+                  reason: "no_consent_channel",
+                  hint: `This caller did not confirm human consent for "${name}" (ARCHITECTURE.md §12). Claude Code ≥ v2.1.199 confirms it automatically over MCP; every other caller (including the CLI) is denied by design until another consent channel is implemented.`,
+                },
+              );
+            }
 
             throw new RpcApplicationError(
               "policy_denied",
@@ -503,7 +542,7 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
               alias: resolved.alias,
               data: { name, callId, durationMs: clock.now().getTime() - startedAt, outcome: "ok" },
             });
-            writeAudit("ok");
+            writeAudit("ok", undefined, grantedConsent);
 
             return { result, callId };
           } catch (error) {
@@ -515,7 +554,7 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
               alias: resolved.alias,
               data: { name, callId, durationMs: clock.now().getTime() - startedAt, outcome: "error", errorType },
             });
-            writeAudit("error", errorType);
+            writeAudit("error", errorType, grantedConsent);
 
             throw error;
           }

--- a/packages/cordierite/src/mcp/daemon-tools.ts
+++ b/packages/cordierite/src/mcp/daemon-tools.ts
@@ -9,7 +9,7 @@
 import {
   RPC_METHODS,
   type SessionsListResult,
-  type ToolDescriptor,
+  type ToolsListEntry,
   type ToolsListResult,
 } from "@cordierite/shared";
 
@@ -22,7 +22,7 @@ export type DaemonCall = <TResult>(method: string, params?: unknown) => Promise<
 
 export const fetchEffectiveTools = async (call: DaemonCall): Promise<NamespacedTool[]> => {
   const sessions = await call<SessionsListResult>(RPC_METHODS.sessionsList);
-  const toolsByAlias = new Map<string, ToolDescriptor[]>();
+  const toolsByAlias = new Map<string, ToolsListEntry[]>();
 
   for (const session of sessions) {
     try {

--- a/packages/cordierite/src/mcp/server.ts
+++ b/packages/cordierite/src/mcp/server.ts
@@ -67,9 +67,17 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> => {
  * "don't ask again" option. Older Claude Code and every other client ignore the flag silently. */
 const REQUIRES_USER_INTERACTION_MIN_VERSION = [2, 1, 199] as const;
 
+/** Strict `\d+` per dot-separated part — rejects a pre-release/build suffix (`"2.1.199-beta.1"`,
+ * `"2.1.199rc"`) rather than letting `Number.parseInt`'s leading-digits-only parsing treat it as
+ * `2.1.199` and wrongly report a pre-release as version-compliant. */
 const parseVersionParts = (version: string): number[] | undefined => {
-  const parts = version.split(".").map((part) => Number.parseInt(part, 10));
-  return parts.length > 0 && parts.every((part) => Number.isInteger(part) && part >= 0) ? parts : undefined;
+  const rawParts = version.split(".");
+
+  if (!rawParts.every((part) => /^\d+$/u.test(part))) {
+    return undefined;
+  }
+
+  return rawParts.map((part) => Number.parseInt(part, 10));
 };
 
 const isVersionAtLeast = (version: string, min: readonly number[]): boolean => {
@@ -167,6 +175,15 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
     { capabilities: { tools: { listChanged: true }, resources: {} } },
   );
 
+  // The `mcpName`s this connection's *most recent* `tools/list` response actually emitted
+  // `_meta["anthropic/requiresUserInteraction"]` for — repopulated on every `tools/list` request,
+  // never on the internal `list_changed` refresh below (which doesn't answer a client request, so
+  // nothing was shown to a human). `callProxiedTool` requires membership here in addition to
+  // recomputing the tool's live policy and the client check, so `consent: "client"` reflects an
+  // MCP `Tool` the client actually listed with the flag set on *this* connection, not merely a
+  // client that happens to qualify version-wise (ARCHITECTURE.md §12 / issue #14).
+  const emittedRequiresUserInteraction = new Set<string>();
+
   const callProxiedTool = async (
     tool: NamespacedTool,
     args: Record<string, unknown>,
@@ -177,7 +194,11 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
     // can't be replayed to manufacture consent (ARCHITECTURE.md §12 / issue #14): this is the
     // daemon's sole evidence a human gate exists for a "prompt"-policy tool.
     const consent: "client" | undefined =
-      tool.policy === "prompt" && clientHonorsRequiresUserInteraction(server) ? "client" : undefined;
+      tool.policy === "prompt" &&
+      clientHonorsRequiresUserInteraction(server) &&
+      emittedRequiresUserInteraction.has(tool.mcpName)
+        ? "client"
+        : undefined;
 
     if (progressToken === undefined) {
       const result = await stream.call<ToolsCallResult>(RPC_METHODS.toolsCall, {
@@ -253,6 +274,13 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     const tools = await fetchEffectiveTools(stream.call);
     const clientHonors = clientHonorsRequiresUserInteraction(server);
+
+    emittedRequiresUserInteraction.clear();
+    for (const tool of tools) {
+      if (tool.policy === "prompt" && clientHonors) {
+        emittedRequiresUserInteraction.add(tool.mcpName);
+      }
+    }
 
     return {
       tools: [

--- a/packages/cordierite/src/mcp/server.ts
+++ b/packages/cordierite/src/mcp/server.ts
@@ -62,6 +62,49 @@ const isPlainObject = (value: unknown): value is Record<string, unknown> => {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 };
 
+/** The minimum Claude Code version documented (ARCHITECTURE.md §12 / issue #14) to enforce
+ * `_meta["anthropic/requiresUserInteraction"]` on every call, in every permission mode, with no
+ * "don't ask again" option. Older Claude Code and every other client ignore the flag silently. */
+const REQUIRES_USER_INTERACTION_MIN_VERSION = [2, 1, 199] as const;
+
+const parseVersionParts = (version: string): number[] | undefined => {
+  const parts = version.split(".").map((part) => Number.parseInt(part, 10));
+  return parts.length > 0 && parts.every((part) => Number.isInteger(part) && part >= 0) ? parts : undefined;
+};
+
+const isVersionAtLeast = (version: string, min: readonly number[]): boolean => {
+  const parts = parseVersionParts(version);
+
+  if (!parts) {
+    return false;
+  }
+
+  for (let i = 0; i < min.length; i++) {
+    const part = parts[i] ?? 0;
+
+    if (part > min[i]!) {
+      return true;
+    }
+
+    if (part < min[i]!) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+/**
+ * Whether the connected MCP client is known to enforce `_meta["anthropic/requiresUserInteraction"]`
+ * (ARCHITECTURE.md §12 / issue #14). `clientInfo` is self-reported at `initialize` — a hostile
+ * client could claim to be Claude Code, but that is outside this feature's threat model
+ * (unattended automation, not a malicious client); it is documented as a known limitation.
+ */
+const clientHonorsRequiresUserInteraction = (server: Server): boolean => {
+  const clientInfo = server.getClientVersion();
+  return clientInfo?.name === "claude-code" && isVersionAtLeast(clientInfo.version, REQUIRES_USER_INTERACTION_MIN_VERSION);
+};
+
 const toolSuccessContent = (result: unknown): CallToolResult => {
   const content = [{ type: "text" as const, text: JSON.stringify(result) }];
 
@@ -130,12 +173,19 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
     progressToken: string | number | undefined,
     sendNotification: (notification: unknown) => Promise<void>,
   ): Promise<unknown> => {
+    // Recomputed at call time (never cached from the `tools/list` snapshot) so a stale `_meta`
+    // can't be replayed to manufacture consent (ARCHITECTURE.md §12 / issue #14): this is the
+    // daemon's sole evidence a human gate exists for a "prompt"-policy tool.
+    const consent: "client" | undefined =
+      tool.policy === "prompt" && clientHonorsRequiresUserInteraction(server) ? "client" : undefined;
+
     if (progressToken === undefined) {
       const result = await stream.call<ToolsCallResult>(RPC_METHODS.toolsCall, {
         selector: tool.selector,
         name: tool.descriptor.name,
         args,
         caller: "mcp",
+        ...(consent ? { consent } : {}),
       });
 
       return result.result;
@@ -188,6 +238,7 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
           name: tool.descriptor.name,
           args,
           caller: "mcp",
+          ...(consent ? { consent } : {}),
         });
 
         return result.result;
@@ -201,9 +252,14 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     const tools = await fetchEffectiveTools(stream.call);
+    const clientHonors = clientHonorsRequiresUserInteraction(server);
 
     return {
-      tools: [CONNECT_TOOL_DESCRIPTOR, WAIT_FOR_SESSION_TOOL_DESCRIPTOR, ...tools.map(toMcpTool)],
+      tools: [
+        CONNECT_TOOL_DESCRIPTOR,
+        WAIT_FOR_SESSION_TOOL_DESCRIPTOR,
+        ...tools.map((tool) => toMcpTool(tool, clientHonors)),
+      ],
     };
   });
 

--- a/packages/cordierite/src/mcp/tool-mapping.ts
+++ b/packages/cordierite/src/mcp/tool-mapping.ts
@@ -3,6 +3,11 @@
  * `Tool` wire shape (ARCHITECTURE.md §9/§7): `description` and `input_schema`/`output_schema` map
  * directly; an absent `input_schema` becomes an empty, permissive object schema (MCP requires every
  * tool's `inputSchema.type` to be the literal `"object"`); `annotations` map verbatim.
+ *
+ * A tool whose effective policy is `"prompt"` (ARCHITECTURE.md §12) gets
+ * `_meta["anthropic/requiresUserInteraction"] = true` — but only when the connected client is
+ * known to enforce it (issue #14); emitting the flag for a client that ignores it would create a
+ * false sense of security, so the caller must confirm that separately and pass it in.
  */
 
 import type { NamespacedTool } from "./tool-namespace.js";
@@ -17,10 +22,12 @@ export type McpToolSchema = {
   inputSchema: Record<string, unknown>;
   outputSchema?: Record<string, unknown>;
   annotations?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
 };
 
-export const toMcpTool = (tool: NamespacedTool): McpToolSchema => {
+export const toMcpTool = (tool: NamespacedTool, clientHonorsRequiresUserInteraction: boolean): McpToolSchema => {
   const { descriptor } = tool;
+  const requiresUserInteraction = tool.policy === "prompt" && clientHonorsRequiresUserInteraction;
 
   return {
     name: tool.mcpName,
@@ -28,5 +35,7 @@ export const toMcpTool = (tool: NamespacedTool): McpToolSchema => {
     inputSchema: descriptor.input_schema ?? EMPTY_OBJECT_SCHEMA,
     ...(descriptor.output_schema ? { outputSchema: descriptor.output_schema } : {}),
     ...(descriptor.annotations ? { annotations: { ...descriptor.annotations } } : {}),
+    // Must be the JSON boolean `true` literal — any other value is ignored by the client.
+    ...(requiresUserInteraction ? { _meta: { "anthropic/requiresUserInteraction": true } } : {}),
   };
 };

--- a/packages/cordierite/src/mcp/tool-namespace.ts
+++ b/packages/cordierite/src/mcp/tool-namespace.ts
@@ -11,7 +11,7 @@
  * the first occurrence of `__` in a namespaced name is always the alias/tool-name boundary.
  */
 
-import type { SessionSummary, ToolDescriptor } from "@cordierite/shared";
+import type { EffectivePolicyDecision, SessionSummary, ToolDescriptor, ToolsListEntry } from "@cordierite/shared";
 
 export const TOOL_NAMESPACE_SEPARATOR = "__";
 
@@ -22,23 +22,29 @@ export type NamespacedTool = {
   /** The session alias `tools.call`'s `selector` should target for this tool. */
   selector: string;
   descriptor: ToolDescriptor;
+  /** The effective policy decision for this tool right now (ARCHITECTURE.md §12), as resolved by
+   * the daemon's `tools.list` — carried through so the MCP server can emit
+   * `_meta["anthropic/requiresUserInteraction"]` and set `consent` on `tools.call` without a
+   * second round trip (issue #14). */
+  policy: EffectivePolicyDecision;
 };
 
 /** Builds the namespaced (or not) tool list for the current set of live sessions. `toolsByAlias`
  * is looked up by `session.alias` (not `sessionId`) to match `tools.list`'s `selector` semantics. */
 export const buildNamespacedTools = (
   sessions: readonly SessionSummary[],
-  toolsByAlias: ReadonlyMap<string, readonly ToolDescriptor[]>,
+  toolsByAlias: ReadonlyMap<string, readonly ToolsListEntry[]>,
 ): NamespacedTool[] => {
   const namespaced = sessions.length > 1;
   const tools: NamespacedTool[] = [];
 
   for (const session of sessions) {
-    for (const descriptor of toolsByAlias.get(session.alias) ?? []) {
+    for (const { policy, ...descriptor } of toolsByAlias.get(session.alias) ?? []) {
       tools.push({
         mcpName: namespaced ? `${session.alias}${TOOL_NAMESPACE_SEPARATOR}${descriptor.name}` : descriptor.name,
         selector: session.alias,
         descriptor,
+        policy,
       });
     }
   }
@@ -58,7 +64,7 @@ export const findNamespacedTool = (
  * `notifications/tools/list_changed` rather than on every qualifying daemon event. */
 export const namespacedToolsSnapshotKey = (tools: readonly NamespacedTool[]): string => {
   const sorted = tools
-    .map((tool) => ({ name: tool.mcpName, selector: tool.selector, descriptor: tool.descriptor }))
+    .map((tool) => ({ name: tool.mcpName, selector: tool.selector, descriptor: tool.descriptor, policy: tool.policy }))
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return JSON.stringify(sorted);

--- a/packages/cordierite/src/mcp/tool-namespace.ts
+++ b/packages/cordierite/src/mcp/tool-namespace.ts
@@ -39,12 +39,23 @@ export const buildNamespacedTools = (
   const tools: NamespacedTool[] = [];
 
   for (const session of sessions) {
-    for (const { policy, ...descriptor } of toolsByAlias.get(session.alias) ?? []) {
+    for (const entry of toolsByAlias.get(session.alias) ?? []) {
+      // Explicit pick (not a `{ policy, ...descriptor }` rest-spread) so a future non-descriptor
+      // field added to `ToolsListEntry` can't silently leak into `descriptor` and from there into
+      // the MCP tool surface and the snapshot key below.
+      const descriptor: ToolDescriptor = {
+        name: entry.name,
+        description: entry.description,
+        input_schema: entry.input_schema,
+        output_schema: entry.output_schema,
+        annotations: entry.annotations,
+      };
+
       tools.push({
         mcpName: namespaced ? `${session.alias}${TOOL_NAMESPACE_SEPARATOR}${descriptor.name}` : descriptor.name,
         selector: session.alias,
         descriptor,
-        policy,
+        policy: entry.policy,
       });
     }
   }

--- a/packages/shared/src/domains/rpc.ts
+++ b/packages/shared/src/domains/rpc.ts
@@ -48,12 +48,15 @@ export type SessionSelectorParams = {
 
 // --- daemon.status ---
 
+/** Wire-safe mirror of `daemon/config.ts`'s `PolicyDecision` (ARCHITECTURE.md §12). */
+export type EffectivePolicyDecision = "allow" | "deny" | "prompt";
+
 /** Wire-safe mirror of `daemon/config.ts`'s `CordieritePolicyConfig` (ARCHITECTURE.md §12):
  * `daemon.status`'s effective policy, exactly as loaded from `config.json` plus defaults. */
 export type EffectivePolicyConfig = {
-  default: "allow" | "deny";
-  destructive: "allow" | "deny";
-  tools?: Record<string, "allow" | "deny">;
+  default: EffectivePolicyDecision;
+  destructive: EffectivePolicyDecision;
+  tools?: Record<string, EffectivePolicyDecision>;
 };
 
 export type DaemonStatusResult = {
@@ -118,7 +121,16 @@ export type SessionsRevokeResult = { ok: true };
 // --- tools.list / tools.call ---
 
 export type ToolsListParams = SessionSelectorParams;
-export type ToolsListResult = ToolDescriptor[];
+
+/** A `tools.list` entry: the tool's descriptor plus the policy decision (ARCHITECTURE.md §12)
+ * that would apply to it right now — resolved daemon-side (it needs `session.alias` and
+ * `config.policy`) so the MCP server can emit `_meta["anthropic/requiresUserInteraction"]` for
+ * `"prompt"` tools at `tools/list` time without a second round trip. */
+export type ToolsListEntry = ToolDescriptor & {
+  policy: EffectivePolicyDecision;
+};
+
+export type ToolsListResult = ToolsListEntry[];
 
 export type ToolsCallParams = SessionSelectorParams & {
   name: string;
@@ -127,6 +139,17 @@ export type ToolsCallParams = SessionSelectorParams & {
   /** Attribution for the audit log (ARCHITECTURE.md §12): who issued this call. The MCP server
    * always sets `"mcp"`; omitted (the CLI's case) defaults to `"cli"` at the daemon. */
   caller?: "cli" | "mcp";
+  /**
+   * Set by the MCP server only, and only when all of: (a) this tool's effective policy is
+   * `"prompt"`, (b) the server emitted `_meta["anthropic/requiresUserInteraction"]` for it at
+   * `tools/list` time, and (c) the connected client's `initialize` `clientInfo` is one known to
+   * enforce that flag (`name === "claude-code"`, version ≥ 2.1.199). The daemon treats this as
+   * the sole evidence a human gate exists for a `"prompt"`-policy call — anything else (CLI, a
+   * non-compliant MCP client, a forged param from an untrusted caller) is denied
+   * (`policy_denied`, reason `no_consent_channel`). `"prompt"` fails closed by design: see issue
+   * #14 / ARCHITECTURE.md §12.
+   */
+  consent?: "client";
 };
 
 export type ToolsCallResult = {

--- a/packages/shared/src/domains/rpc.ts
+++ b/packages/shared/src/domains/rpc.ts
@@ -140,14 +140,17 @@ export type ToolsCallParams = SessionSelectorParams & {
    * always sets `"mcp"`; omitted (the CLI's case) defaults to `"cli"` at the daemon. */
   caller?: "cli" | "mcp";
   /**
-   * Set by the MCP server only, and only when all of: (a) this tool's effective policy is
-   * `"prompt"`, (b) the server emitted `_meta["anthropic/requiresUserInteraction"]` for it at
-   * `tools/list` time, and (c) the connected client's `initialize` `clientInfo` is one known to
-   * enforce that flag (`name === "claude-code"`, version ≥ 2.1.199). The daemon treats this as
-   * the sole evidence a human gate exists for a `"prompt"`-policy call — anything else (CLI, a
-   * non-compliant MCP client, a forged param from an untrusted caller) is denied
-   * (`policy_denied`, reason `no_consent_channel`). `"prompt"` fails closed by design: see issue
-   * #14 / ARCHITECTURE.md §12.
+   * Set by this codebase's own MCP server, and only when all of: (a) this tool's effective policy
+   * is `"prompt"`, (b) the server emitted `_meta["anthropic/requiresUserInteraction"]` for it in
+   * this connection's most recent `tools/list` response, and (c) the connected client's
+   * `initialize` `clientInfo` is one known to enforce that flag (`name === "claude-code"`, version
+   * ≥ 2.1.199). The daemon trusts this param verbatim once present — it is the sole evidence a
+   * human gate exists for a `"prompt"`-policy call, and everything else (CLI, a non-compliant MCP
+   * client) is denied (`policy_denied`, reason `no_consent_channel`). The daemon cannot itself
+   * re-verify an MCP client's behavior, so this is not a defense against another local process
+   * (one with access to the same `daemon.sock`) sending this param directly — see
+   * `docs/SECURITY.md`'s threat model, which already treats socket access as full daemon control.
+   * `"prompt"` fails closed by design: see issue #14 / ARCHITECTURE.md §12.
    */
   consent?: "client";
 };


### PR DESCRIPTION
## Summary
- Adds a third `PolicyDecision` value, `"prompt"`, alongside `"allow"`/`"deny"`. It means "a human gate is required; if one cannot be guaranteed, deny" and fails closed everywhere except one channel.
- The only implemented consent channel: an MCP client that enforces `_meta["anthropic/requiresUserInteraction"]` (Claude Code ≥ v2.1.199). `tools/list` emits the flag per connection, only for a tool a client is known to gate on, and `tools/call` requires the connection to have actually listed that exact tool as flagged before it will proceed — not merely that the tool's live policy is `"prompt"` and the client happens to qualify. This closes a gap an earlier draft had (see review notes below).
- Every other caller — the CLI, an older or non-compliant MCP client — is denied with `policy_denied`, reason `no_consent_channel`, rather than silently behaving like `"allow"`.
- Audit records gain `consent?: "client"` (set only when a `"prompt"` call actually proceeded via the gate) and `deniedReason?: "policy" | "no_consent_channel"` (so a denied line is distinguishable without cross-referencing config).
- `tools.list`'s wire shape grows a `policy` field per entry (`ToolDescriptor & { policy }`) so the MCP server can emit `_meta` without an extra round trip — backward compatible for every existing consumer since it's a strict superset.

Closes callstackincubator/cordierite#14.

## Review
This branch went through an adversarial Opus review pass before this PR was opened. It found one real gap (consent could be granted for a tool the client never actually saw flagged in a listing on that connection — fixed by tracking per-connection emission) and several doc inaccuracies (a comment/docs claim that a forged `consent` param is denied, which isn't true — the daemon trusts `consent: "client"` verbatim once present, consistent with this codebase's existing "anything on `daemon.sock` has full control" trust boundary; docs now say so honestly). All must-fix and should-fix findings were addressed; see the second commit for the detailed list.

## Test plan
- [x] `pnpm -w turbo run build test` — full workspace build + test suite (244 tests in `cordierite`, all passing)
- [x] New/updated coverage in `policy-and-audit.integration.test.ts`: config accepts `"prompt"`, `_meta` emission gated on compliant `clientInfo`, version boundary (`2.1.198` vs `2.1.199`), consent requires an actual prior listing on the same connection, CLI/non-compliant-client denial with `no_consent_channel`, `"deny"` still denies for a compliant client, `consent` never fabricated on `"allow"` calls, `consent: "client"` survives an errored `"prompt"` call.

https://claude.ai/code/session_01PDiisQpURPAt7hZLN4hD23