### PR TITLE
fix: end the session on a terminal 1008 close instead of retrying until grace

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -348,13 +348,21 @@ Client behavior:
   which anchors `grace_s`; ack time does not. On socket loss, auto-reconnect with
   exponential backoff (0.5 s → 30 s cap, jitter) while the lease remains within grace,
   and re-send the full registry snapshot after every successful resume. Resume attempts
-  pause in background and restart on foreground.
+  pause in background and restart on foreground. A `1008` close is terminal in both
+  directions — mid-session, and as the rejection of a claim/resume handshake: it is the
+  daemon's "no retry of this frame can succeed" signal (`unknown_session`,
+  `invalid_resume_token`, `link_expired`, …), so the session is lost immediately with the
+  daemon's own reason rather than retried for the remainder of the grace window.
+  Transport-level closes (`1011`, `1001`, `1006`) stay retryable.
 - Installing the bootstrap explicitly or importing `/auto` registers the runtime URL
   listener first, then restores once from the native lease before considering the initial
   launch URL. A successful restore suppresses that initial URL claim; no lease or an
   unexpected orchestration failure falls back to normal initial-link handling. This lets
   a fresh Metro JS runtime resume automatically with the same alias and no new link.
-  Native app process death erases the lease and requires a fresh bootstrap.
+  Native app process death erases the lease and requires a fresh bootstrap. Apps that
+  drive bootstrap themselves and never install the listener must call the exported
+  `restoreSession()` at startup — it is the only other reader of the lease, so skipping it
+  drops a resumable session on every JS runtime replacement.
 - `registerTool({ name, description, inputSchema?, outputSchema?, annotations?, handler })`
   → `{ remove() }`. The disposer removes only its own registration (compare by
   registration identity, not name). Duplicate name registration logs a dev warning and

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -119,9 +119,21 @@ import { installCordieriteDeepLinkBootstrap } from "@cordierite/react-native";
 installCordieriteDeepLinkBootstrap();
 ```
 
+If you skip `installCordieriteDeepLinkBootstrap()` entirely and call `connect()` yourself, call `restoreSession()` once at startup before your own bootstrap handling — nothing else reads the native resume lease, so without it every Metro reload drops a session the native side could still have resumed:
+
+```ts
+import { connect, restoreSession } from "@cordierite/react-native";
+
+if (!(await restoreSession())) {
+  await connect(myBootstrapPayload); // only claim a fresh link if there was nothing to restore
+}
+```
+
 **Bootstrap connection and recovery:** installation registers the runtime URL listener immediately, reads the initial launch URL, and attempts native-lease recovery once. The initial URL waits for recovery: a successful restore suppresses the old launch-link claim, while no lease or an unexpected orchestration failure falls back to the normal initial-link flow. Runtime URLs still parse the v2 bootstrap payload and call `connect` when the client is idle. You do not need your own `Linking` handler for the default flow.
 
-The resume lease is native **process-memory only** and is committed before JS receives each successful claim/resume acknowledgement. That supports Metro reloads and JS runtime replacement with the same alias and no new link, provided the native app process stays alive. It is never persisted to disk; after native process death, open a fresh bootstrap link. The grace window starts when the transport suspends/disconnects, not when the acknowledgement was received. Advanced flows can trigger the same recovery explicitly with `cordieriteClient.restoreSession()`.
+The resume lease is native **process-memory only** and is committed before JS receives each successful claim/resume acknowledgement. That supports Metro reloads and JS runtime replacement with the same alias and no new link, provided the native app process stays alive. It is never persisted to disk; after native process death, open a fresh bootstrap link. The grace window starts when the transport suspends/disconnects, not when the acknowledgement was received. Any flow can trigger the same recovery explicitly with the exported `restoreSession()` (or `cordieriteClient.restoreSession()`).
+
+**Reconnect vs. give up:** socket loss inside the grace window auto-reconnects with jittered backoff (0.5 s → 30 s cap), including transport-level closes such as `1011 send_failed` and `1001 daemon_shutdown` — the daemon may well be back before grace expires. A `1008` close is different: it is how the daemon reports a rejection no retry of the same frame can satisfy (`unknown_session` after a daemon restart, `invalid_resume_token`, an expired or revoked session, a malformed frame). Those end the session immediately with a `sessionChange: lost` carrying the daemon's reason, instead of retrying for the rest of the grace window.
 
 **Errors:** use `addCordieriteListener("error", callback)` for bootstrap-parse, connect, socket, and tool-handler failures — one unified channel.
 

--- a/packages/react-native/ios/CordieriteTurboBridge.swift
+++ b/packages/react-native/ios/CordieriteTurboBridge.swift
@@ -129,6 +129,13 @@ public final class CordieriteTurboBridge: NSObject, @unchecked Sendable {
   /// TurboModule invalidation entry point (see `RCTNativeCordierite.invalidate`). Cancels the
   /// socket, invalidates the URLSession, and drops event callbacks so a Metro reload fully
   /// releases the transport instead of leaving a wedged "connecting or active" state.
+  ///
+  /// The `Task` makes this asynchronous, so on a fast reload the replacement manager can resume
+  /// before this body runs — deliberately safe, not a race to fix: the lease store's owner
+  /// generation makes the stale `markDisconnected` a no-op once the replacement's ack has landed
+  /// (`CordieriteProcessResumeLeaseStore.markDisconnected`), and a daemon that briefly sees both
+  /// sockets adopts the new one and closes the old with `1000 session_replaced` (the daemon's
+  /// `handleResume`).
   @objc public func invalidate() {
     Task {
       await self.manager.invalidate()

--- a/packages/react-native/src/__tests__/client.test.ts
+++ b/packages/react-native/src/__tests__/client.test.ts
@@ -595,6 +595,112 @@ describe("createCordieriteClient: resume after socket loss", () => {
     expect(storedLease).toBeNull();
   });
 
+  test("a 1008 rejection of the resume itself ends the session instead of retrying until grace", async () => {
+    const nativeModule = createMockModule();
+    const timers = createFakeTimers({ randomValues: [0, 0] });
+    let storedLease: unknown = validResumeLease();
+    const client = createCordieriteClient(nativeModule, {
+      timers,
+      resumeLeaseStore: {
+        get: () => storedLease,
+        clear: () => {
+          storedLease = null;
+        },
+      },
+    });
+
+    const connectPromise = client.connect(validBootstrap());
+    fireMessage(nativeModule, buildAck());
+    await connectPromise;
+
+    const sessionEvents: CordieriteSessionChangeEvent[] = [];
+    client.addCordieriteListener("sessionChange", (e) => sessionEvents.push(e));
+
+    // Transport-level loss: retryable, so the backoff loop starts as usual.
+    fireClose(nativeModule, { code: 1006, reason: "abnormal closure" });
+    expect(client.getClientState()).toBe("reconnecting");
+
+    // The retry goes out, and *this* time the daemon rejects the resume itself — the shape of a
+    // daemon restart (sessions are in-memory only), or a session revoked/expired while offline.
+    // The close settles the in-flight handshake, so it never reaches `onSocketLost`.
+    timers.advance(1);
+    expect(nativeModule.connectCalls).toHaveLength(2);
+    fireClose(nativeModule, { code: 1008, reason: "unknown_session" });
+    await flushMicrotasks();
+
+    expect(client.getClientState()).toBe("closed");
+    expect(sessionEvents).toEqual([
+      {
+        type: "lost",
+        sessionId: "session-123",
+        alias: "device-1",
+        reason: "unknown_session",
+      },
+    ]);
+    // No further retry is scheduled, and the unusable lease is gone.
+    expect(timers.pendingCount()).toBe(0);
+    expect(storedLease).toBeNull();
+
+    timers.advance(60_000);
+    expect(nativeModule.connectCalls).toHaveLength(2);
+  });
+
+  test("a 1008 close mid-session ends it immediately (no reconnect loop)", async () => {
+    const nativeModule = createMockModule();
+    const timers = createFakeTimers();
+    const client = createCordieriteClient(nativeModule, { timers });
+
+    const connectPromise = client.connect(validBootstrap());
+    fireMessage(nativeModule, buildAck());
+    await connectPromise;
+
+    const sessionEvents: CordieriteSessionChangeEvent[] = [];
+    const errorEvents: CordieriteUnifiedErrorEvent[] = [];
+    client.addCordieriteListener("sessionChange", (e) => sessionEvents.push(e));
+    client.addCordieriteListener("error", (e) => errorEvents.push(e));
+
+    fireClose(nativeModule, { code: 1008, reason: "invalid_message" });
+
+    expect(client.getClientState()).toBe("closed");
+    expect(sessionEvents).toEqual([
+      {
+        type: "lost",
+        sessionId: "session-123",
+        alias: "device-1",
+        reason: "invalid_message",
+      },
+    ]);
+    // The rejection still reaches the unified error channel before the session is finalized.
+    expect(errorEvents).toHaveLength(1);
+    expect(errorEvents[0]?.closeReason).toBe("invalid_message");
+    expect(timers.pendingCount()).toBe(0);
+  });
+
+  test("1011 and 1001 stay retryable: only 1008 is treated as terminal", async () => {
+    const nativeModule = createMockModule();
+    const timers = createFakeTimers({ randomValues: [0, 0] });
+    const client = createCordieriteClient(nativeModule, { timers });
+
+    const connectPromise = client.connect(validBootstrap());
+    fireMessage(nativeModule, buildAck());
+    await connectPromise;
+
+    // `send_failed` — a transport hiccup, not a rejection of the session.
+    fireClose(nativeModule, { code: 1011, reason: "send_failed" });
+    expect(client.getClientState()).toBe("reconnecting");
+
+    timers.advance(1);
+    expect(nativeModule.connectCalls).toHaveLength(2);
+
+    // `daemon_shutdown` — the daemon may well come back inside the grace window.
+    fireClose(nativeModule, { code: 1001, reason: "daemon_shutdown" });
+    await flushMicrotasks();
+    expect(client.getClientState()).toBe("reconnecting");
+
+    timers.advance(1);
+    expect(nativeModule.connectCalls).toHaveLength(3);
+  });
+
   test("a fresh connect() supersedes and stops any in-flight reconnect loop", async () => {
     const nativeModule = createMockModule();
     const timers = createFakeTimers({ randomValues: [0] });

--- a/packages/react-native/src/__tests__/noop-parity.test.ts
+++ b/packages/react-native/src/__tests__/noop-parity.test.ts
@@ -39,6 +39,7 @@ describe("noop parity: type-level (see also public-api.ts's doc comment)", () =>
       "getRegisteredTools",
       "installCordieriteDeepLinkBootstrap",
       "addCordieriteListener",
+      "restoreSession",
       "getCordieriteState",
       "connect",
       "getCordieriteBuildConfig",
@@ -113,6 +114,11 @@ describe("noop entry: runtime no-op behavior", () => {
     });
 
     expect(getRegisteredTools()).toEqual([]);
+  });
+
+  test("restoreSession() always resolves false (no native lease exists)", async () => {
+    const { restoreSession } = await import("../noop");
+    await expect(restoreSession()).resolves.toBe(false);
   });
 
   test('getCordieriteState() always returns "idle"', async () => {

--- a/packages/react-native/src/__tests__/root-entry-laziness.test.ts
+++ b/packages/react-native/src/__tests__/root-entry-laziness.test.ts
@@ -72,6 +72,12 @@ describe("root entry (@cordierite/react-native): TurboModule laziness", () => {
     expect(nativeAccessAttempts).toBeGreaterThan(0);
   });
 
+  test("the exported restoreSession() degrades to ./noop's false when no native module exists", async () => {
+    const { restoreSession } = await import("../index");
+
+    await expect(restoreSession()).resolves.toBe(false);
+  });
+
   test("registerTool does not throw, even with no native module available", async () => {
     const { registerTool } = await import("../index");
 

--- a/packages/react-native/src/client/index.ts
+++ b/packages/react-native/src/client/index.ts
@@ -35,6 +35,12 @@ import { createUnifiedListenerBus } from "./listeners";
 import { createToolRegistry, type RegistryDelta } from "./registry";
 import { isResumeLeaseExpired, parseResumeLease } from "./resume-lease";
 import {
+  CordieriteHandshakeClosedError,
+  isTerminalCloseEvent,
+  isTerminalHandshakeRejection,
+  terminalCloseReason,
+} from "./terminal-close";
+import {
   systemClientTimers,
   type ClientTimerHandle,
   type ClientTimers,
@@ -352,6 +358,14 @@ export const createCordieriteClient = (
         message: "Cordierite resume attempt failed.",
         cause: error,
       });
+      if (isTerminalHandshakeRejection(error)) {
+        // The daemon rejected the resume itself (`unknown_session` after a daemon restart, an
+        // expired/revoked session, `invalid_resume_token`). Retrying the identical frame until the
+        // grace window runs out would leave the app in `reconnecting` for up to `grace_s` — minutes
+        // — before it ever hears `sessionChange: lost`. Finalize now instead.
+        finalizeSessionLost(terminalCloseReason(error.closeEvent));
+        return;
+      }
       scheduleReconnectAttempt(myEpoch);
       return;
     }
@@ -400,6 +414,13 @@ export const createCordieriteClient = (
       hint: lastError?.hint,
     });
 
+    if (isTerminalCloseEvent(event)) {
+      // A policy-violation close mid-session (e.g. the daemon rejected a frame we sent) is as
+      // unresumable as one during the handshake — see `attemptResume`'s matching branch.
+      finalizeSessionLost(terminalCloseReason(event));
+      return;
+    }
+
     const now = timers.now();
     const disconnectedAtMs = heldSession.disconnectedAtMs ?? now;
     heldSession.disconnectedAtMs = disconnectedAtMs;
@@ -444,11 +465,17 @@ export const createCordieriteClient = (
     const errorEvent = lastErrorEvent;
     lastErrorEvent = null;
 
+    // A close that lands while a claim/resume is in flight settles *that attempt* and stops here —
+    // `onSocketLost` never sees it. So the close event travels with the rejection, letting
+    // `attemptResume` tell a terminal daemon rejection apart from a retryable transport failure.
     if (
       settlePendingAttempt({
         ok: false,
-        error: new Error(
-          event.reason ?? errorEvent?.message ?? "Cordierite connection closed."
+        error: new CordieriteHandshakeClosedError(
+          event.reason ??
+            errorEvent?.message ??
+            "Cordierite connection closed.",
+          event
         ),
       })
     ) {

--- a/packages/react-native/src/client/terminal-close.ts
+++ b/packages/react-native/src/client/terminal-close.ts
@@ -1,0 +1,50 @@
+import type { CordieriteCloseEvent } from "../Cordierite.types";
+
+/**
+ * RFC 6455 "policy violation". Every daemon-side rejection that a `session_resume` (or
+ * `session_claim`) can never talk its way out of closes with this code: `unknown_session`,
+ * `invalid_resume_token`, `link_expired`, `already_claimed`, `claim_attempts_exceeded`,
+ * `invalid_token`, `invalid_message`, `invalid_registry`, `unknown_message_type` (see the daemon's
+ * `closeSocket` call sites in `packages/cordierite/src/daemon/sessions.ts`). Retrying an identical
+ * frame against any of them can only fail the same way, so 1008 is treated as terminal wholesale
+ * rather than by matching individual reason strings — a new daemon-side rejection reason is then
+ * terminal by default instead of silently falling into the retry loop.
+ *
+ * Deliberately *not* terminal: 1011 (`send_failed`) and 1001 (`daemon_shutdown`) are transport-level
+ * and genuinely worth retrying inside the grace window, as is 1006 (abnormal close — backgrounding,
+ * network blips).
+ */
+export const POLICY_VIOLATION_CLOSE_CODE = 1008;
+
+/** Whether the daemon closed with a rejection that no retry of the same frame could ever satisfy. */
+export const isTerminalCloseEvent = (event: CordieriteCloseEvent): boolean =>
+  event.code === POLICY_VIOLATION_CLOSE_CODE;
+
+/** The `sessionChange: lost` reason to report for a terminal close — the daemon's own wire reason
+ * (`unknown_session`, `invalid_resume_token`, …) when it sent one. */
+export const terminalCloseReason = (event: CordieriteCloseEvent): string =>
+  event.reason ?? "rejected_by_daemon";
+
+/**
+ * Rejection of an in-flight claim/resume handshake caused by the socket closing, carrying the close
+ * event itself. Without this the close code is lost by the time `attemptResume` catches the
+ * rejection — and that catch, not `onSocketLost`, is where a failed *resume* lands (the `close`
+ * listener settles the pending attempt and returns early), so it is the retry loop that has to be
+ * able to recognize a terminal rejection.
+ */
+export class CordieriteHandshakeClosedError extends Error {
+  readonly closeEvent: CordieriteCloseEvent;
+
+  constructor(message: string, closeEvent: CordieriteCloseEvent) {
+    super(message);
+    this.name = "CordieriteHandshakeClosedError";
+    this.closeEvent = closeEvent;
+  }
+}
+
+/** Whether `error` is a handshake rejection the daemon marked terminal. */
+export const isTerminalHandshakeRejection = (
+  error: unknown,
+): error is CordieriteHandshakeClosedError =>
+  error instanceof CordieriteHandshakeClosedError &&
+  isTerminalCloseEvent(error.closeEvent);

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -184,6 +184,28 @@ export function addCordieriteListener<Kind extends CordieriteListenerKind>(
   );
 }
 
+/**
+ * Recovers the session held in the native process-memory lease, on the default client. Resolves
+ * `true` once a resume attempt has started (not once the daemon has acknowledged it), `false` when
+ * there is no valid, unexpired lease to restore or this client is already connecting/active.
+ *
+ * `installCordieriteDeepLinkBootstrap` (and the `./auto` entry) already calls this at startup, so
+ * apps using it need nothing more. Call this explicitly if you handle bootstrap links yourself —
+ * custom deep-link routing, QR scanning, a manual `connect()` — because otherwise **nothing** reads
+ * the lease, and every Metro reload silently drops a session the native side could still have
+ * resumed. Call it once at startup, before your own bootstrap handling: a successful restore means
+ * you should skip claiming a fresh link.
+ *
+ * Only a JS runtime replacement is recoverable this way; the lease is process memory and never
+ * touches disk, so native process death still requires a fresh bootstrap link.
+ */
+export function restoreSession(): Promise<boolean> {
+  return noopIfNativeUnavailable(
+    () => cordieriteClient.restoreSession(),
+    () => noop.restoreSession(),
+  );
+}
+
 /** Unified client state on the default client: `idle | connecting | active | reconnecting | closed`. */
 export function getCordieriteState(): CordieriteClientState {
   return noopIfNativeUnavailable(

--- a/packages/react-native/src/noop.ts
+++ b/packages/react-native/src/noop.ts
@@ -70,6 +70,11 @@ export function addCordieriteListener<Kind extends CordieriteListenerKind>(
   return noopSubscription;
 }
 
+/** Always `false`: this build has no native module, so there is no resume lease to recover. */
+export function restoreSession(): Promise<boolean> {
+  return Promise.resolve(false);
+}
+
 /** Always `"idle"`. */
 export function getCordieriteState(): CordieriteClientState {
   return "idle";

--- a/packages/react-native/src/public-api.ts
+++ b/packages/react-native/src/public-api.ts
@@ -50,6 +50,8 @@ export type CordierePublicApi = {
     callback: CordieriteUnifiedListenerMap[Kind],
   ): CordieriteSubscription;
 
+  restoreSession(): Promise<boolean>;
+
   getCordieriteState(): CordieriteClientState;
 
   connect(input: CordieriteConnectInput): Promise<void>;


### PR DESCRIPTION
Two auto-heal gaps found while auditing what actually happens to a WebSocket session across JS reloads and disconnects. Both are on the RN client side.

## 1. A terminal daemon rejection burned the whole grace window

`onSocketLost` treated only close code 1000 as terminal, so anything else scheduled a retry. That means a rejection no retry could ever satisfy kept the backoff loop running until the local grace timer fired:

- `unknown_session` after a daemon restart — daemon sessions are in-memory only
- `invalid_resume_token`
- a session revoked or expired while the app was offline

The app sat in `reconnecting` for up to `grace_s` (**600 s** by default), retrying at the 30 s backoff cap, before its `sessionChange: lost` listener ever fired.

Every daemon-side rejection of this kind closes with **1008** (`sessions.ts`'s `closeSocket` call sites: `unknown_session`, `invalid_resume_token`, `link_expired`, `already_claimed`, `claim_attempts_exceeded`, `invalid_token`, `invalid_message`, `invalid_registry`, `unknown_message_type`). So 1008 is now terminal wholesale rather than matched by reason string — a new daemon rejection reason is terminal by default instead of silently joining the retry loop. Transport-level closes stay retryable: **1011** `send_failed`, **1001** `daemon_shutdown`, **1006** abnormal (backgrounding, network blips) — the daemon may well be back inside the grace window.

The subtle part: a failed **resume** never reaches `onSocketLost`. The `close` listener settles the in-flight handshake and returns early, so the rejection lands in `attemptResume`'s catch — where the close code had already been thrown away. The close event now travels with the rejection via `CordieriteHandshakeClosedError`, and both paths finalize with the daemon's own reason.

No protocol change: the reason string already survived the whole path (daemon `closeSocket(socket, 1008, "unknown_session")` → native decode → `event.reason`).

## 2. `restoreSession()` was effectively unreachable

It was called from exactly one place — `installCordieriteDeepLinkBootstrap` — and otherwise only reachable through the `cordieriteClient` proxy. Apps that drive bootstrap themselves (custom deep-link routing, QR scanning, a manual `connect()`) had **nothing** reading the native lease, so every Metro reload dropped a session the native side could still have resumed.

It is now a first-class export on the root and `./noop` entries, in `CordierePublicApi`, with README and ARCHITECTURE guidance.

I did **not** auto-fire it on client construction, which is what I first leaned toward. Two things argue against it: the root entry's laziness contract pins lease reads to an explicit `restoreSession()` call (`resume-lease-native-adapter.test.ts`: "default client reads the adapter only when restoreSession is invoked"), and recovery ordering against the initial launch URL is deliberately owned by bootstrap installation (ARCHITECTURE.md §11). Happy to switch to the automatic variant if you'd rather — it needs a memoized in-flight promise so `installCordieriteDeepLinkBootstrap` doesn't race its own restore and fall back to the initial URL.

## 3. iOS async `invalidate()` — comment only

`Task { await manager.invalidate() }` can run after a fast reload's replacement manager has already resumed. I traced it and it's safe as written: the lease store's owner generation makes the stale `markDisconnected` a no-op, and a daemon that briefly sees both sockets adopts the new one and closes the old with `1000 session_replaced`. Documented rather than changed.

## Out of scope

Native app restart (process death erases the process-memory lease) was explicitly excluded from this pass, as was expiring a suspended session early when the app is killed — the daemon can't distinguish app death from a recoverable backgrounding on the wire, so that needs its own change (a lifecycle death beacon and/or device-identity reclaim on next claim).

## Testing

- 4 new client tests: 1008 rejecting a resume, 1008 mid-session, 1011/1001 staying retryable, and the noop/root-entry `restoreSession` parity cases
- `packages/react-native`: 209 tests pass, `tsc` clean, no new lint warnings (verified warning counts unchanged against `main` for the touched files)
- Repo-wide `pnpm typecheck` fails identically on clean `main` (stale `@cordierite/shared` build) — unrelated to this branch
