### PR TITLE
feat: daemon-side app_event retention and an MCP pull surface

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -86,6 +86,7 @@ The daemon refuses to load a key file that is group/world-readable.
   "graceSeconds": 600,
   "linkTtlSeconds": 300,
   "keepaliveIntervalSeconds": 15,
+  "eventBufferSize": 256,
   "policy": { "default": "allow", "destructive": "allow" },
   "advertisedIp": null,
   "scheme": null
@@ -95,6 +96,7 @@ The daemon refuses to load a key file that is group/world-readable.
 `advertisedIp` overrides auto-detection of the address advertised in minted bootstrap
 payloads. `scheme` is the deep-link URI scheme composed into `cordierite link`'s output
 when `--scheme` is not passed (§10) — set it once here instead of on every invocation.
+`eventBufferSize` caps the per-session `events.since` retention buffer (§5).
 
 ## 4. Daemon lifecycle
 
@@ -141,6 +143,7 @@ Methods:
 | `tools.list` | `{ selector? }` | `ToolDescriptor[]` (full schemas + annotations) |
 | `tools.call` | `{ selector?, name, args, timeoutMs? }` | `{ result, callId }` on success — `callId` lets a caller with several in-flight calls match `tool_call_progress`/`tool_call_finished` events back to this call; JSON-RPC error with `data.type` preserving the wire error type on failure |
 | `events.subscribe` | `{ sessionSelector?, kinds? }` | `{ ok: true }`, then `event` notifications on this connection |
+| `events.since` | `{ selector?, since?, kinds?, limit? }` | `{ events: EventNotification[], cursor }` — pull counterpart to `events.subscribe`, draining the per-session retention buffer described below |
 
 `SessionSummary`: `{ sessionId, alias, state, device: { manufacturer?, model?, os? },
 createdAt, claimedAt?, suspendedAt?, toolCount }`.
@@ -148,11 +151,26 @@ createdAt, claimedAt?, suspendedAt?, toolCount }`.
 `daemon.status`'s result also reports the effective policy config and audit surfacing:
 `{ ..., policy: { default, destructive, tools? }, audit: { path, failedWrites } }` (§12).
 
-Event notification payload: `{ kind, sessionId?, alias?, ts, data }` where `kind` is one
+Event notification payload: `{ kind, sessionId?, alias?, ts, data, seq }` where `kind` is one
 of `daemon_started`, `link_created`, `link_expired`, `session_claimed`,
 `session_suspended`, `session_resumed`, `session_revoked`, `session_expired`,
 `tools_changed`, `app_event`, `tool_call_started`, `tool_call_progress`,
-`tool_call_finished`.
+`tool_call_finished`. `seq` is a per-session cursor (§ below); daemon-wide events (no
+`sessionId`) carry `seq: 0` and are never retained.
+
+**Event retention (issue #6):** alongside the live `events.subscribe` fan-out, the daemon
+keeps a per-session ring buffer of the last `eventBufferSize` events (`config.json`,
+default 256), each stamped with a `seq` that increases monotonically per session. `events.since`
+drains it — `since` is an exclusive lower bound on `seq`, `kinds` filters by event kind, `limit`
+caps the response to the newest N; the result's `cursor` is the session's true highest `seq`
+(not just among the returned events), so a caller passes it straight back into the next
+`since` even when `limit` truncated the response or nothing new had happened. `selector`
+defaults the same way as every other selector-taking method (§ above). A session's buffer is
+discarded the instant it hits a terminal event (`session_expired`/`session_revoked`) — matching
+"terminal states free the alias" (§6) — the terminal event itself is still delivered live, just
+never retained. This exists because MCP is strictly request/response (§9): without it, an agent
+that calls a tool and then asks "what happened?" has already missed the answer, since it was
+never subscribed at the moment the app pushed it.
 
 **Error codes** (JSON-RPC `error.data.type`): `no_session`, `ambiguous_session`,
 `unknown_session`, `session_not_active`, `tool_not_found`,
@@ -235,6 +253,17 @@ proxies daemon RPC (auto-spawning the daemon like any client):
 - Two built-in management tools, `cordierite_connect` and `cordierite_wait_for_session`,
   let an agent mint a bootstrap link, deliver it to an emulator/simulator, and wait for the
   claim — without shell access. This is what makes the agent path self-service.
+- Two more built-in tools, `cordierite_events` and `cordierite_wait_for_event` (issue #6),
+  give an agent a pull surface over `postEvent()`-pushed `app_event`s: `cordierite_events`
+  is a thin proxy over `events.since`; `cordierite_wait_for_event` blocks for a matching
+  event, draining the retained buffer for an already-arrived match before falling back to
+  a live wait — closing the same race `cordierite_wait_for_session` doesn't have to worry
+  about (a session is either claimed or not, but an event can fire between "the agent
+  decides to wait" and "the wait subscription lands"). `timeoutMs` is capped server-side
+  well under the 30-minute idle window a stdio MCP tool call gets before Claude Code aborts
+  it for sending neither a response nor a progress notification; a call still running after
+  about two minutes moves to a Claude Code background task, so its result may arrive well
+  after the call returns.
 
 ## 10. CLI surface
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,17 +160,24 @@ of `daemon_started`, `link_created`, `link_expired`, `session_claimed`,
 
 **Event retention (issue #6):** alongside the live `events.subscribe` fan-out, the daemon
 keeps a per-session ring buffer of the last `eventBufferSize` events (`config.json`,
-default 256), each stamped with a `seq` that increases monotonically per session. `events.since`
-drains it — `since` is an exclusive lower bound on `seq`, `kinds` filters by event kind, `limit`
-caps the response to the newest N; the result's `cursor` is the session's true highest `seq`
-(not just among the returned events), so a caller passes it straight back into the next
-`since` even when `limit` truncated the response or nothing new had happened. `selector`
-defaults the same way as every other selector-taking method (§ above). A session's buffer is
-discarded the instant it hits a terminal event (`session_expired`/`session_revoked`) — matching
-"terminal states free the alias" (§6) — the terminal event itself is still delivered live, just
-never retained. This exists because MCP is strictly request/response (§9): without it, an agent
-that calls a tool and then asks "what happened?" has already missed the answer, since it was
-never subscribed at the moment the app pushed it.
+default 256; `tool_call_progress` is excluded — a single chatty call can emit far more of
+these than the buffer holds, which would otherwise evict every retained `app_event`),
+each stamped with a `seq` that increases monotonically per session. `events.since` drains
+it — `since` is an exclusive lower bound on `seq`, `kinds` filters by event kind, `limit`
+caps the response to the **oldest** N so paging forward with the returned `cursor` never
+skips anything; the result's `cursor` is the `seq` of the last event actually **returned**
+(so `since: cursor` on the next call resumes right after it), falling back to the session's
+true high-water mark only when nothing was returned (an empty buffer, or every retained
+event was filtered out by `kinds`) so an empty page still lets a caller skip past events it
+explicitly excluded rather than re-scanning them forever. `selector` defaults the same way
+as every other selector-taking method (§ above). A session's buffer is discarded the
+instant it hits a terminal event (`session_expired`/`session_revoked`) — matching "terminal
+states free the alias" (§6) — the terminal event itself is still delivered live, just never
+retained; an unclaimed pending link's buffer is discarded the same way when it's
+discarded for any reason (TTL, revoke, attempt-limit exceeded), even the paths with no
+event kind of their own. This exists because MCP is strictly request/response (§9): without
+it, an agent that calls a tool and then asks "what happened?" has already missed the
+answer, since it was never subscribed at the moment the app pushed it.
 
 **Error codes** (JSON-RPC `error.data.type`): `no_session`, `ambiguous_session`,
 `unknown_session`, `session_not_active`, `tool_not_found`,

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -205,7 +205,9 @@ an MCP progress notification.
 ```
 
 Guard: `isEventMessage`. Emitted by `postEvent(name, payload?)` on the React Native
-client; surfaced daemon-side as an `app_event` (`events.subscribe`, `cordierite events`).
+client; surfaced daemon-side as an `app_event` (`events.subscribe`, `cordierite events`) and
+retained per-session (`events.since`, §8) so a request/response caller (an MCP client, a script)
+can ask "what happened?" after the fact instead of only listening live.
 
 ## 5. Tool descriptor shape
 
@@ -307,3 +309,14 @@ types also establish these details:
   `audit: { path, failedWrites }` (ARCHITECTURE.md §12's audit surfacing).
 - `events.subscribe` includes `link_expired` (a pending link's TTL elapsed with no
   claim) and `tool_call_progress` (mirroring the wire message in §4).
+- `events.since` (issue #6) is the pull counterpart: it drains a per-session ring buffer
+  the daemon retains alongside the live `events.subscribe` fan-out, so a caller that only
+  finds out it wants to know "what happened?" after the fact (every MCP tool call, since
+  MCP is strictly request/response) doesn't need to have been subscribed in advance. Every
+  `EventNotification` carries a `seq`: a cursor that increases monotonically per session,
+  assigned at retention time. Pass the highest `seq` seen back as `since` on the next call
+  to resume without re-reading; a session-scoped event whose session hits a terminal state
+  (`session_expired`/`session_revoked`) discards that session's buffer, matching "terminal
+  states free the alias" (ARCHITECTURE.md §6) — there is no persisted history past that
+  point. Daemon-wide events (no `sessionId`, e.g. `daemon_started`) are never buffered and
+  carry `seq: 0`.

--- a/packages/cordierite/README.md
+++ b/packages/cordierite/README.md
@@ -34,7 +34,7 @@ The command writes an unencrypted PEM private key (PKCS#8) to `<state-dir>/key.p
 | `cordierite ls` | list sessions: alias, state, device, tool count |
 | `cordierite tools [selector] [name] [--full]` | list a session's tools, or show one tool's full schema |
 | `cordierite invoke [selector] <tool> --input '<json>' [--timeout <ms>]` | call a tool |
-| `cordierite events [selector] [--follow]` | stream session/tool events; `--json` emits NDJSON |
+| `cordierite events [selector] [--follow] [--since <cursor>]` | stream session/tool events (default), or one-shot pull everything retained since `<cursor>` (`--since`); `--json` emits NDJSON |
 | `cordierite revoke [selector]` | revoke a session |
 | `cordierite daemon run\|start\|stop\|status` | daemon lifecycle |
 | `cordierite mcp` | start a stdio MCP server proxying connected apps' tools to MCP clients |
@@ -63,7 +63,7 @@ Add `cordierite mcp` to the agent's MCP server config — no separate server pro
 }
 ```
 
-Once configured, the connected app's tools appear as MCP tools automatically: `tools/list` mirrors the live registry (namespaced `<alias>__<name>` when more than one session is active), and `tools/call` proxies straight to the app with progress and errors preserved. Two built-in management tools let an agent bootstrap a session without shell access: `cordierite_connect` mints a link (optionally delivering it directly to a booted `android`/`ios-sim` target), and `cordierite_wait_for_session` waits for that session to be claimed.
+Once configured, the connected app's tools appear as MCP tools automatically: `tools/list` mirrors the live registry (namespaced `<alias>__<name>` when more than one session is active), and `tools/call` proxies straight to the app with progress and errors preserved. Two built-in management tools let an agent bootstrap a session without shell access: `cordierite_connect` mints a link (optionally delivering it directly to a booted `android`/`ios-sim` target), and `cordierite_wait_for_session` waits for that session to be claimed. Two more built-in tools give an agent a pull surface over `postEvent()`-pushed app events: `cordierite_events` drains everything retained since a cursor, and `cordierite_wait_for_event` blocks for a matching event (checking what's already retained before waiting live), rejecting with `tool_timeout` if none arrives in time.
 
 ## Release gate: `cordierite doctor`
 

--- a/packages/cordierite/src/__tests__/__snapshots__/mcp-server.integration.test.ts.snap
+++ b/packages/cordierite/src/__tests__/__snapshots__/mcp-server.integration.test.ts.snap
@@ -29,6 +29,61 @@ exports[`mcp: tools/list and tools/call > the generated MCP tool list (built-ins
     "inputSchema": {
       "additionalProperties": false,
       "properties": {
+        "kinds": {
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
+        "limit": {
+          "exclusiveMinimum": 0,
+          "type": "number",
+        },
+        "selector": {
+          "type": "string",
+        },
+        "since": {
+          "minimum": 0,
+          "type": "number",
+        },
+      },
+      "type": "object",
+    },
+    "name": "cordierite_events",
+    "outputSchema": undefined,
+  },
+  {
+    "annotations": undefined,
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "match": {
+          "type": "object",
+        },
+        "name": {
+          "type": "string",
+        },
+        "selector": {
+          "type": "string",
+        },
+        "timeoutMs": {
+          "exclusiveMinimum": 0,
+          "type": "number",
+        },
+      },
+      "required": [
+        "name",
+      ],
+      "type": "object",
+    },
+    "name": "cordierite_wait_for_event",
+    "outputSchema": undefined,
+  },
+  {
+    "annotations": undefined,
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
         "sessionId": {
           "type": "string",
         },

--- a/packages/cordierite/src/__tests__/__snapshots__/mcp-server.integration.test.ts.snap
+++ b/packages/cordierite/src/__tests__/__snapshots__/mcp-server.integration.test.ts.snap
@@ -31,20 +31,35 @@ exports[`mcp: tools/list and tools/call > the generated MCP tool list (built-ins
       "properties": {
         "kinds": {
           "items": {
+            "enum": [
+              "daemon_started",
+              "link_created",
+              "link_expired",
+              "session_claimed",
+              "session_suspended",
+              "session_resumed",
+              "session_revoked",
+              "session_expired",
+              "tools_changed",
+              "app_event",
+              "tool_call_started",
+              "tool_call_progress",
+              "tool_call_finished",
+            ],
             "type": "string",
           },
           "type": "array",
         },
         "limit": {
           "exclusiveMinimum": 0,
-          "type": "number",
+          "type": "integer",
         },
         "selector": {
           "type": "string",
         },
         "since": {
           "minimum": 0,
-          "type": "number",
+          "type": "integer",
         },
       },
       "type": "object",
@@ -58,6 +73,14 @@ exports[`mcp: tools/list and tools/call > the generated MCP tool list (built-ins
       "additionalProperties": false,
       "properties": {
         "match": {
+          "additionalProperties": {
+            "type": [
+              "string",
+              "number",
+              "boolean",
+              "null",
+            ],
+          },
           "type": "object",
         },
         "name": {
@@ -65,6 +88,10 @@ exports[`mcp: tools/list and tools/call > the generated MCP tool list (built-ins
         },
         "selector": {
           "type": "string",
+        },
+        "since": {
+          "minimum": 0,
+          "type": "integer",
         },
         "timeoutMs": {
           "exclusiveMinimum": 0,

--- a/packages/cordierite/src/__tests__/command-options.test.ts
+++ b/packages/cordierite/src/__tests__/command-options.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import {
   parseJsonInputOption,
+  parseNonNegativeIntegerOption,
   parsePositiveIntegerOption,
   splitOptionalSelector,
   splitOptionalSelectorAndTarget,
@@ -21,6 +22,23 @@ describe("parsePositiveIntegerOption", () => {
     expect(() => parsePositiveIntegerOption("0", "--ttl")).toThrow(/positive integer/u);
     expect(() => parsePositiveIntegerOption("-5", "--ttl")).toThrow(/positive integer/u);
     expect(() => parsePositiveIntegerOption("abc", "--ttl")).toThrow(/positive integer/u);
+  });
+});
+
+describe("parseNonNegativeIntegerOption", () => {
+  test("passes through undefined", () => {
+    expect(parseNonNegativeIntegerOption(undefined, "--since")).toBeUndefined();
+  });
+
+  test("accepts a numeric string, including zero", () => {
+    expect(parseNonNegativeIntegerOption("0", "--since")).toBe(0);
+    expect(parseNonNegativeIntegerOption("42", "--since")).toBe(42);
+  });
+
+  test("rejects negative, non-integer, and non-numeric values", () => {
+    expect(() => parseNonNegativeIntegerOption("-1", "--since")).toThrow(/non-negative integer/u);
+    expect(() => parseNonNegativeIntegerOption("1.5", "--since")).toThrow(/non-negative integer/u);
+    expect(() => parseNonNegativeIntegerOption("abc", "--since")).toThrow(/non-negative integer/u);
   });
 });
 

--- a/packages/cordierite/src/__tests__/e2e/mcp.e2e.test.ts
+++ b/packages/cordierite/src/__tests__/e2e/mcp.e2e.test.ts
@@ -25,7 +25,12 @@ import {
 
 afterEach(cleanupAfterEach);
 
-const BUILTIN_TOOL_NAMES = new Set(["cordierite_connect", "cordierite_wait_for_session"]);
+const BUILTIN_TOOL_NAMES = new Set([
+  "cordierite_connect",
+  "cordierite_wait_for_session",
+  "cordierite_events",
+  "cordierite_wait_for_event",
+]);
 
 const withoutBuiltinTools = <T extends { name: string }>(tools: T[]): T[] => {
   return tools.filter((tool) => !BUILTIN_TOOL_NAMES.has(tool.name));

--- a/packages/cordierite/src/__tests__/event-bus.test.ts
+++ b/packages/cordierite/src/__tests__/event-bus.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure unit tests for `daemon/event-bus.ts`'s retention buffer (issue #6): cursor assignment,
+ * `since` filtering, the ring buffer's eviction cap, and the terminal-state buffer drop. No daemon,
+ * no socket, no device — `createEventBus` takes a `Clock` seam precisely so this needs none of that.
+ */
+
+import { describe, expect, test } from "vitest";
+
+import { createEventBus } from "../daemon/event-bus.js";
+
+const clock = { now: () => new Date("2026-01-01T00:00:00.000Z") };
+
+describe("event-bus: retention buffer", () => {
+  test("assigns a monotonically increasing per-session seq, starting at 1", () => {
+    const bus = createEventBus({ clock });
+
+    bus.emit({ kind: "app_event", sessionId: "s1", data: { name: "a" } });
+    bus.emit({ kind: "app_event", sessionId: "s1", data: { name: "b" } });
+    bus.emit({ kind: "app_event", sessionId: "s1", data: { name: "c" } });
+
+    const { events, cursor } = bus.since("s1");
+    expect(events.map((event) => event.seq)).toEqual([1, 2, 3]);
+    expect(cursor).toBe(3);
+  });
+
+  test("seq counters are independent per session", () => {
+    const bus = createEventBus({ clock });
+
+    bus.emit({ kind: "app_event", sessionId: "s1", data: {} });
+    bus.emit({ kind: "app_event", sessionId: "s2", data: {} });
+    bus.emit({ kind: "app_event", sessionId: "s1", data: {} });
+
+    expect(bus.since("s1").cursor).toBe(2);
+    expect(bus.since("s2").cursor).toBe(1);
+  });
+
+  test("daemon-wide events (no sessionId) are fanned out but never buffered", () => {
+    const bus = createEventBus({ clock });
+    const seen: number[] = [];
+    bus.subscribe((event) => seen.push(event.seq));
+
+    bus.emit({ kind: "daemon_started", data: {} });
+
+    expect(seen).toEqual([0]);
+    // Nothing to drain for any session id — a daemon-wide event was never anyone's to retain.
+    expect(bus.since("s1")).toEqual({ events: [], cursor: 0 });
+  });
+
+  test("since excludes everything at or before the given cursor", () => {
+    const bus = createEventBus({ clock });
+
+    for (let i = 0; i < 5; i++) {
+      bus.emit({ kind: "app_event", sessionId: "s1", data: { i } });
+    }
+
+    const { events } = bus.since("s1", { since: 2 });
+    expect(events.map((event) => event.seq)).toEqual([3, 4, 5]);
+  });
+
+  test("kinds filters the retained buffer without disturbing seq/cursor", () => {
+    const bus = createEventBus({ clock });
+
+    bus.emit({ kind: "app_event", sessionId: "s1", data: {} });
+    bus.emit({ kind: "tools_changed", sessionId: "s1", data: {} });
+    bus.emit({ kind: "app_event", sessionId: "s1", data: {} });
+
+    const { events, cursor } = bus.since("s1", { kinds: ["app_event"] });
+    expect(events.map((event) => event.kind)).toEqual(["app_event", "app_event"]);
+    expect(events.map((event) => event.seq)).toEqual([1, 3]);
+    // cursor reflects the whole session, not just the filtered subset.
+    expect(cursor).toBe(3);
+  });
+
+  test("limit truncates to the newest N, cursor still reflects everything retained", () => {
+    const bus = createEventBus({ clock });
+
+    for (let i = 0; i < 5; i++) {
+      bus.emit({ kind: "app_event", sessionId: "s1", data: { i } });
+    }
+
+    const { events, cursor } = bus.since("s1", { limit: 2 });
+    expect(events.map((event) => event.seq)).toEqual([4, 5]);
+    expect(cursor).toBe(5);
+  });
+
+  test("the ring buffer caps retention at bufferSize, dropping the oldest first", () => {
+    const bus = createEventBus({ clock, bufferSize: 3 });
+
+    for (let i = 0; i < 5; i++) {
+      bus.emit({ kind: "app_event", sessionId: "s1", data: { i } });
+    }
+
+    const { events, cursor } = bus.since("s1");
+    // seq 1 and 2 were evicted; the cursor still reflects the true total emitted, not just retained.
+    expect(events.map((event) => event.seq)).toEqual([3, 4, 5]);
+    expect(cursor).toBe(5);
+  });
+
+  test("a terminal event (session_expired/session_revoked) discards the session's buffer", () => {
+    const bus = createEventBus({ clock });
+
+    bus.emit({ kind: "app_event", sessionId: "s1", data: {} });
+    bus.emit({ kind: "app_event", sessionId: "s1", data: {} });
+    bus.emit({ kind: "session_expired", sessionId: "s1", data: {} });
+
+    expect(bus.since("s1")).toEqual({ events: [], cursor: 0 });
+  });
+
+  test("the terminal event itself is still delivered live even though it isn't retained", () => {
+    const bus = createEventBus({ clock });
+    const seen: string[] = [];
+    bus.subscribe((event) => seen.push(event.kind));
+
+    bus.emit({ kind: "app_event", sessionId: "s1", data: {} });
+    bus.emit({ kind: "session_revoked", sessionId: "s1", data: {} });
+
+    expect(seen).toEqual(["app_event", "session_revoked"]);
+  });
+
+  test("session_revoked also discards the buffer, matching session_expired", () => {
+    const bus = createEventBus({ clock });
+
+    bus.emit({ kind: "app_event", sessionId: "s1", data: {} });
+    bus.emit({ kind: "session_revoked", sessionId: "s1", data: {} });
+
+    expect(bus.since("s1")).toEqual({ events: [], cursor: 0 });
+  });
+
+  test("a throwing subscriber never breaks buffering or another subscriber", () => {
+    const bus = createEventBus({ clock });
+    const seen: string[] = [];
+
+    bus.subscribe(() => {
+      throw new Error("boom");
+    });
+    bus.subscribe((event) => seen.push(event.kind));
+
+    bus.emit({ kind: "app_event", sessionId: "s1", data: {} });
+
+    expect(seen).toEqual(["app_event"]);
+    expect(bus.since("s1").events).toHaveLength(1);
+  });
+});

--- a/packages/cordierite/src/__tests__/event-bus.test.ts
+++ b/packages/cordierite/src/__tests__/event-bus.test.ts
@@ -71,16 +71,40 @@ describe("event-bus: retention buffer", () => {
     expect(cursor).toBe(3);
   });
 
-  test("limit truncates to the newest N, cursor still reflects everything retained", () => {
+  test("limit truncates to the oldest N so paging with the returned cursor never skips events", () => {
     const bus = createEventBus({ clock });
 
     for (let i = 0; i < 5; i++) {
       bus.emit({ kind: "app_event", sessionId: "s1", data: { i } });
     }
 
-    const { events, cursor } = bus.since("s1", { limit: 2 });
-    expect(events.map((event) => event.seq)).toEqual([4, 5]);
-    expect(cursor).toBe(5);
+    const first = bus.since("s1", { limit: 2 });
+    expect(first.events.map((event) => event.seq)).toEqual([1, 2]);
+    // cursor is the last *returned* event, not the session's true high-water mark — that's what
+    // makes re-calling with `since: cursor` page forward instead of returning the same window.
+    expect(first.cursor).toBe(2);
+
+    const second = bus.since("s1", { since: first.cursor, limit: 2 });
+    expect(second.events.map((event) => event.seq)).toEqual([3, 4]);
+    expect(second.cursor).toBe(4);
+
+    const third = bus.since("s1", { since: second.cursor, limit: 2 });
+    expect(third.events.map((event) => event.seq)).toEqual([5]);
+    // Fewer than `limit` left: cursor still tracks the last event actually returned.
+    expect(third.cursor).toBe(5);
+  });
+
+  test("an empty page with a kinds filter still advances the cursor to the session's high-water mark", () => {
+    const bus = createEventBus({ clock });
+
+    bus.emit({ kind: "tools_changed", sessionId: "s1", data: {} });
+    bus.emit({ kind: "tools_changed", sessionId: "s1", data: {} });
+
+    // Nothing matches "app_event" — without the high-water-mark fallback this would return
+    // cursor: 0 forever, forcing the caller to re-scan the same (empty) result on every call.
+    const { events, cursor } = bus.since("s1", { kinds: ["app_event"] });
+    expect(events).toEqual([]);
+    expect(cursor).toBe(2);
   });
 
   test("the ring buffer caps retention at bufferSize, dropping the oldest first", () => {
@@ -124,6 +148,51 @@ describe("event-bus: retention buffer", () => {
     bus.emit({ kind: "session_revoked", sessionId: "s1", data: {} });
 
     expect(bus.since("s1")).toEqual({ events: [], cursor: 0 });
+  });
+
+  test("since returns a snapshot, not the live buffer — a later emit doesn't mutate an already-returned result", () => {
+    const bus = createEventBus({ clock });
+
+    bus.emit({ kind: "app_event", sessionId: "s1", data: {} });
+    const { events } = bus.since("s1");
+    expect(events).toHaveLength(1);
+
+    bus.emit({ kind: "app_event", sessionId: "s1", data: {} });
+    // The array returned by the first `since` call must still have length 1 — it must not be the
+    // same array `emit` just pushed into.
+    expect(events).toHaveLength(1);
+  });
+
+  test("tool_call_progress is fanned out live but never retained, so it can't evict app_events", () => {
+    const bus = createEventBus({ clock, bufferSize: 2 });
+    const seen: string[] = [];
+    bus.subscribe((event) => seen.push(event.kind));
+
+    bus.emit({ kind: "app_event", sessionId: "s1", data: {} });
+
+    for (let i = 0; i < 10; i++) {
+      bus.emit({ kind: "tool_call_progress", sessionId: "s1", data: { progress: i } });
+    }
+
+    expect(seen.filter((kind) => kind === "tool_call_progress")).toHaveLength(10);
+    // A `bufferSize` of 2 would otherwise have evicted the app_event many times over.
+    expect(bus.since("s1").events.map((event) => event.kind)).toEqual(["app_event"]);
+  });
+
+  test("drop() discards a session's buffer outright, with no event required", () => {
+    const bus = createEventBus({ clock });
+
+    bus.emit({ kind: "link_created", sessionId: "s1", data: {} });
+    expect(bus.since("s1").events).toHaveLength(1);
+
+    bus.drop("s1");
+
+    expect(bus.since("s1")).toEqual({ events: [], cursor: 0 });
+  });
+
+  test("drop() on a session with nothing retained is a harmless no-op", () => {
+    const bus = createEventBus({ clock });
+    expect(() => bus.drop("never-emitted")).not.toThrow();
   });
 
   test("a throwing subscriber never breaks buffering or another subscriber", () => {

--- a/packages/cordierite/src/__tests__/events-tool.test.ts
+++ b/packages/cordierite/src/__tests__/events-tool.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Pure unit test for `mcp/events-tool.ts`'s `clampWaitForEventTimeoutMs` (issue #6's "Cap
+ * timeoutMs server-side below the idle window rather than trusting the caller"). No daemon, no
+ * socket — the actual bounds (120s default, 1500000ms cap) are minutes long, so this exercises the
+ * boundary math directly rather than waiting either one out through the full MCP tool.
+ */
+
+import { describe, expect, test } from "vitest";
+
+import { clampWaitForEventTimeoutMs } from "../mcp/events-tool.js";
+
+describe("clampWaitForEventTimeoutMs", () => {
+  test("defaults to 120000ms when no timeoutMs is given", () => {
+    expect(clampWaitForEventTimeoutMs(undefined)).toBe(120_000);
+  });
+
+  test("passes a requested value through unchanged when it's under the cap", () => {
+    expect(clampWaitForEventTimeoutMs(5_000)).toBe(5_000);
+  });
+
+  test("caps a requested value at 1500000ms (25 minutes), never trusting the caller past it", () => {
+    expect(clampWaitForEventTimeoutMs(1_500_000)).toBe(1_500_000);
+    expect(clampWaitForEventTimeoutMs(10_000_000)).toBe(1_500_000);
+    expect(clampWaitForEventTimeoutMs(Number.MAX_SAFE_INTEGER)).toBe(1_500_000);
+  });
+});

--- a/packages/cordierite/src/__tests__/events.integration.test.ts
+++ b/packages/cordierite/src/__tests__/events.integration.test.ts
@@ -217,25 +217,33 @@ describe("cordierite events --json", () => {
     expect(await waitForExit(sinceProcess)).toBe(0);
 
     const lines = stdout.split("\n").filter((line) => line.length > 0);
-    expect(lines.length).toBeGreaterThan(0);
+    expect(lines.length).toBeGreaterThan(1); // at least one event line plus the trailing cursor line
 
-    let cursor = 0;
-    for (const line of lines) {
+    // The last line is the trailing `{"cursor":N}` marker (issue #6: a scripted caller shouldn't
+    // have to reconstruct the resume point by maxing `seq` over the event lines, which is
+    // impossible when the response is empty); everything before it is an event.
+    const cursorLine = JSON.parse(lines[lines.length - 1]!) as { cursor: number };
+    const eventLines = lines.slice(0, -1);
+
+    for (const line of eventLines) {
       const parsed = JSON.parse(line);
       expect(parsed).toHaveProperty("kind");
       expect(parsed).toHaveProperty("seq");
-      cursor = Math.max(cursor, parsed.seq);
     }
 
-    expect(lines.some((line) => JSON.parse(line).kind === "app_event")).toBe(true);
+    expect(eventLines.some((line) => JSON.parse(line).kind === "app_event")).toBe(true);
 
-    const drainedProcess = spawnCliBinary(["events", alias, "--since", String(cursor), "--json"], { stateDir });
+    const drainedProcess = spawnCliBinary(["events", alias, "--since", String(cursorLine.cursor), "--json"], { stateDir });
     let drainedStdout = "";
     drainedProcess.stdout.on("data", (chunk: Buffer) => {
       drainedStdout += chunk.toString("utf8");
     });
     expect(await waitForExit(drainedProcess)).toBe(0);
-    expect(drainedStdout.trim()).toBe("");
+
+    // Nothing new since the cursor: only the trailing cursor line itself, no event lines.
+    const drainedLines = drainedStdout.split("\n").filter((line) => line.length > 0);
+    expect(drainedLines).toHaveLength(1);
+    expect(JSON.parse(drainedLines[0]!)).toEqual({ cursor: cursorLine.cursor });
 
     socket.close();
     const stopResult = runCliJson(["daemon", "stop"], stateDir);

--- a/packages/cordierite/src/__tests__/events.integration.test.ts
+++ b/packages/cordierite/src/__tests__/events.integration.test.ts
@@ -11,8 +11,14 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { afterEach, describe, expect, test } from "vitest";
+import WebSocket from "ws";
+
+import { decodeBootstrap } from "@cordierite/shared";
 
 import { runCliBinary, spawnCliBinary, waitForExit, writeTestHostKey } from "./fixtures.js";
+
+// Client pinning is the app's job; this test skips it client-side for its throwaway self-signed key.
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
 const stateDirs: string[] = [];
 const daemonPids: number[] = [];
@@ -55,7 +61,7 @@ const pickFreePort = async (): Promise<number> => {
   });
 };
 
-const makeTempStateDir = async (): Promise<string> => {
+const makeTempStateDir = async (): Promise<{ stateDir: string; port: number }> => {
   const directory = await mkdtemp(path.join(tmpdir(), "cordierite-events-cli-"));
   await writeTestHostKey(path.join(directory, "key.pem"));
 
@@ -68,7 +74,7 @@ const makeTempStateDir = async (): Promise<string> => {
   );
 
   stateDirs.push(directory);
-  return directory;
+  return { stateDir: directory, port };
 };
 
 const runCliJson = (args: string[], stateDir: string) => {
@@ -77,9 +83,53 @@ const runCliJson = (args: string[], stateDir: string) => {
   return JSON.parse(result.stdout);
 };
 
+const nextMessage = (socket: WebSocket): Promise<Record<string, unknown>> => {
+  return new Promise((resolve, reject) => {
+    socket.once("message", (data) => {
+      try {
+        resolve(JSON.parse(data.toString("utf8")));
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+};
+
+/** Mints a link via the CLI, claims it over a fresh `ws` socket, and returns the claimed device's
+ * identity plus the open socket (caller closes it). */
+const claimAppOverCli = async (
+  stateDir: string,
+  port: number,
+): Promise<{ socket: WebSocket; alias: string; sessionId: string }> => {
+  const linkResult = runCliJson(["link", "--ttl", "30", "--scheme", "cordierite-events-since-test"], stateDir);
+  expect(linkResult.ok).toBe(true);
+
+  const payload = (linkResult.data.deepLink as string).split("cordierite=")[1]!.split("&")[0]!;
+  const decoded = decodeBootstrap(payload)!;
+
+  const socket = new WebSocket(`wss://127.0.0.1:${port}`, { rejectUnauthorized: false });
+  await new Promise<void>((resolve, reject) => {
+    socket.once("open", () => resolve());
+    socket.once("error", reject);
+  });
+
+  socket.send(
+    JSON.stringify({
+      type: "session_claim",
+      protocol_version: 2,
+      session_id: decoded.sessionId,
+      token: decoded.token,
+      device_model: "Pixel 8",
+    }),
+  );
+  const ack = await nextMessage(socket);
+
+  return { socket, alias: ack.alias as string, sessionId: decoded.sessionId };
+};
+
 describe("cordierite events --json", () => {
   test("streams NDJSON lines and exits 0 on SIGINT", async () => {
-    const stateDir = await makeTempStateDir();
+    const { stateDir } = await makeTempStateDir();
 
     // `daemon status` both auto-spawns the daemon and gives us its pid for cleanup.
     const status = runCliJson(["daemon", "status"], stateDir);
@@ -139,6 +189,55 @@ describe("cordierite events --json", () => {
     const exitCode = await waitForExit(eventsProcess);
     expect(exitCode).toBe(0);
 
+    const stopResult = runCliJson(["daemon", "stop"], stateDir);
+    expect(stopResult.ok).toBe(true);
+  }, 15_000);
+
+  test("--since pulls retained events one-shot for a claimed session, and a later pull with the returned cursor sees nothing new", async () => {
+    const { stateDir, port } = await makeTempStateDir();
+
+    const status = runCliJson(["daemon", "status"], stateDir);
+    expect(status.ok).toBe(true);
+    daemonPids.push(status.data.daemon.pid);
+
+    const { socket, alias, sessionId } = await claimAppOverCli(stateDir, port);
+    socket.send(JSON.stringify({ type: "event", session_id: sessionId, name: "greeting", ts: Date.now() }));
+    // The claim ack round-trip already guarantees `session_claimed` landed; give the `event` frame a
+    // beat to reach the daemon and land in the retention buffer before pulling.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Attach the data listener before the process can exit — the child's stdout write and its
+    // `process.exit()` race the parent's own read otherwise, and a `for await` started only once
+    // the child has already exited can end up seeing nothing.
+    const sinceProcess = spawnCliBinary(["events", alias, "--since", "0", "--json"], { stateDir });
+    let stdout = "";
+    sinceProcess.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    expect(await waitForExit(sinceProcess)).toBe(0);
+
+    const lines = stdout.split("\n").filter((line) => line.length > 0);
+    expect(lines.length).toBeGreaterThan(0);
+
+    let cursor = 0;
+    for (const line of lines) {
+      const parsed = JSON.parse(line);
+      expect(parsed).toHaveProperty("kind");
+      expect(parsed).toHaveProperty("seq");
+      cursor = Math.max(cursor, parsed.seq);
+    }
+
+    expect(lines.some((line) => JSON.parse(line).kind === "app_event")).toBe(true);
+
+    const drainedProcess = spawnCliBinary(["events", alias, "--since", String(cursor), "--json"], { stateDir });
+    let drainedStdout = "";
+    drainedProcess.stdout.on("data", (chunk: Buffer) => {
+      drainedStdout += chunk.toString("utf8");
+    });
+    expect(await waitForExit(drainedProcess)).toBe(0);
+    expect(drainedStdout.trim()).toBe("");
+
+    socket.close();
     const stopResult = runCliJson(["daemon", "stop"], stateDir);
     expect(stopResult.ok).toBe(true);
   }, 15_000);

--- a/packages/cordierite/src/__tests__/exit-codes.integration.test.ts
+++ b/packages/cordierite/src/__tests__/exit-codes.integration.test.ts
@@ -95,6 +95,14 @@ describe("exit codes: v2 command surface", () => {
     expect(payload.error.type).toBe("usage_error");
   });
 
+  test("usage_error (64): events --since combined with --follow", async () => {
+    const stateDir = await makeTempStateDir();
+    const { exitCode, payload } = runCli(["events", "--since", "0", "--follow"], stateDir);
+
+    expect(exitCode).toBe(64);
+    expect(payload.error.type).toBe("usage_error");
+  });
+
   test("usage_error (64): keygen refuses to overwrite without --force", async () => {
     const stateDir = await makeTempStateDir();
     const keyPath = path.join(stateDir, "existing.pem");

--- a/packages/cordierite/src/__tests__/links.test.ts
+++ b/packages/cordierite/src/__tests__/links.test.ts
@@ -62,8 +62,9 @@ describe("PendingLinkRegistry: TTL expiry and eventual free", () => {
       clock: { now: () => new Date("2026-01-01T00:00:00.000Z") },
       timers,
       eventBus: {
-        emit: (event) => events.push({ ...event, ts: event.ts ?? 0 }),
+        emit: (event) => events.push({ ...event, ts: event.ts ?? 0, seq: 0 }),
         subscribe: () => () => {},
+        since: () => ({ events: [], cursor: 0 }),
       },
     });
 
@@ -98,7 +99,7 @@ describe("PendingLinkRegistry: TTL expiry and eventual free", () => {
       getEndpoint: () => ({ family: 4, address: "127.0.0.1", port: 8443 }),
       clock: { now: () => new Date("2026-01-01T00:00:00.000Z") },
       timers,
-      eventBus: { emit: () => {}, subscribe: () => () => {} },
+      eventBus: { emit: () => {}, subscribe: () => () => {}, since: () => ({ events: [], cursor: 0 }) },
     });
 
     const { link } = registry.create(30);

--- a/packages/cordierite/src/__tests__/links.test.ts
+++ b/packages/cordierite/src/__tests__/links.test.ts
@@ -65,6 +65,7 @@ describe("PendingLinkRegistry: TTL expiry and eventual free", () => {
         emit: (event) => events.push({ ...event, ts: event.ts ?? 0, seq: 0 }),
         subscribe: () => () => {},
         since: () => ({ events: [], cursor: 0 }),
+        drop: () => {},
       },
     });
 
@@ -99,7 +100,12 @@ describe("PendingLinkRegistry: TTL expiry and eventual free", () => {
       getEndpoint: () => ({ family: 4, address: "127.0.0.1", port: 8443 }),
       clock: { now: () => new Date("2026-01-01T00:00:00.000Z") },
       timers,
-      eventBus: { emit: () => {}, subscribe: () => () => {}, since: () => ({ events: [], cursor: 0 }) },
+      eventBus: {
+        emit: () => {},
+        subscribe: () => () => {},
+        since: () => ({ events: [], cursor: 0 }),
+        drop: () => {},
+      },
     });
 
     const { link } = registry.create(30);

--- a/packages/cordierite/src/__tests__/mcp-server.integration.test.ts
+++ b/packages/cordierite/src/__tests__/mcp-server.integration.test.ts
@@ -211,7 +211,12 @@ const snapshotTools = async (
   await toolsChanged;
 };
 
-const BUILTIN_TOOL_NAMES = new Set(["cordierite_connect", "cordierite_wait_for_session"]);
+const BUILTIN_TOOL_NAMES = new Set([
+  "cordierite_connect",
+  "cordierite_wait_for_session",
+  "cordierite_events",
+  "cordierite_wait_for_event",
+]);
 
 /** Every `tools/list` response always includes the two built-in management tools alongside
  * whatever proxied device tools are live; tests that care only about the proxied tools filter
@@ -552,6 +557,119 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     expect(data.alias.length).toBeGreaterThan(0);
 
     socket.close();
+  }, 10_000);
+});
+
+describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
+  test("cordierite_events drains app_events already emitted, and honors the returned cursor", async () => {
+    const { daemon, stateDir, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+
+    const emitted = waitForEvent(daemon, "app_event");
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "greeting", payload: { hi: true }, ts: Date.now() }));
+    await emitted;
+
+    const handle = await createMcpHandle(stateDir);
+    const client = await connectInMemoryClient(handle);
+
+    const first = await client.request(
+      { method: "tools/call", params: { name: "cordierite_events", arguments: {} } },
+      CallToolResultSchema,
+    );
+    expect(first.isError).not.toBe(true);
+    const firstData = first.structuredContent as { events: Array<{ kind: string; data: { name: string } }>; cursor: number };
+    expect(firstData.events.some((event) => event.kind === "app_event" && event.data.name === "greeting")).toBe(true);
+
+    const second = await client.request(
+      { method: "tools/call", params: { name: "cordierite_events", arguments: { since: firstData.cursor } } },
+      CallToolResultSchema,
+    );
+    const secondData = second.structuredContent as { events: unknown[] };
+    expect(secondData.events).toEqual([]);
+
+    app.socket.close();
+  });
+
+  test("cordierite_wait_for_event resolves immediately for an event that already fired before the call", async () => {
+    const { daemon, stateDir, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+
+    const emitted = waitForEvent(daemon, "app_event");
+    app.socket.send(
+      JSON.stringify({ type: "event", session_id: app.sessionId, name: "already-happened", payload: { n: 1 }, ts: Date.now() }),
+    );
+    await emitted;
+
+    const handle = await createMcpHandle(stateDir);
+    const client = await connectInMemoryClient(handle);
+
+    const result = await client.request(
+      {
+        method: "tools/call",
+        params: { name: "cordierite_wait_for_event", arguments: { name: "already-happened", timeoutMs: 2000 } },
+      },
+      CallToolResultSchema,
+    );
+
+    expect(result.isError).not.toBe(true);
+    const data = result.structuredContent as { name: string; payload: { n: number } };
+    expect(data.name).toBe("already-happened");
+    expect(data.payload).toEqual({ n: 1 });
+
+    app.socket.close();
+  }, 10_000);
+
+  test("cordierite_wait_for_event resolves once a live-only matching event arrives, ignoring non-matching ones", async () => {
+    const { daemon, stateDir, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+
+    const handle = await createMcpHandle(stateDir);
+    const client = await connectInMemoryClient(handle);
+
+    const waitPromise = client.request(
+      {
+        method: "tools/call",
+        params: { name: "cordierite_wait_for_event", arguments: { name: "target", timeoutMs: 5000 } },
+      },
+      CallToolResultSchema,
+    );
+
+    const otherEmitted = waitForEvent(daemon, "app_event");
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "not-it", ts: Date.now() }));
+    await otherEmitted;
+
+    const targetEmitted = waitForEvent(daemon, "app_event");
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "target", payload: { ok: true }, ts: Date.now() }));
+    await targetEmitted;
+
+    const result = await waitPromise;
+    expect(result.isError).not.toBe(true);
+    const data = result.structuredContent as { name: string; payload: { ok: boolean } };
+    expect(data.name).toBe("target");
+    expect(data.payload).toEqual({ ok: true });
+
+    app.socket.close();
+  }, 10_000);
+
+  test("cordierite_wait_for_event rejects with tool_timeout when nothing matches in time", async () => {
+    const { daemon, stateDir, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+
+    const handle = await createMcpHandle(stateDir);
+    const client = await connectInMemoryClient(handle);
+
+    const result = await client.request(
+      {
+        method: "tools/call",
+        params: { name: "cordierite_wait_for_event", arguments: { selector: app.alias, name: "never-arrives", timeoutMs: 300 } },
+      },
+      CallToolResultSchema,
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.content as Array<{ text: string }>)[0]!.text).toContain("tool_timeout");
+
+    app.socket.close();
   }, 10_000);
 });
 

--- a/packages/cordierite/src/__tests__/mcp-server.integration.test.ts
+++ b/packages/cordierite/src/__tests__/mcp-server.integration.test.ts
@@ -671,6 +671,128 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
 
     app.socket.close();
   }, 10_000);
+
+  test("cordierite_wait_for_event's match filters by shallow payload equality", async () => {
+    const { daemon, stateDir, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+
+    const handle = await createMcpHandle(stateDir);
+    const client = await connectInMemoryClient(handle);
+
+    const waitPromise = client.request(
+      {
+        method: "tools/call",
+        params: { name: "cordierite_wait_for_event", arguments: { name: "screen_changed", match: { screen: "Checkout" }, timeoutMs: 5000 } },
+      },
+      CallToolResultSchema,
+    );
+
+    const nonMatching = waitForEvent(daemon, "app_event");
+    app.socket.send(
+      JSON.stringify({ type: "event", session_id: app.sessionId, name: "screen_changed", payload: { screen: "Home" }, ts: Date.now() }),
+    );
+    await nonMatching;
+
+    const matching = waitForEvent(daemon, "app_event");
+    app.socket.send(
+      JSON.stringify({ type: "event", session_id: app.sessionId, name: "screen_changed", payload: { screen: "Checkout", total: 42 }, ts: Date.now() }),
+    );
+    await matching;
+
+    const result = await waitPromise;
+    expect(result.isError).not.toBe(true);
+    const data = result.structuredContent as { payload: { screen: string; total: number } };
+    expect(data.payload).toEqual({ screen: "Checkout", total: 42 });
+
+    app.socket.close();
+  }, 10_000);
+
+  test("cordierite_wait_for_event rejects match values that could never match (objects/arrays)", async () => {
+    const { stateDir, port, daemon } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+
+    const handle = await createMcpHandle(stateDir);
+    const client = await connectInMemoryClient(handle);
+
+    const result = await client.request(
+      {
+        method: "tools/call",
+        params: { name: "cordierite_wait_for_event", arguments: { name: "x", match: { nested: { a: 1 } } } },
+      },
+      CallToolResultSchema,
+    );
+
+    expect(result.isError).toBe(true);
+    expect((result.content as Array<{ text: string }>)[0]!.text).toContain("invalid_request");
+
+    app.socket.close();
+  });
+
+  test("cordierite_wait_for_event's since skips an already-retained match and waits for a fresh one", async () => {
+    const { daemon, stateDir, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+
+    const first = waitForEvent(daemon, "app_event");
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "ping", payload: { n: 1 }, ts: Date.now() }));
+    await first;
+
+    const handle = await createMcpHandle(stateDir);
+    const client = await connectInMemoryClient(handle);
+
+    const drained = await client.request(
+      { method: "tools/call", params: { name: "cordierite_events", arguments: { selector: app.alias } } },
+      CallToolResultSchema,
+    );
+    const cursor = (drained.structuredContent as { cursor: number }).cursor;
+
+    const waitPromise = client.request(
+      {
+        method: "tools/call",
+        params: { name: "cordierite_wait_for_event", arguments: { name: "ping", since: cursor, timeoutMs: 5000 } },
+      },
+      CallToolResultSchema,
+    );
+
+    // Give the tool a beat to have drained the (empty, since-filtered) backlog and be listening
+    // live before the second `ping` — the earlier one, already covered by `since`, must not resolve it.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const second = waitForEvent(daemon, "app_event");
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "ping", payload: { n: 2 }, ts: Date.now() }));
+    await second;
+
+    const result = await waitPromise;
+    expect(result.isError).not.toBe(true);
+    const data = result.structuredContent as { payload: { n: number } };
+    expect(data.payload).toEqual({ n: 2 });
+
+    app.socket.close();
+  }, 10_000);
+
+  test("cordierite_events rejects a non-integer since/limit and an unknown kind", async () => {
+    const { stateDir } = await startTestDaemon();
+    const handle = await createMcpHandle(stateDir);
+    const client = await connectInMemoryClient(handle);
+
+    const nonIntegerSince = await client.request(
+      { method: "tools/call", params: { name: "cordierite_events", arguments: { since: 1.5 } } },
+      CallToolResultSchema,
+    );
+    expect(nonIntegerSince.isError).toBe(true);
+    expect((nonIntegerSince.content as Array<{ text: string }>)[0]!.text).toContain("invalid_request");
+
+    const zeroLimit = await client.request(
+      { method: "tools/call", params: { name: "cordierite_events", arguments: { limit: 0 } } },
+      CallToolResultSchema,
+    );
+    expect(zeroLimit.isError).toBe(true);
+
+    const unknownKind = await client.request(
+      { method: "tools/call", params: { name: "cordierite_events", arguments: { kinds: ["not_a_real_kind"] } } },
+      CallToolResultSchema,
+    );
+    expect(unknownKind.isError).toBe(true);
+  });
 });
 
 describe("mcp: cordierite://sessions resource", () => {

--- a/packages/cordierite/src/__tests__/output.test.ts
+++ b/packages/cordierite/src/__tests__/output.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { renderEventLine, renderResult } from "../output.js";
+import { renderEventLine, renderEventsCursorLine, renderResult } from "../output.js";
 import { FIXED_NOW } from "./fixtures.js";
 
 describe("output rendering", () => {
@@ -292,5 +292,18 @@ describe("renderEventLine", () => {
 
     expect(line).toContain("tools_changed");
     expect(line).toContain("pixel-8");
+  });
+});
+
+describe("renderEventsCursorLine", () => {
+  test("NDJSON mode emits a parseable { cursor } object", () => {
+    const line = renderEventsCursorLine(42, { json: true, color: false });
+    expect(JSON.parse(line)).toEqual({ cursor: 42 });
+  });
+
+  test("human mode includes the cursor value and the resume flag", () => {
+    const line = renderEventsCursorLine(42, { json: false, color: false });
+    expect(line).toContain("42");
+    expect(line).toContain("--since 42");
   });
 });

--- a/packages/cordierite/src/__tests__/output.test.ts
+++ b/packages/cordierite/src/__tests__/output.test.ts
@@ -278,7 +278,7 @@ describe("output rendering", () => {
 
 describe("renderEventLine", () => {
   test("NDJSON mode emits parseable, verbatim JSON", () => {
-    const event = { kind: "session_claimed" as const, sessionId: "s1", alias: "pixel-8", ts: 1_700_000_000_000, data: {} };
+    const event = { kind: "session_claimed" as const, sessionId: "s1", alias: "pixel-8", ts: 1_700_000_000_000, data: {}, seq: 1 };
     const line = renderEventLine(event, { json: true, color: false });
 
     expect(JSON.parse(line)).toEqual(event);
@@ -286,7 +286,7 @@ describe("renderEventLine", () => {
 
   test("human mode includes the kind and alias", () => {
     const line = renderEventLine(
-      { kind: "tools_changed", sessionId: "s1", alias: "pixel-8", ts: 1_700_000_000_000, data: { toolCount: 2 } },
+      { kind: "tools_changed", sessionId: "s1", alias: "pixel-8", ts: 1_700_000_000_000, data: { toolCount: 2 }, seq: 1 },
       { json: false, color: false },
     );
 

--- a/packages/cordierite/src/__tests__/tool-invocation.integration.test.ts
+++ b/packages/cordierite/src/__tests__/tool-invocation.integration.test.ts
@@ -620,7 +620,7 @@ describe("events.since", () => {
 
     const appEvents = since.events.filter((event) => event.kind === "app_event");
     expect(appEvents.map((event) => event.data.name)).toEqual(["a", "b"]);
-    expect(since.cursor).toBeGreaterThanOrEqual(appEvents[appEvents.length - 1]!.seq);
+    expect(since.cursor).toBe(appEvents[appEvents.length - 1]!.seq);
 
     // A second pull with `since` set to the first response's cursor sees nothing new.
     const drained = (await rpcCall(daemon.paths.socketPath, "events.since", {
@@ -663,6 +663,95 @@ describe("events.since", () => {
     await expect(
       rpcCall(daemon.paths.socketPath, "events.since", { selector: app.sessionId }),
     ).rejects.toMatchObject({ data: { type: "unknown_session" } });
+  });
+
+  test("no_session and ambiguous_session error types, matching every other selector-taking method", async () => {
+    const { daemon, port } = await startTestDaemon();
+
+    await expect(rpcCall(daemon.paths.socketPath, "events.since", {})).rejects.toMatchObject({
+      data: { type: "no_session" },
+    });
+
+    const appA = await claimApp(daemon, port, "Pixel 8");
+    const appB = await claimApp(daemon, port, "Pixel 8");
+
+    await expect(rpcCall(daemon.paths.socketPath, "events.since", {})).rejects.toMatchObject({
+      data: { type: "ambiguous_session" },
+    });
+
+    appA.socket.close();
+    appB.socket.close();
+  });
+
+  test("limit keeps the oldest N and cursor pages forward, never skipping a retained event", async () => {
+    const { daemon, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+
+    for (const name of ["a", "b", "c"]) {
+      const emitted = waitForEvent(daemon, "app_event");
+      app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name, ts: Date.now() }));
+      await emitted;
+    }
+
+    const first = (await rpcCall(daemon.paths.socketPath, "events.since", {
+      selector: app.alias,
+      kinds: ["app_event"],
+      limit: 1,
+    })) as { events: Array<{ data: { name: string } }>; cursor: number };
+    expect(first.events.map((event) => event.data.name)).toEqual(["a"]);
+
+    const second = (await rpcCall(daemon.paths.socketPath, "events.since", {
+      selector: app.alias,
+      kinds: ["app_event"],
+      since: first.cursor,
+      limit: 1,
+    })) as { events: Array<{ data: { name: string } }>; cursor: number };
+    expect(second.events.map((event) => event.data.name)).toEqual(["b"]);
+
+    const third = (await rpcCall(daemon.paths.socketPath, "events.since", {
+      selector: app.alias,
+      kinds: ["app_event"],
+      since: second.cursor,
+      limit: 1,
+    })) as { events: Array<{ data: { name: string } }> };
+    expect(third.events.map((event) => event.data.name)).toEqual(["c"]);
+
+    app.socket.close();
+  });
+
+  test("tool_call_progress is fanned out live but never retained, so it can't evict app_events", async () => {
+    const { daemon, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+    await snapshotTools(daemon, app, [{ name: "slow" }]);
+
+    const appEventEmitted = waitForEvent(daemon, "app_event");
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "before-progress", ts: Date.now() }));
+    await appEventEmitted;
+
+    app.socket.on("message", (data) => {
+      const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
+
+      if (msg.type === "tool_call") {
+        for (let i = 0; i < 10; i++) {
+          app.socket.send(
+            JSON.stringify({ type: "tool_call_progress", session_id: app.sessionId, id: msg.id, progress: i / 10 }),
+          );
+        }
+        app.socket.send(JSON.stringify({ type: "tool_result", session_id: app.sessionId, id: msg.id, result: "ok" }));
+      }
+    });
+
+    const finished = waitForEvent(daemon, "tool_call_finished");
+    await rpcCall(daemon.paths.socketPath, "tools.call", { selector: app.alias, name: "slow", args: {} });
+    await finished;
+
+    const since = (await rpcCall(daemon.paths.socketPath, "events.since", { selector: app.alias })) as {
+      events: Array<{ kind: string }>;
+    };
+    expect(since.events.some((event) => event.kind === "tool_call_progress")).toBe(false);
+    expect(since.events.some((event) => event.kind === "app_event")).toBe(true);
+
+    app.socket.close();
   });
 });
 

--- a/packages/cordierite/src/__tests__/tool-invocation.integration.test.ts
+++ b/packages/cordierite/src/__tests__/tool-invocation.integration.test.ts
@@ -600,6 +600,72 @@ describe("events.subscribe", () => {
   });
 });
 
+describe("events.since", () => {
+  test("drains retained app_events with no live subscription, and cursor advances", async () => {
+    const { daemon, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+
+    const first = waitForEvent(daemon, "app_event");
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "a", ts: Date.now() }));
+    await first;
+
+    const second = waitForEvent(daemon, "app_event");
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "b", ts: Date.now() }));
+    await second;
+
+    const since = (await rpcCall(daemon.paths.socketPath, "events.since", { selector: app.alias })) as {
+      events: Array<{ kind: string; seq: number; data: { name: string } }>;
+      cursor: number;
+    };
+
+    const appEvents = since.events.filter((event) => event.kind === "app_event");
+    expect(appEvents.map((event) => event.data.name)).toEqual(["a", "b"]);
+    expect(since.cursor).toBeGreaterThanOrEqual(appEvents[appEvents.length - 1]!.seq);
+
+    // A second pull with `since` set to the first response's cursor sees nothing new.
+    const drained = (await rpcCall(daemon.paths.socketPath, "events.since", {
+      selector: app.alias,
+      since: since.cursor,
+    })) as { events: unknown[] };
+    expect(drained.events).toEqual([]);
+
+    app.socket.close();
+  });
+
+  test("selector defaults to the sole active/suspended session, matching sessions.describe", async () => {
+    const { daemon, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+
+    const emitted = waitForEvent(daemon, "app_event");
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "solo", ts: Date.now() }));
+    await emitted;
+
+    const since = (await rpcCall(daemon.paths.socketPath, "events.since", {})) as {
+      events: Array<{ kind: string; data: { name: string } }>;
+    };
+    expect(since.events.some((event) => event.kind === "app_event" && event.data.name === "solo")).toBe(true);
+
+    app.socket.close();
+  });
+
+  test("a terminal transition discards the retained buffer", async () => {
+    const { daemon, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+
+    const emitted = waitForEvent(daemon, "app_event");
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "before-revoke", ts: Date.now() }));
+    await emitted;
+
+    const revoked = waitForEvent(daemon, "session_revoked");
+    await rpcCall(daemon.paths.socketPath, "sessions.revoke", { selector: app.alias });
+    await revoked;
+
+    await expect(
+      rpcCall(daemon.paths.socketPath, "events.since", { selector: app.sessionId }),
+    ).rejects.toMatchObject({ data: { type: "unknown_session" } });
+  });
+});
+
 describe("tools.* selectors", () => {
   test("unknown_session and ambiguous_session error types", async () => {
     const { daemon, port } = await startTestDaemon();

--- a/packages/cordierite/src/cli/command-options.ts
+++ b/packages/cordierite/src/cli/command-options.ts
@@ -22,6 +22,23 @@ export const parsePositiveIntegerOption = (value: unknown, flagName: string): nu
   return parsed;
 };
 
+/** Parses a `cac`-provided option value into a non-negative integer (0 allowed, unlike
+ * {@link parsePositiveIntegerOption}), or throws a clear `usage_error`. Used by `events --since`,
+ * whose cursor `0` is a meaningful "everything retained" value, not an omission. */
+export const parseNonNegativeIntegerOption = (value: unknown, flagName: string): number | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = typeof value === "number" ? value : Number(value);
+
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+    throw usageError(`"${flagName}" must be a non-negative integer.`);
+  }
+
+  return parsed;
+};
+
 /**
  * Splits the positional args of a command shaped `<command> [selector] <target>` (e.g. `invoke
  * [selector] <tool>`, `tools [selector] <name>`): the last positional is always the required

--- a/packages/cordierite/src/cli/create-cli.ts
+++ b/packages/cordierite/src/cli/create-cli.ts
@@ -41,7 +41,8 @@ export const createCli = () => {
 
   cli
     .command("events [selector]", "Stream session/tool events until interrupted.")
-    .option("--follow", "Accepted for script readability; the default behavior already follows.");
+    .option("--follow", "Accepted for script readability; the default behavior already follows.")
+    .option("--since <cursor>", "One-shot: print events retained since this cursor instead of streaming live.");
 
   cli.command("revoke [selector]", "Revoke a session.");
 

--- a/packages/cordierite/src/cli/dispatch.ts
+++ b/packages/cordierite/src/cli/dispatch.ts
@@ -17,7 +17,7 @@ import { handleRevokeCommand } from "../commands/revoke.js";
 import { handleToolsCommand } from "../commands/tools.js";
 import { resolveStateDir } from "../daemon/state-dir.js";
 import { usageError } from "../errors.js";
-import { renderEventLine } from "../output.js";
+import { renderEventLine, renderEventsCursorLine } from "../output.js";
 import {
   parseJsonInputOption,
   parseNonNegativeIntegerOption,
@@ -184,19 +184,31 @@ export const runCli = async (argv: string[], options: RunCliOptions = {}): Promi
     case "events": {
       const { selector } = splitOptionalSelector(parsedArgs, "events [selector]");
       const since = parseNonNegativeIntegerOption(parsedOptions.since, "--since");
+      const follow = Boolean(parsedOptions.follow);
 
       return executeHostedCommand(
         "events",
-        () =>
-          handleEventsCommand(
+        () => {
+          // Deferred into the wrapped handler (rather than thrown directly in this case body,
+          // matching the codebase's existing lax convention for that) so `executeHostedCommand`'s
+          // own try/catch renders it as a normal usage_error instead of an uncaught rejection.
+          if (since !== undefined && follow) {
+            throw usageError('"--since" is a one-shot pull and cannot be combined with "--follow".');
+          }
+
+          return handleEventsCommand(
             { selector, since },
             {
               stateDir,
               onEvent: (event: EventNotification) => {
                 writers.stdout.write(`${renderEventLine(event, { json, color })}\n`);
               },
+              onCursor: (cursor) => {
+                writers.stdout.write(`${renderEventsCursorLine(cursor, { json, color })}\n`);
+              },
             },
-          ),
+          );
+        },
         {
           ...io,
           reporter: {

--- a/packages/cordierite/src/cli/dispatch.ts
+++ b/packages/cordierite/src/cli/dispatch.ts
@@ -20,6 +20,7 @@ import { usageError } from "../errors.js";
 import { renderEventLine } from "../output.js";
 import {
   parseJsonInputOption,
+  parseNonNegativeIntegerOption,
   parsePositiveIntegerOption,
   splitOptionalSelector,
   splitOptionalSelectorAndTarget,
@@ -182,12 +183,13 @@ export const runCli = async (argv: string[], options: RunCliOptions = {}): Promi
 
     case "events": {
       const { selector } = splitOptionalSelector(parsedArgs, "events [selector]");
+      const since = parseNonNegativeIntegerOption(parsedOptions.since, "--since");
 
       return executeHostedCommand(
         "events",
         () =>
           handleEventsCommand(
-            { selector },
+            { selector, since },
             {
               stateDir,
               onEvent: (event: EventNotification) => {

--- a/packages/cordierite/src/commands/events.ts
+++ b/packages/cordierite/src/commands/events.ts
@@ -4,15 +4,23 @@
  * the one command whose output isn't a single rendered `CliResult` — each event is written as it
  * arrives (NDJSON under `--json`, a human line otherwise) — so it plugs into `executeHostedCommand`
  * with a live reporter that suppresses the default one-shot bootstrap render (`cli/runner.ts`).
+ *
+ * `--since <cursor>` (issue #6) switches to a one-shot mode: a single `events.since` pull instead
+ * of a live subscription. It falls out of the same `EventsHostedResult` shape (each retained event
+ * is written through `onEvent` exactly like a live one) so the CLI plumbing needs no forking — the
+ * "hosted command" here just completes immediately instead of running until interrupted.
  */
 
-import { RPC_METHODS, type EventNotification, type EventsSubscribeResult } from "@cordierite/shared";
+import { RPC_METHODS, type EventNotification, type EventsSinceResult, type EventsSubscribeResult } from "@cordierite/shared";
 
 import type { CliResult } from "../cli/result-types.js";
 import { openDaemonStream, type SpawnFn } from "../rpc/client.js";
 
 export type EventsCommandOptions = {
   selector?: string;
+  /** Exclusive lower bound on `EventNotification.seq`; switches this command to a one-shot
+   * `events.since` pull instead of a live `events.subscribe` stream. */
+  since?: number;
 };
 
 export type EventsCommandContext = {
@@ -27,10 +35,38 @@ export type EventsHostedResult = {
   stop: () => void;
 };
 
+const NEVER_RESULT: CliResult<never> = { ok: true, data: undefined as never };
+
+const handleEventsSinceCommand = async (
+  options: EventsCommandOptions,
+  context: EventsCommandContext,
+): Promise<EventsHostedResult> => {
+  const stream = await openDaemonStream({ stateDir: context.stateDir, spawn: context.spawn });
+
+  try {
+    const since = await stream.call<EventsSinceResult>(RPC_METHODS.eventsSince, {
+      selector: options.selector,
+      since: options.since,
+    });
+
+    for (const event of since.events) {
+      context.onEvent(event);
+    }
+  } finally {
+    stream.close();
+  }
+
+  return { result: NEVER_RESULT, completion: Promise.resolve(), stop: () => {} };
+};
+
 export const handleEventsCommand = async (
   options: EventsCommandOptions,
   context: EventsCommandContext,
 ): Promise<EventsHostedResult> => {
+  if (options.since !== undefined) {
+    return handleEventsSinceCommand(options, context);
+  }
+
   const stream = await openDaemonStream({ stateDir: context.stateDir, spawn: context.spawn });
 
   try {

--- a/packages/cordierite/src/commands/events.ts
+++ b/packages/cordierite/src/commands/events.ts
@@ -27,6 +27,10 @@ export type EventsCommandContext = {
   stateDir: string;
   spawn?: SpawnFn;
   onEvent: (event: EventNotification) => void;
+  /** `--since` mode only: called once with the pull's resulting cursor, so a scripted caller
+   * doesn't have to reconstruct it by maxing `seq` over the printed lines (impossible when the
+   * response is empty — the whole point of a cursor is knowing where to resume from either way). */
+  onCursor?: (cursor: number) => void;
 };
 
 export type EventsHostedResult = {
@@ -52,6 +56,8 @@ const handleEventsSinceCommand = async (
     for (const event of since.events) {
       context.onEvent(event);
     }
+
+    context.onCursor?.(since.cursor);
   } finally {
     stream.close();
   }
@@ -108,7 +114,7 @@ export const handleEventsCommand = async (
   return {
     // Never rendered: the reporter passed to `executeHostedCommand` suppresses the bootstrap
     // render for this command (see the doc comment above).
-    result: { ok: true, data: undefined as never },
+    result: NEVER_RESULT,
     completion,
     stop,
   };

--- a/packages/cordierite/src/daemon/config.ts
+++ b/packages/cordierite/src/daemon/config.ts
@@ -29,6 +29,9 @@ export type CordieriteConfig = {
   graceSeconds: number;
   linkTtlSeconds: number;
   keepaliveIntervalSeconds: number;
+  /** Max retained `app_event`/etc. events per session (ARCHITECTURE.md §5's `events.since`
+   * retention buffer); default 256. */
+  eventBufferSize: number;
   policy: CordieritePolicyConfig;
   /** Operator override for advertised-address detection (daemon/address.ts); undefined = auto-detect. */
   advertisedIp?: string;
@@ -48,6 +51,7 @@ const KNOWN_TOP_LEVEL_KEYS = new Set<string>([
   "graceSeconds",
   "linkTtlSeconds",
   "keepaliveIntervalSeconds",
+  "eventBufferSize",
   "policy",
   "advertisedIp",
   "scheme",
@@ -105,6 +109,7 @@ export const defaultConfig = (paths: StateDirPaths): CordieriteConfig => {
     graceSeconds: 600,
     linkTtlSeconds: 300,
     keepaliveIntervalSeconds: 15,
+    eventBufferSize: 256,
     policy: {
       default: "allow",
       destructive: "allow",
@@ -175,6 +180,10 @@ export const loadConfig = async (
       parsed.keepaliveIntervalSeconds,
       "keepaliveIntervalSeconds",
     );
+  }
+
+  if (parsed.eventBufferSize !== undefined) {
+    config.eventBufferSize = requirePositiveInteger(parsed.eventBufferSize, "eventBufferSize");
   }
 
   if (parsed.policy !== undefined) {

--- a/packages/cordierite/src/daemon/daemon.ts
+++ b/packages/cordierite/src/daemon/daemon.ts
@@ -18,6 +18,8 @@ import {
   type ErrorType,
   type DaemonShutdownResult,
   type DaemonStatusResult,
+  type EventsSinceParams,
+  type EventsSinceResult,
   type EventsSubscribeParams,
   type EventsSubscribeResult,
   type LinkCreateParams,
@@ -211,6 +213,46 @@ const asEventsSubscribeParams = (params: unknown): EventsSubscribeParams => {
   return { sessionSelector: sessionSelector as string | undefined, kinds };
 };
 
+const asEventsSinceParams = (params: unknown): EventsSinceParams => {
+  const record = asRecordParams(params);
+
+  const selector = record.selector;
+
+  if (selector !== undefined && typeof selector !== "string") {
+    throw new RpcApplicationError("invalid_request", '"selector" must be a string.');
+  }
+
+  const since = record.since;
+
+  if (since !== undefined && (typeof since !== "number" || !Number.isInteger(since) || since < 0)) {
+    throw new RpcApplicationError("invalid_request", '"since" must be a non-negative integer.');
+  }
+
+  const kindsRaw = record.kinds;
+  let kinds: EventKind[] | undefined;
+
+  if (kindsRaw !== undefined) {
+    if (!Array.isArray(kindsRaw) || !kindsRaw.every((kind) => typeof kind === "string" && KNOWN_EVENT_KINDS.has(kind))) {
+      throw new RpcApplicationError("invalid_request", '"kinds" must be an array of known event kinds.');
+    }
+
+    kinds = kindsRaw as EventKind[];
+  }
+
+  const limit = record.limit;
+
+  if (limit !== undefined && (typeof limit !== "number" || !Number.isInteger(limit) || limit <= 0)) {
+    throw new RpcApplicationError("invalid_request", '"limit" must be a positive integer.');
+  }
+
+  return {
+    selector: selector as string | undefined,
+    since: since as number | undefined,
+    kinds,
+    limit: limit as number | undefined,
+  };
+};
+
 const asLinkCreateParams = (params: unknown): LinkCreateParams => {
   if (params === undefined || params === null) {
     return {};
@@ -291,7 +333,7 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
       },
     });
 
-    eventBus = createEventBus(clock);
+    eventBus = createEventBus({ clock, bufferSize: config.eventBufferSize });
     const activeEventBus = eventBus;
     const detectAddress =
       options.detectAddress ??
@@ -529,6 +571,16 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
           } satisfies EventSubscription;
 
           return { ok: true };
+        },
+        [RPC_METHODS.eventsSince]: (params): EventsSinceResult => {
+          const { selector, since, kinds, limit } = asEventsSinceParams(params);
+          // Resolved the same way as every other selector-taking method (`sessions.describe`,
+          // `tools.list`): defaults to the sole active/suspended session, errors on ambiguity, and
+          // works for a suspended session too — a suspended app's already-retained events are still
+          // fair game to drain.
+          const resolved = activeSessionManager.describe(selector);
+
+          return activeEventBus.since(resolved.sessionId, { since, kinds, limit });
         },
       },
     });

--- a/packages/cordierite/src/daemon/daemon.ts
+++ b/packages/cordierite/src/daemon/daemon.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   RPC_METHODS,
+  EVENT_KINDS,
   type EventKind,
   type ErrorType,
   type DaemonShutdownResult,
@@ -49,23 +50,8 @@ import { createSessionManager, type SessionManager } from "./sessions.js";
 import { ensureStateDir, getSocketPath, getStateDirPaths, type StateDirPaths } from "./state-dir.js";
 import { createTlsManager, toAgentEndpoint, type TlsManager } from "./tls.js";
 
-/** Runtime mirror of the shared `EventKind` union (ARCHITECTURE.md §5), used to validate
- * `events.subscribe`'s `kinds` filter — the shared package only exports the type. */
-const KNOWN_EVENT_KINDS: ReadonlySet<string> = new Set<EventKind>([
-  "daemon_started",
-  "link_created",
-  "link_expired",
-  "session_claimed",
-  "session_suspended",
-  "session_resumed",
-  "session_revoked",
-  "session_expired",
-  "tools_changed",
-  "app_event",
-  "tool_call_started",
-  "tool_call_progress",
-  "tool_call_finished",
-]);
+/** Used to validate `events.subscribe`/`events.since`'s `kinds` filter. */
+const KNOWN_EVENT_KINDS: ReadonlySet<string> = new Set<EventKind>(EVENT_KINDS);
 
 /** Per-connection `events.subscribe` state, stashed in `RpcConnection.state`. */
 type EventSubscription = {

--- a/packages/cordierite/src/daemon/event-bus.ts
+++ b/packages/cordierite/src/daemon/event-bus.ts
@@ -4,12 +4,14 @@
  * per-session retention ring buffer, and must never let a throwing subscriber take down the daemon
  * or another subscriber.
  *
- * Retention (issue #6): every session-scoped event (`sessionId` set) is appended to a per-session
- * ring buffer with a monotonically increasing `seq`, capped at `bufferSize` entries (oldest
- * dropped first). A session's buffer is discarded the moment it emits a terminal event
- * (`session_expired` / `session_revoked`) — "terminal states free the alias" (sessions.ts) applies
- * to retained events too, matching "no persisted history" (ARCHITECTURE.md §3/§13). Daemon-wide
- * events (no `sessionId`, e.g. `daemon_started`) are fanned out but never buffered.
+ * Retention (issue #6): every session-scoped event (`sessionId` set), except the high-frequency
+ * kinds in `EXCLUDED_FROM_RETENTION`, is appended to a per-session ring buffer with a
+ * monotonically increasing `seq`, capped at `bufferSize` entries (oldest dropped first). A
+ * session's buffer is discarded the moment it emits a terminal event (`session_expired` /
+ * `session_revoked`) — "terminal states free the alias" (sessions.ts) applies to retained events
+ * too, matching "no persisted history" (ARCHITECTURE.md §3/§13) — or via an explicit `drop()` for
+ * the pending-link discard paths that never reach one of those event kinds. Daemon-wide events (no
+ * `sessionId`, e.g. `daemon_started`) are fanned out but never buffered.
  */
 
 import type { EventKind, EventNotification } from "@cordierite/shared";
@@ -22,6 +24,13 @@ export type EventBusListener = (event: EventNotification) => void;
 
 /** Terminal event kinds whose arrival for a session discards that session's retained buffer. */
 const TERMINAL_EVENT_KINDS: ReadonlySet<EventKind> = new Set<EventKind>(["session_expired", "session_revoked"]);
+
+/** Fanned out live like any other event, but never appended to the retention buffer: a single
+ * chatty `tools.call` can emit far more of these than `bufferSize` allows, which would otherwise
+ * evict every retained `app_event` for the session — defeating the reason the buffer exists.
+ * `tool_call_started`/`tool_call_finished` (one pair per call, not per progress tick) are still
+ * retained. */
+const EXCLUDED_FROM_RETENTION: ReadonlySet<EventKind> = new Set<EventKind>(["tool_call_progress"]);
 
 export type EventsSinceQuery = {
   since?: number;
@@ -40,6 +49,10 @@ export type EventBus = {
   /** Drains the retained buffer for `sessionId`. Returns an empty result (`cursor: 0`) for a
    * session with no retained events (nothing emitted yet, or its buffer already discarded). */
   since: (sessionId: string, query?: EventsSinceQuery) => EventsSinceQueryResult;
+  /** Discards `sessionId`'s retained buffer outright, with no event required. Covers the pending-
+   * link discard paths that never reach a terminal event kind (attempt-limit exceeded, the TTL
+   * free-timer) — `TERMINAL_EVENT_KINDS` only catches the ones that *do* emit one. Idempotent. */
+  drop: (sessionId: string) => void;
 };
 
 export type CreateEventBusOptions = {
@@ -89,7 +102,7 @@ export const createEventBus = (options: CreateEventBusOptions = {}): EventBus =>
           // the session is gone.
           buffers.delete(sessionId);
           cursors.delete(sessionId);
-        } else {
+        } else if (!EXCLUDED_FROM_RETENTION.has(notification.kind)) {
           appendToBuffer(sessionId, notification);
         }
       }
@@ -111,9 +124,12 @@ export const createEventBus = (options: CreateEventBusOptions = {}): EventBus =>
     },
     since: (sessionId, query = {}) => {
       const buffer = buffers.get(sessionId) ?? [];
-      const cursor = cursors.get(sessionId) ?? 0;
+      const sessionCursor = cursors.get(sessionId) ?? 0;
 
-      let events = buffer;
+      // Never hand back the live buffer array itself — `emit()` keeps pushing into it after this
+      // call returns, and a caller that gets `events` by reference (the common case: no filter
+      // narrows it below) would see it mutate underneath it.
+      let events = buffer.slice();
 
       if (query.since !== undefined) {
         events = events.filter((event) => event.seq > query.since!);
@@ -125,10 +141,25 @@ export const createEventBus = (options: CreateEventBusOptions = {}): EventBus =>
       }
 
       if (query.limit !== undefined && events.length > query.limit) {
-        events = events.slice(events.length - query.limit);
+        // Keep the OLDEST N, not the newest: `limit` exists to bound one response, not to skip
+        // ahead — a caller pages forward by re-calling with `since` set to the response's own
+        // `cursor`. Keeping the newest N instead would make that same re-call return the same
+        // window forever, silently and unrecoverably losing whatever `limit` cut off.
+        events = events.slice(0, query.limit);
       }
 
+      // The cursor a caller should resume from: the last event actually returned, so paging
+      // through a `limit`-truncated response with `since: cursor` always advances. Only when
+      // nothing was returned (empty buffer, or every retained event was filtered out) does it fall
+      // back to the session's true high-water mark, so an empty page still lets a caller skip past
+      // events it explicitly filtered out (by `kinds`) rather than re-fetching them forever.
+      const cursor = events.length > 0 ? events[events.length - 1]!.seq : sessionCursor;
+
       return { events, cursor };
+    },
+    drop: (sessionId) => {
+      buffers.delete(sessionId);
+      cursors.delete(sessionId);
     },
   };
 };

--- a/packages/cordierite/src/daemon/event-bus.ts
+++ b/packages/cordierite/src/daemon/event-bus.ts
@@ -1,31 +1,98 @@
 /**
  * Typed in-process event bus (ARCHITECTURE.md §5 event kinds). The RPC layer (for
- * `events.subscribe`) and audit subscribe here; this module only owns fan-out and must
- * never let a throwing subscriber take down the daemon or another subscriber.
+ * `events.subscribe`/`events.since`) and audit subscribe here; this module owns fan-out plus a
+ * per-session retention ring buffer, and must never let a throwing subscriber take down the daemon
+ * or another subscriber.
+ *
+ * Retention (issue #6): every session-scoped event (`sessionId` set) is appended to a per-session
+ * ring buffer with a monotonically increasing `seq`, capped at `bufferSize` entries (oldest
+ * dropped first). A session's buffer is discarded the moment it emits a terminal event
+ * (`session_expired` / `session_revoked`) — "terminal states free the alias" (sessions.ts) applies
+ * to retained events too, matching "no persisted history" (ARCHITECTURE.md §3/§13). Daemon-wide
+ * events (no `sessionId`, e.g. `daemon_started`) are fanned out but never buffered.
  */
 
 import type { EventKind, EventNotification } from "@cordierite/shared";
 
 import type { Clock } from "../cli/types.js";
 
-export type EventBusEmitInput = Omit<EventNotification, "ts"> & { kind: EventKind; ts?: number };
+export type EventBusEmitInput = Omit<EventNotification, "ts" | "seq"> & { kind: EventKind; ts?: number };
 
 export type EventBusListener = (event: EventNotification) => void;
+
+/** Terminal event kinds whose arrival for a session discards that session's retained buffer. */
+const TERMINAL_EVENT_KINDS: ReadonlySet<EventKind> = new Set<EventKind>(["session_expired", "session_revoked"]);
+
+export type EventsSinceQuery = {
+  since?: number;
+  kinds?: EventKind[];
+  limit?: number;
+};
+
+export type EventsSinceQueryResult = {
+  events: EventNotification[];
+  cursor: number;
+};
 
 export type EventBus = {
   emit: (event: EventBusEmitInput) => void;
   subscribe: (listener: EventBusListener) => () => void;
+  /** Drains the retained buffer for `sessionId`. Returns an empty result (`cursor: 0`) for a
+   * session with no retained events (nothing emitted yet, or its buffer already discarded). */
+  since: (sessionId: string, query?: EventsSinceQuery) => EventsSinceQueryResult;
 };
 
-export const createEventBus = (clock: Clock = { now: () => new Date() }): EventBus => {
+export type CreateEventBusOptions = {
+  clock?: Clock;
+  /** Max retained events per session (ARCHITECTURE.md §5's `eventBufferSize`); default 256. */
+  bufferSize?: number;
+};
+
+export const createEventBus = (options: CreateEventBusOptions = {}): EventBus => {
+  const clock = options.clock ?? { now: () => new Date() };
+  const bufferSize = options.bufferSize ?? 256;
+
   const listeners = new Set<EventBusListener>();
+  const buffers = new Map<string, EventNotification[]>();
+  const cursors = new Map<string, number>();
+
+  const appendToBuffer = (sessionId: string, notification: EventNotification): void => {
+    const buffer = buffers.get(sessionId) ?? [];
+    buffer.push(notification);
+
+    if (buffer.length > bufferSize) {
+      buffer.splice(0, buffer.length - bufferSize);
+    }
+
+    buffers.set(sessionId, buffer);
+  };
 
   return {
     emit: (event) => {
+      const sessionId = event.sessionId;
+      const seq = sessionId !== undefined ? (cursors.get(sessionId) ?? 0) + 1 : 0;
+
+      if (sessionId !== undefined) {
+        cursors.set(sessionId, seq);
+      }
+
       const notification: EventNotification = {
         ...event,
         ts: event.ts ?? clock.now().getTime(),
+        seq,
       };
+
+      if (sessionId !== undefined) {
+        if (TERMINAL_EVENT_KINDS.has(notification.kind)) {
+          // The terminal event itself is still delivered live (fan-out below) and reported through
+          // `since`'s `cursor`, but is not retained — nothing can legitimately ask for it again once
+          // the session is gone.
+          buffers.delete(sessionId);
+          cursors.delete(sessionId);
+        } else {
+          appendToBuffer(sessionId, notification);
+        }
+      }
 
       for (const listener of listeners) {
         try {
@@ -41,6 +108,27 @@ export const createEventBus = (clock: Clock = { now: () => new Date() }): EventB
       return () => {
         listeners.delete(listener);
       };
+    },
+    since: (sessionId, query = {}) => {
+      const buffer = buffers.get(sessionId) ?? [];
+      const cursor = cursors.get(sessionId) ?? 0;
+
+      let events = buffer;
+
+      if (query.since !== undefined) {
+        events = events.filter((event) => event.seq > query.since!);
+      }
+
+      if (query.kinds !== undefined) {
+        const kinds = new Set(query.kinds);
+        events = events.filter((event) => kinds.has(event.kind));
+      }
+
+      if (query.limit !== undefined && events.length > query.limit) {
+        events = events.slice(events.length - query.limit);
+      }
+
+      return { events, cursor };
     },
   };
 };

--- a/packages/cordierite/src/daemon/links.ts
+++ b/packages/cordierite/src/daemon/links.ts
@@ -86,6 +86,13 @@ export const createPendingLinkRegistry = (options: PendingLinkRegistryOptions): 
 
     options.timers.clearTimeout(record.timer);
     records.delete(sessionId);
+    // Covers every discard path uniformly, including the ones with no dedicated event kind
+    // (attempt-limit exceeded, the TTL free-timer) — `link_expired`/`session_revoked` also reach
+    // here for the paths that do emit one, so this is a harmless no-op in those cases (the
+    // corresponding event already dropped the buffer, if `event-bus.ts` treats that kind as
+    // terminal) or the only thing that does (issue #6: an unclaimed link must not retain events
+    // forever).
+    options.eventBus.drop(sessionId);
   };
 
   return {

--- a/packages/cordierite/src/mcp/events-tool.ts
+++ b/packages/cordierite/src/mcp/events-tool.ts
@@ -1,0 +1,372 @@
+/**
+ * The built-in `cordierite_events` / `cordierite_wait_for_event` MCP tools (issue #6): a pull
+ * surface over the daemon's `app_event` plumbing (`postEvent()` on the app side, `events.since`'s
+ * per-session retention buffer on the daemon side — see `daemon/event-bus.ts`). MCP is
+ * request/response, so an agent otherwise has no way to observe anything the app pushes.
+ *
+ * `cordierite_wait_for_event` drains the retained buffer for an already-arrived match before
+ * falling back to a live wait, exactly to avoid the race `cordierite_wait_for_session` doesn't
+ * have to worry about (a session is either claimed or it isn't, but an `app_event` can easily fire
+ * between "the agent decides to wait" and "the wait subscription lands"). The buffer read and the
+ * live subscription overlap by design (both start from the same resolved session and the same
+ * `app_event` filter) — events already accounted for by the buffer read are deduped by `seq` so a
+ * late-arriving one over the live channel is never reported twice.
+ */
+
+import {
+  RPC_METHODS,
+  type EventKind,
+  type EventNotification,
+  type EventsSinceResult,
+  type SessionsDescribeResult,
+} from "@cordierite/shared";
+
+import { DaemonRpcError, openDaemonStream, type SpawnFn } from "../rpc/client.js";
+import type { DaemonCall } from "./daemon-tools.js";
+import { McpBuiltinToolError } from "./connect-tool.js";
+
+export const EVENTS_TOOL_NAME = "cordierite_events";
+export const WAIT_FOR_EVENT_TOOL_NAME = "cordierite_wait_for_event";
+
+const DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MS = 120_000;
+/** Kept safely under the 30-minute idle window a stdio MCP server gets before Claude Code aborts a
+ * tool call that has sent neither a response nor a progress notification (issue #6's "Constraint on
+ * the blocking wait tool") — with margin for RPC round-trip and scheduling delay. */
+const MAX_WAIT_FOR_EVENT_TIMEOUT_MS = 25 * 60 * 1000;
+/** How often a progress notification is emitted during a live wait, when the caller supplied a
+ * progress token — informational only (the timeout cap above is what actually keeps the call
+ * within the idle window), but it gives a caller watching progress something to show. */
+const WAIT_FOR_EVENT_PROGRESS_INTERVAL_MS = 60_000;
+
+const KNOWN_EVENT_KINDS = new Set<string>([
+  "daemon_started",
+  "link_created",
+  "link_expired",
+  "session_claimed",
+  "session_suspended",
+  "session_resumed",
+  "session_revoked",
+  "session_expired",
+  "tools_changed",
+  "app_event",
+  "tool_call_started",
+  "tool_call_progress",
+  "tool_call_finished",
+]);
+
+export const EVENTS_TOOL_DESCRIPTOR = {
+  name: EVENTS_TOOL_NAME,
+  description:
+    "Drain events retained in the daemon's per-session ring buffer (ARCHITECTURE.md §5) since a " +
+    "cursor — the pull counterpart to a live subscription, for checking what happened after " +
+    "calling a tool or triggering app behavior. With no selector, targets the sole active/" +
+    "suspended session. Returns { events, cursor }; pass cursor back as since on the next call to " +
+    "avoid re-reading events you've already seen.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      selector: { type: "string" },
+      since: { type: "number", minimum: 0 },
+      kinds: { type: "array", items: { type: "string" } },
+      limit: { type: "number", exclusiveMinimum: 0 },
+    },
+    additionalProperties: false,
+  },
+} as const;
+
+export const WAIT_FOR_EVENT_TOOL_DESCRIPTOR = {
+  name: WAIT_FOR_EVENT_TOOL_NAME,
+  description:
+    "Wait for the connected app to push an event via postEvent(name, payload) matching name (and, " +
+    "if match is given, every one of its keys shallow-equal in the event's payload). Checks " +
+    "already-retained events first, so an event that already fired before this call still resolves " +
+    "immediately. Resolves with { sessionId, alias, name, payload, ts, seq }, or rejects with " +
+    "tool_timeout after timeoutMs (default 120000ms, capped server-side at 1500000ms). A call " +
+    "still running after about two minutes moves to a Claude Code background task, so the result " +
+    "may arrive well after this call returns.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      selector: { type: "string" },
+      name: { type: "string" },
+      match: { type: "object" },
+      timeoutMs: { type: "number", exclusiveMinimum: 0 },
+    },
+    required: ["name"],
+    additionalProperties: false,
+  },
+} as const;
+
+export type EventsToolDeps = {
+  call: DaemonCall;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+
+  return value as Record<string, unknown>;
+};
+
+const asOptionalString = (value: unknown, field: string): string | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "string" || value.length === 0) {
+    throw new McpBuiltinToolError("invalid_request", `"${field}" must be a non-empty string.`);
+  }
+
+  return value;
+};
+
+const asOptionalNonNegativeNumber = (value: unknown, field: string): number | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new McpBuiltinToolError("invalid_request", `"${field}" must be a non-negative number.`);
+  }
+
+  return value;
+};
+
+const asOptionalPositiveNumber = (value: unknown, field: string): number | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new McpBuiltinToolError("invalid_request", `"${field}" must be a positive number.`);
+  }
+
+  return value;
+};
+
+const asOptionalEventKinds = (value: unknown): EventKind[] | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Array.isArray(value) || !value.every((kind) => typeof kind === "string" && KNOWN_EVENT_KINDS.has(kind))) {
+    throw new McpBuiltinToolError("invalid_request", '"kinds" must be an array of known event kinds.');
+  }
+
+  return value as EventKind[];
+};
+
+const asOptionalMatch = (value: unknown): Record<string, unknown> | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new McpBuiltinToolError("invalid_request", '"match" must be a JSON object.');
+  }
+
+  return value as Record<string, unknown>;
+};
+
+export const handleEventsTool = async (rawArgs: unknown, deps: EventsToolDeps): Promise<EventsSinceResult> => {
+  const args = asRecord(rawArgs);
+
+  return deps.call<EventsSinceResult>(RPC_METHODS.eventsSince, {
+    selector: asOptionalString(args.selector, "selector"),
+    since: asOptionalNonNegativeNumber(args.since, "since"),
+    kinds: asOptionalEventKinds(args.kinds),
+    limit: asOptionalPositiveNumber(args.limit, "limit"),
+  });
+};
+
+export type WaitForEventToolDeps = {
+  stateDir: string;
+  spawn?: SpawnFn;
+  /** Present only when the incoming `tools/call` carried a progress token; used to emit periodic
+   * "still waiting" progress notifications during a live wait. */
+  progress?: {
+    token: string | number;
+    sendNotification: (notification: unknown) => Promise<void>;
+  };
+};
+
+export type WaitForEventToolResult = {
+  sessionId: string;
+  alias?: string;
+  name: string;
+  payload: unknown;
+  /** Unix ms. */
+  ts: number;
+  seq: number;
+};
+
+const payloadShallowMatches = (payload: unknown, match: Record<string, unknown>): boolean => {
+  if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+    return false;
+  }
+
+  const record = payload as Record<string, unknown>;
+
+  return Object.entries(match).every(([key, value]) => record[key] === value);
+};
+
+export const handleWaitForEventTool = async (
+  rawArgs: unknown,
+  deps: WaitForEventToolDeps,
+): Promise<WaitForEventToolResult> => {
+  const args = asRecord(rawArgs);
+
+  const selector = asOptionalString(args.selector, "selector");
+  const name = asOptionalString(args.name, "name");
+
+  if (!name) {
+    throw new McpBuiltinToolError("invalid_request", '"name" must be a non-empty string.');
+  }
+
+  const match = asOptionalMatch(args.match);
+  const requestedTimeoutMs = asOptionalPositiveNumber(args.timeoutMs, "timeoutMs") ?? DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MS;
+  const timeoutMs = Math.min(requestedTimeoutMs, MAX_WAIT_FOR_EVENT_TIMEOUT_MS);
+
+  const stream = await openDaemonStream({ stateDir: deps.stateDir, spawn: deps.spawn });
+
+  try {
+    // Resolve the selector to one concrete session up front (same shape as
+    // `handleWaitForSessionTool`) so the buffer drain below and the live subscription target the
+    // exact same session — `events.subscribe`'s own `sessionSelector` has no "sole session" default,
+    // so leaving it unresolved here would silently widen the live half of the wait to every session.
+    let sessionId: string;
+    let alias: string | undefined;
+
+    try {
+      const described = await stream.call<SessionsDescribeResult>(RPC_METHODS.sessionsDescribe, { selector });
+      sessionId = described.sessionId;
+      alias = described.alias;
+    } catch (error) {
+      throw error instanceof DaemonRpcError
+        ? new McpBuiltinToolError("invalid_request", error.message)
+        : error;
+    }
+
+    const toResult = (event: EventNotification): WaitForEventToolResult | undefined => {
+      if (event.kind !== "app_event") {
+        return undefined;
+      }
+
+      const data = event.data as { name?: unknown; payload?: unknown };
+
+      if (data.name !== name) {
+        return undefined;
+      }
+
+      if (match && !payloadShallowMatches(data.payload, match)) {
+        return undefined;
+      }
+
+      return { sessionId, alias, name, payload: data.payload, ts: event.ts, seq: event.seq };
+    };
+
+    // Subscribe before draining the buffer: an `app_event` emitted in the gap between the two calls
+    // below is then guaranteed to appear in the `since` snapshot (it landed on this connection's
+    // socket before the `events.since` request was even sent), never only on the live channel.
+    await stream.call(RPC_METHODS.eventsSubscribe, { sessionSelector: sessionId, kinds: ["app_event"] });
+
+    const since = await stream.call<EventsSinceResult>(RPC_METHODS.eventsSince, {
+      selector: sessionId,
+      kinds: ["app_event"],
+    });
+
+    let highestDrainedSeq = 0;
+
+    for (const event of since.events) {
+      highestDrainedSeq = Math.max(highestDrainedSeq, event.seq);
+      const result = toResult(event);
+
+      if (result) {
+        return result;
+      }
+    }
+
+    return await new Promise<WaitForEventToolResult>((resolve, reject) => {
+      let settled = false;
+
+      const settle = (fn: () => void): void => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        clearTimeout(timer);
+
+        if (progressTimer) {
+          clearInterval(progressTimer);
+        }
+
+        unsubscribeNotification();
+        unsubscribeClose();
+        fn();
+      };
+
+      const timer = setTimeout(() => {
+        settle(() =>
+          reject(
+            new McpBuiltinToolError(
+              "tool_timeout",
+              `Timed out after ${timeoutMs}ms waiting for event "${name}".`,
+            ),
+          ),
+        );
+      }, timeoutMs);
+
+      const startedAt = Date.now();
+      const progressTimer = deps.progress
+        ? setInterval(() => {
+            deps.progress!.sendNotification({
+              method: "notifications/progress",
+              params: {
+                progressToken: deps.progress!.token,
+                progress: Date.now() - startedAt,
+                total: timeoutMs,
+                message: `Still waiting for event "${name}"...`,
+              },
+            }).catch(() => {
+              // A failed progress notification must never abort the wait itself.
+            });
+          }, WAIT_FOR_EVENT_PROGRESS_INTERVAL_MS)
+        : undefined;
+
+      const unsubscribeClose = stream.onClose(() => {
+        settle(() =>
+          reject(
+            new McpBuiltinToolError(
+              "tool_execution_error",
+              `The connection to the Cordierite daemon closed while waiting for event "${name}".`,
+            ),
+          ),
+        );
+      });
+
+      const unsubscribeNotification = stream.onNotification((payload) => {
+        if (settled) {
+          return;
+        }
+
+        const event = payload as EventNotification;
+
+        // Already accounted for by the buffer drain above — the live channel re-delivers it too
+        // (subscription started before the drain), so skip anything not strictly newer.
+        if (event.sessionId === sessionId && event.seq <= highestDrainedSeq) {
+          return;
+        }
+
+        const result = toResult(event);
+
+        if (result) {
+          settle(() => resolve(result));
+        }
+      });
+    });
+  } finally {
+    stream.close();
+  }
+};

--- a/packages/cordierite/src/mcp/events-tool.ts
+++ b/packages/cordierite/src/mcp/events-tool.ts
@@ -7,21 +7,26 @@
  * `cordierite_wait_for_event` drains the retained buffer for an already-arrived match before
  * falling back to a live wait, exactly to avoid the race `cordierite_wait_for_session` doesn't
  * have to worry about (a session is either claimed or it isn't, but an `app_event` can easily fire
- * between "the agent decides to wait" and "the wait subscription lands"). The buffer read and the
- * live subscription overlap by design (both start from the same resolved session and the same
- * `app_event` filter) — events already accounted for by the buffer read are deduped by `seq` so a
- * late-arriving one over the live channel is never reported twice.
+ * between "the agent decides to wait" and "the wait subscription lands"). The live notification
+ * listener is registered *before* the `events.since` drain call is even sent — not merely before
+ * it resolves — because the daemon's response to that call and a subsequent `notify()` for a new
+ * event can arrive in the same socket chunk; `rpc/client.ts` fans a chunk's notification lines out
+ * to whatever listeners exist at the moment it's processed, so a listener added only after `await
+ * stream.call(eventsSince, …)` returns can miss an event that was already in that same chunk.
+ * Arrivals before the drain has been merged into the backlog are buffered, then merged in
+ * (deduped by `seq`) before falling through to the live phase — see `handleWaitForEventTool` below.
  */
 
 import {
   RPC_METHODS,
+  EVENT_KINDS,
   type EventKind,
   type EventNotification,
   type EventsSinceResult,
   type SessionsDescribeResult,
 } from "@cordierite/shared";
 
-import { DaemonRpcError, openDaemonStream, type SpawnFn } from "../rpc/client.js";
+import { openDaemonStream, type SpawnFn } from "../rpc/client.js";
 import type { DaemonCall } from "./daemon-tools.js";
 import { McpBuiltinToolError } from "./connect-tool.js";
 
@@ -38,37 +43,32 @@ const MAX_WAIT_FOR_EVENT_TIMEOUT_MS = 25 * 60 * 1000;
  * within the idle window), but it gives a caller watching progress something to show. */
 const WAIT_FOR_EVENT_PROGRESS_INTERVAL_MS = 60_000;
 
-const KNOWN_EVENT_KINDS = new Set<string>([
-  "daemon_started",
-  "link_created",
-  "link_expired",
-  "session_claimed",
-  "session_suspended",
-  "session_resumed",
-  "session_revoked",
-  "session_expired",
-  "tools_changed",
-  "app_event",
-  "tool_call_started",
-  "tool_call_progress",
-  "tool_call_finished",
-]);
+const KNOWN_EVENT_KINDS = new Set<string>(EVENT_KINDS);
+
+/** Server-side cap on `timeoutMs` (issue #6's "Cap timeoutMs server-side below the idle window
+ * rather than trusting the caller") — a pure function so the cap's boundary behavior is
+ * unit-testable without spinning up a daemon or actually waiting out either bound. */
+export const clampWaitForEventTimeoutMs = (requestedMs: number | undefined): number => {
+  return Math.min(requestedMs ?? DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MS, MAX_WAIT_FOR_EVENT_TIMEOUT_MS);
+};
 
 export const EVENTS_TOOL_DESCRIPTOR = {
   name: EVENTS_TOOL_NAME,
   description:
-    "Drain events retained in the daemon's per-session ring buffer (ARCHITECTURE.md §5) since a " +
-    "cursor — the pull counterpart to a live subscription, for checking what happened after " +
-    "calling a tool or triggering app behavior. With no selector, targets the sole active/" +
-    "suspended session. Returns { events, cursor }; pass cursor back as since on the next call to " +
-    "avoid re-reading events you've already seen.",
+    "Drain events retained in the daemon's per-session ring buffer since a cursor — the pull " +
+    "counterpart to a live subscription, for checking what happened after calling a tool or " +
+    "triggering app behavior. With no selector, targets the sole active/suspended session. " +
+    "Returns { events, cursor }; pass cursor back as since on the next call to avoid re-reading " +
+    "events you've already seen. limit (if given) keeps the OLDEST events in the window and " +
+    "advances cursor only past what was actually returned, so repeated calls page forward through " +
+    "everything retained rather than skipping ahead.",
   inputSchema: {
     type: "object",
     properties: {
       selector: { type: "string" },
-      since: { type: "number", minimum: 0 },
-      kinds: { type: "array", items: { type: "string" } },
-      limit: { type: "number", exclusiveMinimum: 0 },
+      since: { type: "integer", minimum: 0 },
+      kinds: { type: "array", items: { type: "string", enum: EVENT_KINDS } },
+      limit: { type: "integer", exclusiveMinimum: 0 },
     },
     additionalProperties: false,
   },
@@ -78,18 +78,23 @@ export const WAIT_FOR_EVENT_TOOL_DESCRIPTOR = {
   name: WAIT_FOR_EVENT_TOOL_NAME,
   description:
     "Wait for the connected app to push an event via postEvent(name, payload) matching name (and, " +
-    "if match is given, every one of its keys shallow-equal in the event's payload). Checks " +
-    "already-retained events first, so an event that already fired before this call still resolves " +
-    "immediately. Resolves with { sessionId, alias, name, payload, ts, seq }, or rejects with " +
-    "tool_timeout after timeoutMs (default 120000ms, capped server-side at 1500000ms). A call " +
-    "still running after about two minutes moves to a Claude Code background task, so the result " +
-    "may arrive well after this call returns.",
+    "if match is given, every one of its keys strictly-equal — primitives only, not objects/arrays " +
+    "— in the event's payload). Checks already-retained events first, so an event that already " +
+    "fired before this call still resolves immediately; pass since (a cursor from a previous " +
+    "cordierite_events/cordierite_wait_for_event call) to skip events you've already handled and " +
+    "wait only for a new one — omitting it can return an old match instantly on every call. " +
+    "Requires a claimed session to already exist (use cordierite_wait_for_session first if not). " +
+    "Resolves with { sessionId, alias, name, payload, ts, seq }, or rejects with tool_timeout after " +
+    "timeoutMs (default 120000ms, capped server-side at 1500000ms). A call still running after " +
+    "about two minutes moves to a Claude Code background task, so the result may arrive well after " +
+    "this call returns.",
   inputSchema: {
     type: "object",
     properties: {
       selector: { type: "string" },
       name: { type: "string" },
-      match: { type: "object" },
+      match: { type: "object", additionalProperties: { type: ["string", "number", "boolean", "null"] } },
+      since: { type: "integer", minimum: 0 },
       timeoutMs: { type: "number", exclusiveMinimum: 0 },
     },
     required: ["name"],
@@ -121,18 +126,35 @@ const asOptionalString = (value: unknown, field: string): string | undefined => 
   return value;
 };
 
-const asOptionalNonNegativeNumber = (value: unknown, field: string): number | undefined => {
+/** `since`/`limit` mirror the daemon's own `asEventsSinceParams` (`daemon/daemon.ts`), which
+ * requires integers — accepting e.g. `1.5` here would just round-trip to a `DaemonRpcError`
+ * instead of this tool's own clearer `invalid_request`. */
+const asOptionalNonNegativeInteger = (value: unknown, field: string): number | undefined => {
   if (value === undefined) {
     return undefined;
   }
 
-  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-    throw new McpBuiltinToolError("invalid_request", `"${field}" must be a non-negative number.`);
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new McpBuiltinToolError("invalid_request", `"${field}" must be a non-negative integer.`);
   }
 
   return value;
 };
 
+const asOptionalPositiveInteger = (value: unknown, field: string): number | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new McpBuiltinToolError("invalid_request", `"${field}" must be a positive integer.`);
+  }
+
+  return value;
+};
+
+/** `timeoutMs` is not required to be an integer (unlike the daemon's `since`/`limit`) — it's never
+ * forwarded to the daemon verbatim, only used as this process's own `setTimeout` duration. */
 const asOptionalPositiveNumber = (value: unknown, field: string): number | undefined => {
   if (value === undefined) {
     return undefined;
@@ -157,7 +179,15 @@ const asOptionalEventKinds = (value: unknown): EventKind[] | undefined => {
   return value as EventKind[];
 };
 
-const asOptionalMatch = (value: unknown): Record<string, unknown> | undefined => {
+type MatchPrimitive = string | number | boolean | null;
+
+const isMatchPrimitive = (value: unknown): value is MatchPrimitive => {
+  return value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+};
+
+/** `payloadShallowMatches` compares with `===`, so an object/array value here could never equal
+ * anything and would just make the wait time out with no explanation — reject it up front instead. */
+const asOptionalMatch = (value: unknown): Record<string, MatchPrimitive> | undefined => {
   if (value === undefined) {
     return undefined;
   }
@@ -166,7 +196,18 @@ const asOptionalMatch = (value: unknown): Record<string, unknown> | undefined =>
     throw new McpBuiltinToolError("invalid_request", '"match" must be a JSON object.');
   }
 
-  return value as Record<string, unknown>;
+  const record = value as Record<string, unknown>;
+
+  for (const [key, entry] of Object.entries(record)) {
+    if (!isMatchPrimitive(entry)) {
+      throw new McpBuiltinToolError(
+        "invalid_request",
+        `"match.${key}" must be a string, number, boolean, or null (objects/arrays can never match).`,
+      );
+    }
+  }
+
+  return record as Record<string, MatchPrimitive>;
 };
 
 export const handleEventsTool = async (rawArgs: unknown, deps: EventsToolDeps): Promise<EventsSinceResult> => {
@@ -174,9 +215,9 @@ export const handleEventsTool = async (rawArgs: unknown, deps: EventsToolDeps): 
 
   return deps.call<EventsSinceResult>(RPC_METHODS.eventsSince, {
     selector: asOptionalString(args.selector, "selector"),
-    since: asOptionalNonNegativeNumber(args.since, "since"),
+    since: asOptionalNonNegativeInteger(args.since, "since"),
     kinds: asOptionalEventKinds(args.kinds),
-    limit: asOptionalPositiveNumber(args.limit, "limit"),
+    limit: asOptionalPositiveInteger(args.limit, "limit"),
   });
 };
 
@@ -201,7 +242,7 @@ export type WaitForEventToolResult = {
   seq: number;
 };
 
-const payloadShallowMatches = (payload: unknown, match: Record<string, unknown>): boolean => {
+const payloadShallowMatches = (payload: unknown, match: Record<string, MatchPrimitive>): boolean => {
   if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
     return false;
   }
@@ -225,8 +266,8 @@ export const handleWaitForEventTool = async (
   }
 
   const match = asOptionalMatch(args.match);
-  const requestedTimeoutMs = asOptionalPositiveNumber(args.timeoutMs, "timeoutMs") ?? DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MS;
-  const timeoutMs = Math.min(requestedTimeoutMs, MAX_WAIT_FOR_EVENT_TIMEOUT_MS);
+  const since = asOptionalNonNegativeInteger(args.since, "since");
+  const timeoutMs = clampWaitForEventTimeoutMs(asOptionalPositiveNumber(args.timeoutMs, "timeoutMs"));
 
   const stream = await openDaemonStream({ stateDir: deps.stateDir, spawn: deps.spawn });
 
@@ -235,21 +276,14 @@ export const handleWaitForEventTool = async (
     // `handleWaitForSessionTool`) so the buffer drain below and the live subscription target the
     // exact same session — `events.subscribe`'s own `sessionSelector` has no "sole session" default,
     // so leaving it unresolved here would silently widen the live half of the wait to every session.
-    let sessionId: string;
-    let alias: string | undefined;
-
-    try {
-      const described = await stream.call<SessionsDescribeResult>(RPC_METHODS.sessionsDescribe, { selector });
-      sessionId = described.sessionId;
-      alias = described.alias;
-    } catch (error) {
-      throw error instanceof DaemonRpcError
-        ? new McpBuiltinToolError("invalid_request", error.message)
-        : error;
-    }
+    // A `DaemonRpcError` (no_session/ambiguous_session/unknown_session) propagates unchanged —
+    // `toolErrorContentFromError` (mcp/server.ts) already maps it to its precise `data.type`.
+    const described = await stream.call<SessionsDescribeResult>(RPC_METHODS.sessionsDescribe, { selector });
+    const sessionId = described.sessionId;
+    const alias = described.alias;
 
     const toResult = (event: EventNotification): WaitForEventToolResult | undefined => {
-      if (event.kind !== "app_event") {
+      if (event.kind !== "app_event" || event.sessionId !== sessionId) {
         return undefined;
       }
 
@@ -266,106 +300,147 @@ export const handleWaitForEventTool = async (
       return { sessionId, alias, name, payload: data.payload, ts: event.ts, seq: event.seq };
     };
 
-    // Subscribe before draining the buffer: an `app_event` emitted in the gap between the two calls
-    // below is then guaranteed to appear in the `since` snapshot (it landed on this connection's
-    // socket before the `events.since` request was even sent), never only on the live channel.
-    await stream.call(RPC_METHODS.eventsSubscribe, { sessionSelector: sessionId, kinds: ["app_event"] });
+    // The notification listener is registered *before* `events.subscribe` is even sent, and starts
+    // buffering into `earlyEvents` rather than resolving anything (`liveHandler` is still null) —
+    // see the module doc comment for why: the `events.since` response and a `notify()` for a
+    // brand-new event can arrive in the same socket chunk, and a listener added only after `await`ing
+    // that response has already missed a notification line from that same chunk.
+    let liveHandler: ((event: EventNotification) => void) | null = null;
+    const earlyEvents: EventNotification[] = [];
 
-    const since = await stream.call<EventsSinceResult>(RPC_METHODS.eventsSince, {
-      selector: sessionId,
-      kinds: ["app_event"],
+    const unsubscribeNotification = stream.onNotification((payload) => {
+      const event = payload as EventNotification;
+
+      if (liveHandler) {
+        liveHandler(event);
+      } else {
+        earlyEvents.push(event);
+      }
     });
 
-    let highestDrainedSeq = 0;
+    let unsubscribeClose = (): void => {};
 
-    for (const event of since.events) {
-      highestDrainedSeq = Math.max(highestDrainedSeq, event.seq);
-      const result = toResult(event);
+    try {
+      await stream.call(RPC_METHODS.eventsSubscribe, { sessionSelector: sessionId, kinds: ["app_event"] });
 
-      if (result) {
-        return result;
-      }
-    }
-
-    return await new Promise<WaitForEventToolResult>((resolve, reject) => {
-      let settled = false;
-
-      const settle = (fn: () => void): void => {
-        if (settled) {
-          return;
-        }
-
-        settled = true;
-        clearTimeout(timer);
-
-        if (progressTimer) {
-          clearInterval(progressTimer);
-        }
-
-        unsubscribeNotification();
-        unsubscribeClose();
-        fn();
-      };
-
-      const timer = setTimeout(() => {
-        settle(() =>
-          reject(
-            new McpBuiltinToolError(
-              "tool_timeout",
-              `Timed out after ${timeoutMs}ms waiting for event "${name}".`,
-            ),
-          ),
-        );
-      }, timeoutMs);
-
-      const startedAt = Date.now();
-      const progressTimer = deps.progress
-        ? setInterval(() => {
-            deps.progress!.sendNotification({
-              method: "notifications/progress",
-              params: {
-                progressToken: deps.progress!.token,
-                progress: Date.now() - startedAt,
-                total: timeoutMs,
-                message: `Still waiting for event "${name}"...`,
-              },
-            }).catch(() => {
-              // A failed progress notification must never abort the wait itself.
-            });
-          }, WAIT_FOR_EVENT_PROGRESS_INTERVAL_MS)
-        : undefined;
-
-      const unsubscribeClose = stream.onClose(() => {
-        settle(() =>
-          reject(
-            new McpBuiltinToolError(
-              "tool_execution_error",
-              `The connection to the Cordierite daemon closed while waiting for event "${name}".`,
-            ),
-          ),
-        );
+      const sinceResult = await stream.call<EventsSinceResult>(RPC_METHODS.eventsSince, {
+        selector: sessionId,
+        since,
+        kinds: ["app_event"],
       });
 
-      const unsubscribeNotification = stream.onNotification((payload) => {
-        if (settled) {
-          return;
+      // Merge the retained backlog with whatever arrived on the live channel while the two calls
+      // above were in flight, deduped by `seq` (the same event can legitimately show up in both:
+      // the daemon buffers before it fans out, so a late-drained event and an in-flight live one can
+      // be the same notification). Everything from here to `liveHandler = …` below is synchronous —
+      // no `await` — so nothing can arrive on the socket and be missed in the gap.
+      const seenSeqs = new Set<number>();
+      const backlog: EventNotification[] = [];
+
+      for (const event of [...sinceResult.events, ...earlyEvents]) {
+        if (event.sessionId === sessionId && !seenSeqs.has(event.seq)) {
+          seenSeqs.add(event.seq);
+          backlog.push(event);
         }
+      }
 
-        const event = payload as EventNotification;
+      backlog.sort((a, b) => a.seq - b.seq);
 
-        // Already accounted for by the buffer drain above — the live channel re-delivers it too
-        // (subscription started before the drain), so skip anything not strictly newer.
-        if (event.sessionId === sessionId && event.seq <= highestDrainedSeq) {
-          return;
-        }
-
+      for (const event of backlog) {
         const result = toResult(event);
 
         if (result) {
-          settle(() => resolve(result));
+          return result;
         }
+      }
+
+      // Nothing matched yet: the cursor to resume live from is the last event actually considered
+      // (backlog's own scan already covers everything since.events + earlyEvents jointly saw), or —
+      // if nothing was retained/arrived at all — `events.since`'s own cursor, which (per
+      // `event-bus.ts`'s `since()`) already reflects the session's true high-water mark even when
+      // the `kinds` filter matched nothing.
+      const highestConsideredSeq = backlog.length > 0 ? backlog[backlog.length - 1]!.seq : sinceResult.cursor;
+
+      return await new Promise<WaitForEventToolResult>((resolve, reject) => {
+        let settled = false;
+
+        const settle = (fn: () => void): void => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          clearTimeout(timer);
+
+          if (progressTimer) {
+            clearInterval(progressTimer);
+          }
+
+          liveHandler = null;
+          fn();
+        };
+
+        const timer = setTimeout(() => {
+          settle(() =>
+            reject(
+              new McpBuiltinToolError(
+                "tool_timeout",
+                `Timed out after ${timeoutMs}ms waiting for event "${name}".`,
+              ),
+            ),
+          );
+        }, timeoutMs);
+
+        const startedAt = Date.now();
+        const progressTimer = deps.progress
+          ? setInterval(() => {
+              deps.progress!.sendNotification({
+                method: "notifications/progress",
+                params: {
+                  progressToken: deps.progress!.token,
+                  progress: Date.now() - startedAt,
+                  total: timeoutMs,
+                  message: `Still waiting for event "${name}"...`,
+                },
+              }).catch(() => {
+                // A failed progress notification must never abort the wait itself.
+              });
+            }, WAIT_FOR_EVENT_PROGRESS_INTERVAL_MS)
+          : undefined;
+
+        unsubscribeClose = stream.onClose(() => {
+          settle(() =>
+            reject(
+              new McpBuiltinToolError(
+                "tool_execution_error",
+                `The connection to the Cordierite daemon closed while waiting for event "${name}".`,
+              ),
+            ),
+          );
+        });
+
+        // From here on, every notification goes straight to this handler instead of `earlyEvents` —
+        // assigned synchronously (no `await` since the backlog scan above), so nothing is missed.
+        liveHandler = (event) => {
+          if (settled) {
+            return;
+          }
+
+          if (event.sessionId === sessionId && event.seq <= highestConsideredSeq) {
+            return;
+          }
+
+          const result = toResult(event);
+
+          if (result) {
+            settle(() => resolve(result));
+          }
+        };
       });
-    });
+    } finally {
+      unsubscribeNotification();
+      unsubscribeClose();
+    }
   } finally {
     stream.close();
   }

--- a/packages/cordierite/src/mcp/server.ts
+++ b/packages/cordierite/src/mcp/server.ts
@@ -38,6 +38,14 @@ import {
   WAIT_FOR_SESSION_TOOL_NAME,
 } from "./connect-tool.js";
 import { fetchEffectiveTools } from "./daemon-tools.js";
+import {
+  EVENTS_TOOL_DESCRIPTOR,
+  EVENTS_TOOL_NAME,
+  handleEventsTool,
+  handleWaitForEventTool,
+  WAIT_FOR_EVENT_TOOL_DESCRIPTOR,
+  WAIT_FOR_EVENT_TOOL_NAME,
+} from "./events-tool.js";
 import { toMcpTool } from "./tool-mapping.js";
 import { findNamespacedTool, namespacedToolsSnapshotKey, type NamespacedTool } from "./tool-namespace.js";
 
@@ -203,7 +211,13 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
     const tools = await fetchEffectiveTools(stream.call);
 
     return {
-      tools: [CONNECT_TOOL_DESCRIPTOR, WAIT_FOR_SESSION_TOOL_DESCRIPTOR, ...tools.map(toMcpTool)],
+      tools: [
+        CONNECT_TOOL_DESCRIPTOR,
+        WAIT_FOR_SESSION_TOOL_DESCRIPTOR,
+        EVENTS_TOOL_DESCRIPTOR,
+        WAIT_FOR_EVENT_TOOL_DESCRIPTOR,
+        ...tools.map(toMcpTool),
+      ],
     };
   });
 
@@ -222,6 +236,23 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
       if (name === WAIT_FOR_SESSION_TOOL_NAME) {
         return toolSuccessContent(
           await handleWaitForSessionTool(args, { stateDir: options.stateDir, spawn: options.spawn }),
+        );
+      }
+
+      if (name === EVENTS_TOOL_NAME) {
+        return toolSuccessContent(await handleEventsTool(args, { call: stream.call }));
+      }
+
+      if (name === WAIT_FOR_EVENT_TOOL_NAME) {
+        return toolSuccessContent(
+          await handleWaitForEventTool(args, {
+            stateDir: options.stateDir,
+            spawn: options.spawn,
+            progress:
+              progressToken !== undefined
+                ? { token: progressToken, sendNotification: extra.sendNotification as (notification: unknown) => Promise<void> }
+                : undefined,
+          }),
         );
       }
 

--- a/packages/cordierite/src/output.ts
+++ b/packages/cordierite/src/output.ts
@@ -380,3 +380,15 @@ export const renderEventLine = (
 
   return `${colors.dim(timestamp)} ${colors.green(event.kind)}${target ? ` ${target}` : ""}${dataSuffix}`;
 };
+
+/** Renders the trailing cursor line for `cordierite events --since` (issue #6): NDJSON under
+ * `--json` so a scripted caller can parse the resume point without maxing `seq` over the printed
+ * events (impossible when the response is empty), a human note otherwise. */
+export const renderEventsCursorLine = (cursor: number, options: { json: boolean; color: boolean }): string => {
+  if (options.json) {
+    return JSON.stringify({ cursor });
+  }
+
+  const colors = pc.createColors(options.color);
+  return colors.dim(`cursor: ${cursor} (pass --since ${cursor} to resume from here)`);
+};

--- a/packages/shared/src/domains/rpc.ts
+++ b/packages/shared/src/domains/rpc.ts
@@ -13,6 +13,7 @@ export const RPC_METHODS = {
   toolsList: "tools.list",
   toolsCall: "tools.call",
   eventsSubscribe: "events.subscribe",
+  eventsSince: "events.since",
 } as const;
 
 export type RpcMethod = (typeof RPC_METHODS)[keyof typeof RPC_METHODS];
@@ -170,6 +171,40 @@ export type EventNotification = {
   /** Unix ms. */
   ts: number;
   data: unknown;
+  /**
+   * Monotonically increasing per-session cursor (ARCHITECTURE.md §5), assigned by the daemon-side
+   * retention buffer at emit time. Only meaningful for session-scoped events (`sessionId` set) —
+   * daemon-wide events (e.g. `daemon_started`) are never buffered and carry `seq: 0`. Pass the
+   * highest `seq` seen back into `events.since`'s `since` to resume after it.
+   */
+  seq: number;
+};
+
+// --- events.since ---
+
+/** Pulls events retained in the daemon's per-session ring buffer (ARCHITECTURE.md §5) — the
+ * request/response counterpart to `events.subscribe`'s push model, for callers (MCP tools, a
+ * scripted `cordierite events --since`) that ask "what happened?" after the fact instead of
+ * listening live. */
+export type EventsSinceParams = {
+  /** Session id or alias; omitted selects the sole active/suspended session (same default as
+   * `SessionSelectorParams`). */
+  selector?: string;
+  /** Exclusive lower bound on `EventNotification.seq`; omitted returns the whole retained buffer
+   * (oldest first, subject to `limit`). */
+  since?: number;
+  kinds?: EventKind[];
+  /** Caps the number of events returned (newest-first truncation); omitted returns everything
+   * matching `since`/`kinds` up to the buffer's own retention limit. */
+  limit?: number;
+};
+
+export type EventsSinceResult = {
+  events: EventNotification[];
+  /** The highest `seq` currently retained for this session (not just among the returned events),
+   * so a caller can pass it straight back into the next `since` even when `limit` truncated the
+   * response or nothing new had happened. */
+  cursor: number;
 };
 
 // --- JSON-RPC 2.0 error shape ---

--- a/packages/shared/src/domains/rpc.ts
+++ b/packages/shared/src/domains/rpc.ts
@@ -141,20 +141,27 @@ export type ToolsCallResult = {
 
 // --- events.subscribe ---
 
-export type EventKind =
-  | "daemon_started"
-  | "link_created"
-  | "link_expired"
-  | "session_claimed"
-  | "session_suspended"
-  | "session_resumed"
-  | "session_revoked"
-  | "session_expired"
-  | "tools_changed"
-  | "app_event"
-  | "tool_call_started"
-  | "tool_call_progress"
-  | "tool_call_finished";
+/** The single source of truth for the `EventKind` union below — a `const` array (not just a type)
+ * so runtime validators (the daemon's `events.subscribe`/`events.since` param parsing, the MCP
+ * `cordierite_events`/`cordierite_wait_for_event` tool schemas) can derive their allow-list from it
+ * instead of hand-maintaining a second copy that can silently drift from this type. */
+export const EVENT_KINDS = [
+  "daemon_started",
+  "link_created",
+  "link_expired",
+  "session_claimed",
+  "session_suspended",
+  "session_resumed",
+  "session_revoked",
+  "session_expired",
+  "tools_changed",
+  "app_event",
+  "tool_call_started",
+  "tool_call_progress",
+  "tool_call_finished",
+] as const;
+
+export type EventKind = (typeof EVENT_KINDS)[number];
 
 export type EventsSubscribeParams = {
   sessionSelector?: string;


### PR DESCRIPTION
## Summary

Implements #6: `postEvent()` → `app_event` was fully wired on the transport and control plane, but the only consumer was a human running `cordierite events --follow`. MCP is strictly request/response, so an agent had no way to observe an app-pushed event at all. This adds a daemon-side retention buffer and a pull surface on top of it.

- **Per-session ring buffer** (`daemon/event-bus.ts`): retains the last `eventBufferSize` events per session (config-driven, default 256; `tool_call_progress` excluded — a single chatty call could otherwise evict every retained `app_event`), each stamped with a `seq` that increases monotonically per session. Discarded on a terminal event (`session_expired`/`session_revoked`) or via an explicit `drop()` for pending-link discard paths that never reach one of those (attempt-limit exceeded, TTL free-timer) — otherwise an unclaimed link would leak buffer entries for the daemon's lifetime.
- **`events.since` RPC**: `{ selector?, since?, kinds?, limit? } → { events, cursor }`. `limit` keeps the *oldest* N so paging forward with the returned `cursor` never skips anything. `cordierite events --since <cursor>` gets a one-shot pull mode for free, with a trailing cursor line so a script doesn't have to reconstruct it from the events themselves.
- **Two new built-in MCP tools** (`mcp/events-tool.ts`): `cordierite_events` is a thin proxy over `events.since`; `cordierite_wait_for_event` drains the retained backlog for an already-arrived match before falling back to a live wait — closing the same race `cordierite_wait_for_session` doesn't have to worry about. `timeoutMs` is capped server-side well under the 30-minute stdio idle window Claude Code enforces.

## Review

Ran an independent Opus review against the issue spec before opening this PR. It found 5 must-fix bugs (a real race where a coalesced socket chunk could silently drop a notification, a pending-link memory leak, an unrecoverable `limit`/`cursor` interaction, a missing `since` on `wait_for_event` that made repeat waits return stale matches forever, and a buffer-aliasing bug) and 7 should-fix issues (error-type downgrading, looser MCP-side validation than the daemon's, `match` accepting values that could never match, `tool_call_progress` flooding retention, a duplicated event-kind allow-list, `--since`/`--follow` not being mutually exclusive). All of those are fixed in the second commit, with new test coverage for each.

## Test plan
- [x] `pnpm -F @cordierite/shared build && pnpm -F cordierite build && pnpm -F cordierite typecheck` — clean
- [x] `pnpm -F cordierite test` — 274/274 passing (new: ring-buffer/cursor/paging semantics, the pending-link leak fix, `tool_call_progress` exclusion, `match` validation, the dedupe path on `cordierite_wait_for_event`, the `timeoutMs` clamp, `events.since` error paths, CLI `--since` end-to-end)
- [x] `pnpm -F @cordierite/shared test` — 115/115 passing
- [x] `pnpm turbo run lint` — no new errors/warnings
- [x] docs updated: `docs/ARCHITECTURE.md` §5 (RPC table, retention semantics, config key, MCP tools), `docs/PROTOCOL.md` §4/§8, `packages/cordierite/README.md`

Closes #6.