### PR TITLE
refactor: make bootstrap policy native config and /auto the only install path

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -306,13 +306,17 @@ Package `@cordierite/react-native`. Entry points:
 
 - `@cordierite/react-native` — **side-effect-free**. Its default API includes
   `registerTool`, `useCordieriteTool`, `postEvent`, `getRegisteredTools`,
-  `installCordieriteDeepLinkBootstrap(options?)`, `addCordieriteListener`,
-  `getCordieriteState`, and `connect`; it also exports `cordieriteClient`, parsing
-  helpers, and types for advanced integrations. TurboModule lookup is lazy (first
-  native call), never at import time.
-- `@cordierite/react-native/auto` — side-effect entry: installs the deep-link bootstrap
-  with defaults and starts native-lease recovery on import (the v1 root-import behavior,
-  now opt-in).
+  `addCordieriteListener`, `getCordieriteState`, `restoreSession`, and `connect`; it
+  also exports `cordieriteClient`, parsing helpers, and types for advanced integrations.
+  It installs nothing. TurboModule lookup is lazy (first native call), never at import
+  time.
+- `@cordierite/react-native/auto` — side-effect entry, and the only entry that installs
+  the deep-link bootstrap and starts native-lease recovery. `require()` it instead of
+  `import`ing to control when that happens (`__DEV__`, a QA-build toggle, after other
+  startup work); installing twice installs once. It takes no options: address policy is
+  native build config (`allowPrivateLanOnly`), read by the deep-link handler from the
+  same `getConstants()` source native `connect()` enforces, so JS can only ever narrow
+  what native allows, never widen it.
 - `@cordierite/react-native/noop` — identical public API, inert implementation.
 - `@cordierite/react-native/metro` — `withCordierite(config, { include })`, the supported way
   to swap the real entries for `/noop` at bundle time. It chains to any existing

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -101,8 +101,8 @@ The package has three entries:
 
 | Entry | Behavior |
 | --- | --- |
-| `@cordierite/react-native` | Side-effect-free. Exports `registerTool`, `useCordieriteTool`, `postEvent`, `installCordieriteDeepLinkBootstrap`, `addCordieriteListener`, `getCordieriteState`, `connect`, and types. The native module is looked up **lazily**, on the first actual native call — importing it (even in Expo Go or a misconfigured build) never crashes; only calling a native-requiring function like `connect()` without native support does, with an actionable error. |
-| `@cordierite/react-native/auto` | Same exports, plus a side effect: installs the default deep-link bootstrap listener and starts recovery from the native process lease on import (the old v1 root-import behavior, now opt-in). |
+| `@cordierite/react-native` | Side-effect-free. Exports `registerTool`, `useCordieriteTool`, `postEvent`, `addCordieriteListener`, `getCordieriteState`, `restoreSession`, `connect`, and types. The native module is looked up **lazily**, on the first actual native call — importing it (even in Expo Go or a misconfigured build) never crashes; only calling a native-requiring function like `connect()` without native support does, with an actionable error. |
+| `@cordierite/react-native/auto` | Same exports, plus a side effect: installs the deep-link bootstrap listener and starts recovery from the native process lease on import. This is the only entry that installs anything. |
 | `@cordierite/react-native/noop` | Same public API, fully inert — for compiling Cordierite out of release builds (see below). |
 
 Most apps just want the deep-link listener installed automatically, so import the side-effect entry once near your app's entry point:
@@ -111,21 +111,23 @@ Most apps just want the deep-link listener installed automatically, so import th
 import "@cordierite/react-native/auto";
 ```
 
-If you'd rather drive bootstrap yourself (custom deep-link handling, QR scanning, tests), import from the root entry and call `installCordieriteDeepLinkBootstrap()` (or `connect()` directly) when you're ready:
+To control *when* that happens — only in `__DEV__`, behind a QA-build toggle, or after other startup work — `require()` the same entry at that point instead. Metro resolves it lazily, and importing it more than once installs once:
 
 ```ts
-import { installCordieriteDeepLinkBootstrap } from "@cordierite/react-native";
-
-installCordieriteDeepLinkBootstrap();
+if (__DEV__) {
+  require("@cordierite/react-native/auto");
+}
 ```
 
-If you skip `installCordieriteDeepLinkBootstrap()` entirely and call `connect()` yourself, call `restoreSession()` once at startup before your own bootstrap handling — nothing else reads the native resume lease, so without it every Metro reload drops a session the native side could still have resumed:
+There is nothing to configure here: which addresses a bootstrap link may point at is native build config (`allowPrivateLanOnly`, configured through the Expo plugin / `CordieriteAllowPrivateLanOnly` above), enforced by native `connect()` and read from the same place by the deep-link handler.
+
+If you drive bootstrap entirely yourself (custom deep-link routing, QR scanning, tests) and never import `/auto`, call `restoreSession()` once at startup before your own bootstrap handling — it is then the only thing reading the native resume lease, and without it every Metro reload drops a session the native side could still have resumed:
 
 ```ts
-import { connect, restoreSession } from "@cordierite/react-native";
+import { connect, parseBootstrapUrl, restoreSession } from "@cordierite/react-native";
 
 if (!(await restoreSession())) {
-  await connect(myBootstrapPayload); // only claim a fresh link if there was nothing to restore
+  await connect(parseBootstrapUrl(url)); // only claim a fresh link if there was nothing to restore
 }
 ```
 

--- a/packages/react-native/src/__tests__/deep-link-install.test.ts
+++ b/packages/react-native/src/__tests__/deep-link-install.test.ts
@@ -2,6 +2,7 @@ import { encodeBootstrap } from "@cordierite/shared";
 import { afterEach, beforeEach, describe, expect, vi, test } from "vitest";
 
 import type { CordieriteConnectionState } from "../Cordierite.types";
+import type { Spec } from "../NativeCordierite";
 
 (globalThis as { __DEV__?: boolean }).__DEV__ = true;
 
@@ -45,6 +46,16 @@ const validBootstrapUrl = () =>
     expiresAt: Math.floor(Date.now() / 1000) + 60,
   })}`;
 
+const nonPrivateBootstrapUrl = () =>
+  `playground:///?cordierite=${encodeBootstrap({
+    family: 4,
+    address: "8.8.8.8",
+    port: 8443,
+    sessionId: "session-123",
+    token: "a".repeat(43),
+    expiresAt: Math.floor(Date.now() / 1000) + 60,
+  })}`;
+
 const createMockClient = (
   initialState: CordieriteConnectionState = "idle",
   restoreSessionImpl: () => Promise<boolean> = () => Promise.resolve(false)
@@ -77,6 +88,12 @@ describe("installCordieriteDeepLinkBootstrap", () => {
     urlListeners = [];
     const mod = await import("../deep-link-install");
     mod.__cordieriteResetInstallGuardForTests();
+    // The native-module loader is process-global; restore the default so a test that installs a
+    // fake `getConstants()` cannot leak its address policy into the next one.
+    const { __cordieriteSetNativeModuleLoaderForTests } = await import(
+      "../CordieriteModule"
+    );
+    __cordieriteSetNativeModuleLoaderForTests();
   });
 
   afterEach(async () => {
@@ -101,14 +118,14 @@ describe("installCordieriteDeepLinkBootstrap", () => {
     expect(client.connects).toEqual([]);
   });
 
-  test("second call is a no-op when options match", async () => {
+  test("second call is a no-op", async () => {
     const { installCordieriteDeepLinkBootstrap } = await import(
       "../deep-link-install"
     );
     const client = createMockClient();
 
-    installCordieriteDeepLinkBootstrap(client, { requirePrivateIp: true });
-    installCordieriteDeepLinkBootstrap(client, { requirePrivateIp: true });
+    installCordieriteDeepLinkBootstrap(client);
+    installCordieriteDeepLinkBootstrap(client);
 
     expect(urlListeners).toHaveLength(1);
     expect(client.restoreCalls).toBe(1);
@@ -179,61 +196,60 @@ describe("installCordieriteDeepLinkBootstrap", () => {
     expect(client.connects).toHaveLength(1);
   });
 
-  test("options are threaded down to the deep-link handler (requirePrivateIp: false)", async () => {
+  test("a non-private address is accepted only when native reports allowPrivateLanOnly: false", async () => {
+    const { __cordieriteSetNativeModuleLoaderForTests } = await import(
+      "../CordieriteModule"
+    );
+    __cordieriteSetNativeModuleLoaderForTests(() => ({
+      NativeCordierite: {
+        getConstants: () => ({
+          trust: "link",
+          hasEmbeddedPins: false,
+          allowPrivateLanOnly: false,
+        }),
+      } as unknown as Spec,
+    }));
+
     const { installCordieriteDeepLinkBootstrap } = await import(
       "../deep-link-install"
     );
     const client = createMockClient();
 
-    installCordieriteDeepLinkBootstrap(client, { requirePrivateIp: false });
+    installCordieriteDeepLinkBootstrap(client);
     expect(urlListeners).toHaveLength(1);
 
-    const nonPrivatePayload = {
-      family: 4 as const,
-      address: "8.8.8.8",
-      port: 8443,
-      sessionId: "session-123",
-      token: "a".repeat(43),
-      expiresAt: Math.floor(Date.now() / 1000) + 60,
-    };
-    const url = `playground:///?cordierite=${encodeBootstrap(
-      nonPrivatePayload
-    )}`;
-
-    urlListeners[0]?.({ url });
+    urlListeners[0]?.({ url: nonPrivateBootstrapUrl() });
     await flushMicrotasks();
 
+    // The address policy is native build config (`CordieriteAllowPrivateLanOnly`), the same value
+    // native `connect()` enforces -- never a JS-side copy an app could set independently.
     expect(client.connects).toHaveLength(1);
   });
 
-  test("reinstalling with different options logs a dev warning instead of silently keeping the first", async () => {
-    const originalDevWarn = console.warn;
-    const warnings: unknown[][] = [];
-    console.warn = (...args: unknown[]) => {
-      warnings.push(args);
-    };
+  test("a non-private address is rejected when the native build config cannot be read", async () => {
+    const { __cordieriteSetNativeModuleLoaderForTests } = await import(
+      "../CordieriteModule"
+    );
+    __cordieriteSetNativeModuleLoaderForTests(() => ({
+      NativeCordierite: undefined as unknown as Spec,
+    }));
 
-    try {
-      const { installCordieriteDeepLinkBootstrap } = await import(
-        "../deep-link-install"
-      );
-      const client = createMockClient();
+    const { installCordieriteDeepLinkBootstrap } = await import(
+      "../deep-link-install"
+    );
+    const client = createMockClient();
 
-      installCordieriteDeepLinkBootstrap(client, { requirePrivateIp: true });
-      installCordieriteDeepLinkBootstrap(client, { requirePrivateIp: false });
+    installCordieriteDeepLinkBootstrap(client);
+    urlListeners[0]?.({ url: nonPrivateBootstrapUrl() });
+    await flushMicrotasks();
 
-      // Still only one listener installed — the guard is run-once regardless.
-      expect(urlListeners).toHaveLength(1);
-      expect(
-        warnings.some((args) =>
-          args.some(
-            (arg) =>
-              typeof arg === "string" && arg.includes("different options")
-          )
-        )
-      ).toBe(true);
-    } finally {
-      console.warn = originalDevWarn;
-    }
+    // Fail closed: an unreadable config must never widen the address policy.
+    expect(client.connects).toEqual([]);
+
+    // ...and the listener really is live — otherwise the assertion above would pass for the wrong
+    // reason (nothing installed at all).
+    urlListeners[0]?.({ url: validBootstrapUrl() });
+    await flushMicrotasks();
+    expect(client.connects).toHaveLength(1);
   });
 });

--- a/packages/react-native/src/__tests__/noop-parity.test.ts
+++ b/packages/react-native/src/__tests__/noop-parity.test.ts
@@ -37,7 +37,6 @@ describe("noop parity: type-level (see also public-api.ts's doc comment)", () =>
       "useCordieriteTool",
       "postEvent",
       "getRegisteredTools",
-      "installCordieriteDeepLinkBootstrap",
       "addCordieriteListener",
       "restoreSession",
       "getCordieriteState",
@@ -85,11 +84,6 @@ describe("noop entry: runtime no-op behavior", () => {
   test("postEvent resolves without doing anything", async () => {
     const { postEvent } = await import("../noop");
     await expect(postEvent("anything", { a: 1 })).resolves.toBeUndefined();
-  });
-
-  test("installCordieriteDeepLinkBootstrap is a no-op", async () => {
-    const { installCordieriteDeepLinkBootstrap } = await import("../noop");
-    expect(() => installCordieriteDeepLinkBootstrap()).not.toThrow();
   });
 
   test("addCordieriteListener returns a disposer; the callback never fires", async () => {

--- a/packages/react-native/src/__tests__/root-entry-inert-parity.test.ts
+++ b/packages/react-native/src/__tests__/root-entry-inert-parity.test.ts
@@ -65,7 +65,7 @@ describe("root entry: exact ./noop parity when the native module is unavailable"
     await expect(postEvent("anything", { a: 1 })).resolves.toBeUndefined();
   });
 
-  test("installCordieriteDeepLinkBootstrap is a no-op (no Linking listener installed)", async () => {
+  test("importing ./auto installs no Linking listener in an inert build", async () => {
     let urlListenerCount = 0;
     vi.doMock("react-native", () => ({
       AppState: {
@@ -81,10 +81,10 @@ describe("root entry: exact ./noop parity when the native module is unavailable"
       },
     }));
 
-    const { installCordieriteDeepLinkBootstrap } = await import("../index");
-    expect(() => installCordieriteDeepLinkBootstrap()).not.toThrow();
-    // The real path calls `Linking.addEventListener` as part of installing the bootstrap listener;
-    // the noop path never touches `Linking` at all.
+    // `./auto` is the only install path, and it is gated on native availability exactly like every
+    // other root-entry function: in an inert build it must not touch `Linking` at all, matching
+    // what a `./noop`-swapped `/auto` would do.
+    await expect(import("../auto")).resolves.toBeDefined();
     expect(urlListenerCount).toBe(0);
   });
 

--- a/packages/react-native/src/auto.ts
+++ b/packages/react-native/src/auto.ts
@@ -1,14 +1,23 @@
-import { installCordieriteDeepLinkBootstrap } from "./index";
+import { installCordieriteDeepLinkBootstrap } from "./deep-link-install";
+import { cordieriteClient, noopIfNativeUnavailable } from "./default-client";
 
 /**
  * `@cordierite/react-native/auto` — side-effect entry (ARCHITECTURE.md §11). Importing this module
- * installs the default deep-link bootstrap listener and starts native-lease recovery immediately
- * (the v1 root-import behavior, now opt-in): `import "@cordierite/react-native/auto";` once, near
- * your app's entry point.
+ * subscribes the default client to runtime deep links and starts native-lease recovery before the
+ * initial URL is considered: `import "@cordierite/react-native/auto";` once, near your app's entry
+ * point.
+ *
+ * To control *when* that happens — behind `__DEV__`, a QA-build toggle, or after other startup
+ * work — `require("@cordierite/react-native/auto")` at that point instead; Metro resolves it
+ * lazily, and importing twice installs once.
  *
  * Re-exports everything the root (`.`) entry exports, so apps that want the auto-install behavior
- * do not also need to import from `.`.
+ * do not also need to import from `.`. The install itself is deliberately *not* re-exported:
+ * bootstrap policy comes from native build config, so there is nothing for an app to configure.
  */
 export * from "./index";
 
-installCordieriteDeepLinkBootstrap();
+noopIfNativeUnavailable(
+  () => installCordieriteDeepLinkBootstrap(cordieriteClient),
+  () => {},
+);

--- a/packages/react-native/src/deep-link-core.ts
+++ b/packages/react-native/src/deep-link-core.ts
@@ -37,7 +37,11 @@ export function hasCordieriteBootstrapQuery(
 
 export type HandleCordieriteDeepLinkOptions = {
   now?: number;
-  /** Reject bootstrap payloads whose address is not a private/loopback range. Default `true`. */
+  /**
+   * Reject bootstrap payloads whose address is not a private/loopback range. Defaults to `true`
+   * (fail-closed). Not an app-facing knob: `deep-link-install.ts` supplies it from the native
+   * `allowPrivateLanOnly` build config, the same value native `connect()` enforces.
+   */
   requirePrivateIp?: boolean;
 };
 

--- a/packages/react-native/src/deep-link-install.ts
+++ b/packages/react-native/src/deep-link-install.ts
@@ -1,57 +1,55 @@
 import { Linking } from "react-native";
 
+import { getCordieriteNativeBuildConfig } from "./CordieriteModule";
 import {
   handleCordieriteDeepLinkUrl,
   type CordieriteAutoBootstrapClient,
 } from "./deep-link-core";
 import { logger } from "./logger";
 
-export type InstallCordieriteDeepLinkBootstrapOptions = {
-  /** Reject bootstrap payloads whose address is not a private/loopback range. Default `true`. */
-  requirePrivateIp?: boolean;
+let installed = false;
+
+/**
+ * Whether a bootstrap payload's address must be private/loopback, read from the same native
+ * `allowPrivateLanOnly` build config (`CordieriteAllowPrivateLanOnly` in Info.plist / the Android
+ * manifest) that native `connect()` enforces — never a second, JS-side copy of the policy. JS can
+ * only ever *narrow* what native allows, so a JS knob that disagreed with native would be a no-op
+ * at best (native rejects the address anyway) and a misleading one at worst.
+ *
+ * Fail-closed on any read failure: an unresolvable native module means no `connect()` can succeed
+ * regardless, so the strict default costs nothing and never widens trust by accident.
+ */
+const requirePrivateIp = (): boolean => {
+  try {
+    return getCordieriteNativeBuildConfig().allowPrivateLanOnly;
+  } catch (error) {
+    logger.debug(
+      "Cordierite: could not read allowPrivateLanOnly; requiring a private address",
+      error,
+    );
+    return true;
+  }
 };
-
-const normalizeOptions = (
-  options: InstallCordieriteDeepLinkBootstrapOptions
-): Required<InstallCordieriteDeepLinkBootstrapOptions> => ({
-  requirePrivateIp: options.requirePrivateIp ?? true,
-});
-
-const optionsEqual = (
-  a: Required<InstallCordieriteDeepLinkBootstrapOptions>,
-  b: Required<InstallCordieriteDeepLinkBootstrapOptions>
-): boolean => a.requirePrivateIp === b.requirePrivateIp;
-
-let installedOptions: Required<InstallCordieriteDeepLinkBootstrapOptions> | null =
-  null;
 
 /**
  * Subscribes to runtime deep links immediately, then attempts startup recovery before considering
- * the initial URL. Safe to call once; later calls no-op — except that a later call with *different*
- * options than the first installation logs a dev warning, since the first installation's options
- * silently remain in effect (the v1 defect: the run-once guard gave callers no way to discover a
- * conflicting reinstall).
+ * the initial URL. Idempotent: later calls no-op.
+ *
+ * @internal Reached by app code only through the `./auto` entry, which passes the default client.
  */
 export function installCordieriteDeepLinkBootstrap(
   client: CordieriteAutoBootstrapClient,
-  options: InstallCordieriteDeepLinkBootstrapOptions = {}
 ): void {
-  const normalized = normalizeOptions(options);
-
-  if (installedOptions) {
-    if (!optionsEqual(installedOptions, normalized)) {
-      logger.devWarn(
-        "installCordieriteDeepLinkBootstrap was already installed with different options; " +
-          "the options from the first call remain in effect."
-      );
-    }
+  if (installed) {
     return;
   }
-  installedOptions = normalized;
+  installed = true;
 
   try {
     Linking.addEventListener("url", ({ url }) => {
-      handleCordieriteDeepLinkUrl(client, url, normalized);
+      handleCordieriteDeepLinkUrl(client, url, {
+        requirePrivateIp: requirePrivateIp(),
+      });
     });
   } catch (error) {
     logger.warn("Cordierite: Linking.addEventListener(url) failed", error);
@@ -62,7 +60,7 @@ export function installCordieriteDeepLinkBootstrap(
     // This is only the orchestration safety net; do not include the error because a third-party
     // client implementation could put lease credentials in its rejection message.
     logger.warn(
-      "Cordierite: startup session recovery failed; falling back to the initial URL"
+      "Cordierite: startup session recovery failed; falling back to the initial URL",
     );
   };
 
@@ -98,7 +96,9 @@ export function installCordieriteDeepLinkBootstrap(
     }
 
     const initialUrl = await initialUrlPromise;
-    handleCordieriteDeepLinkUrl(client, initialUrl, normalized);
+    handleCordieriteDeepLinkUrl(client, initialUrl, {
+      requirePrivateIp: requirePrivateIp(),
+    });
   })().catch(() => {
     logger.warn("Cordierite: startup bootstrap orchestration failed");
   });
@@ -106,5 +106,5 @@ export function installCordieriteDeepLinkBootstrap(
 
 /** @internal */
 export function __cordieriteResetInstallGuardForTests(): void {
-  installedOptions = null;
+  installed = false;
 }

--- a/packages/react-native/src/default-client.ts
+++ b/packages/react-native/src/default-client.ts
@@ -1,0 +1,93 @@
+import {
+  cordieriteNativeModule,
+  cordieriteNativeResumeLeaseStore,
+  isCordieriteNativeModuleAvailable,
+} from "./CordieriteModule";
+import { createCordieriteClient } from "./client";
+import { realAppState } from "./client/real-app-state";
+import { logger } from "./logger";
+
+/**
+ * The default client singleton and the native-availability gate the root (`.`) and `./auto`
+ * entries both build on. Kept out of `index.ts` so `./auto` can reach the gate without `index.ts`
+ * having to export it — `auto.ts` re-exports the whole root entry (`export * from "./index"`), so
+ * anything exported there is public API by construction.
+ */
+
+let cordieriteClientInstance: ReturnType<typeof createCordieriteClient> | null =
+  null;
+
+/**
+ * Whether Cordierite's native module exists in a build at all is decided entirely by
+ * autolinking (see `docs/tasks/00-overview.md`'s "Inclusion" contract), not by any runtime
+ * check here. When it is absent — Expo Go, a JS-only bundle, or the app excluded Cordierite
+ * from autolinking — `TurboModuleRegistry` never finds it, and every exported function of the root
+ * entry degrades to the exact `./noop` entry's behavior instead of the real client's — see
+ * `noopIfNativeUnavailable`. Logged exactly once per process, not once per call, so an app that
+ * calls these functions in a loop or on every render is not spammed.
+ */
+let warnedNativeModuleInert = false;
+const warnNativeModuleInertOnce = (): void => {
+  if (warnedNativeModuleInert) {
+    return;
+  }
+  warnedNativeModuleInert = true;
+  logger.warn(
+    "Cordierite: the native module is not available in this build (Expo Go/JS-only, or " +
+      "excluded via autolinking). The public API is inert, matching the `./noop` entry.",
+  );
+};
+
+/** Runs `whenInert()` (a `./noop` call) instead of `whenAvailable()` (the real client call) once
+ * the native module has been found unavailable, warning exactly once the first time this happens. */
+export function noopIfNativeUnavailable<T>(
+  whenAvailable: () => T,
+  whenInert: () => T,
+): T {
+  if (!isCordieriteNativeModuleAvailable()) {
+    warnNativeModuleInertOnce();
+    return whenInert();
+  }
+  return whenAvailable();
+}
+
+/**
+ * Constructing a `CordieriteClient` subscribes native event listeners immediately —
+ * harmless when the native module is unavailable (`CordieriteModule.ts`'s `addListener` never
+ * throws) but still real work. Deferring the construction itself until first use keeps the root
+ * entry genuinely side-effect-free at import time (ARCHITECTURE.md §11), not merely
+ * non-throwing.
+ */
+const getCordieriteClientInstance = (): ReturnType<
+  typeof createCordieriteClient
+> => {
+  if (!cordieriteClientInstance) {
+    cordieriteClientInstance = createCordieriteClient(cordieriteNativeModule, {
+      appState: realAppState,
+      resumeLeaseStore: cordieriteNativeResumeLeaseStore,
+    });
+  }
+  return cordieriteClientInstance;
+};
+
+/**
+ * Default Cordierite client (native TurboModule, real `AppState`). Prefer importing the package
+ * top-level functions (`registerTool`, `postEvent`, `addCordieriteListener`, `getCordieriteState`,
+ * `restoreSession`) for typical app code; use this instance only for advanced flows (manual
+ * `connect`/`send`, custom listeners, testing).
+ *
+ * A `Proxy` so that merely referencing this export (or importing the module) never constructs the
+ * underlying client — only an actual property access (e.g. `cordieriteClient.getState()`) does,
+ * which is also the first point the root entry's top-level functions touch it.
+ */
+export const cordieriteClient = new Proxy(
+  {} as ReturnType<typeof createCordieriteClient>,
+  {
+    get(_target, property, receiver) {
+      return Reflect.get(getCordieriteClientInstance(), property, receiver);
+    },
+    has(_target, property) {
+      return Reflect.has(getCordieriteClientInstance(), property);
+    },
+  },
+);

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -10,18 +10,10 @@ import type {
 } from "./Cordierite.types";
 import {
   cordieriteNativeModule,
-  cordieriteNativeResumeLeaseStore,
   getCordieriteNativeBuildConfig,
-  isCordieriteNativeModuleAvailable,
 } from "./CordieriteModule";
 import { parseBootstrapPayload, parseBootstrapUrl } from "./bootstrap";
-import { createCordieriteClient } from "./client";
-import { realAppState } from "./client/real-app-state";
-import {
-  installCordieriteDeepLinkBootstrap as installDeepLinkBootstrap,
-  type InstallCordieriteDeepLinkBootstrapOptions,
-} from "./deep-link-install";
-import { logger } from "./logger";
+import { cordieriteClient, noopIfNativeUnavailable } from "./default-client";
 import * as noop from "./noop";
 import { createUseCordieriteTool } from "./useCordieriteTool";
 
@@ -34,102 +26,9 @@ export {
   type CreateCordieriteClientOptions,
 } from "./client";
 export { cordieriteNativeModule };
-export type { InstallCordieriteDeepLinkBootstrapOptions } from "./deep-link-install";
+export { cordieriteClient };
 export type { CordierePublicApi, CordieriteSubscription } from "./public-api";
 export type { UseCordieriteToolOptions } from "./useCordieriteTool";
-
-let cordieriteClientInstance: ReturnType<typeof createCordieriteClient> | null =
-  null;
-
-/**
- * Whether Cordierite's native module exists in a build at all is decided entirely by
- * autolinking (see `docs/tasks/00-overview.md`'s "Inclusion" contract), not by any runtime
- * check here. When it is absent — Expo Go, a JS-only bundle, or the app excluded Cordierite
- * from autolinking — `TurboModuleRegistry` never finds it, and every exported function below
- * degrades to the exact `./noop` entry's behavior instead of the real client's — see
- * `noopIfNativeUnavailable`. Logged exactly once per process, not once per call, so an app that
- * calls these functions in a loop or on every render is not spammed.
- */
-let warnedNativeModuleInert = false;
-const warnNativeModuleInertOnce = (): void => {
-  if (warnedNativeModuleInert) {
-    return;
-  }
-  warnedNativeModuleInert = true;
-  logger.warn(
-    "Cordierite: the native module is not available in this build (Expo Go/JS-only, or " +
-      "excluded via autolinking). The public API is inert, matching the `./noop` entry.",
-  );
-};
-
-/** Runs `whenInert()` (a `./noop` call) instead of `whenAvailable()` (the real client call) once
- * the native module has been found unavailable, warning exactly once the first time this happens. */
-function noopIfNativeUnavailable<T>(
-  whenAvailable: () => T,
-  whenInert: () => T,
-): T {
-  if (!isCordieriteNativeModuleAvailable()) {
-    warnNativeModuleInertOnce();
-    return whenInert();
-  }
-  return whenAvailable();
-}
-
-/**
- * Constructing a `CordieriteClient` subscribes native event listeners immediately —
- * harmless when the native module is unavailable (`CordieriteModule.ts`'s `addListener` never
- * throws) but still real work. Deferring the construction itself until first use keeps this root
- * entry genuinely side-effect-free at import time (ARCHITECTURE.md §11), not merely
- * non-throwing.
- */
-const getCordieriteClientInstance = (): ReturnType<
-  typeof createCordieriteClient
-> => {
-  if (!cordieriteClientInstance) {
-    cordieriteClientInstance = createCordieriteClient(cordieriteNativeModule, {
-      appState: realAppState,
-      resumeLeaseStore: cordieriteNativeResumeLeaseStore,
-    });
-  }
-  return cordieriteClientInstance;
-};
-
-/**
- * Default Cordierite client (native TurboModule, real `AppState`). Prefer importing the package
- * top-level functions (`registerTool`, `postEvent`, `addCordieriteListener`, `getCordieriteState`,
- * `installCordieriteDeepLinkBootstrap`) for typical app code; use this instance only for advanced
- * flows (manual `connect`/`send`, custom listeners, testing).
- *
- * A `Proxy` so that merely referencing this export (or importing the module) never constructs the
- * underlying client — only an actual property access (e.g. `cordieriteClient.getState()`) does,
- * which is also the first point any of this module's other top-level functions touch it.
- */
-export const cordieriteClient = new Proxy(
-  {} as ReturnType<typeof createCordieriteClient>,
-  {
-    get(_target, property, receiver) {
-      return Reflect.get(getCordieriteClientInstance(), property, receiver);
-    },
-    has(_target, property) {
-      return Reflect.has(getCordieriteClientInstance(), property);
-    },
-  },
-);
-
-/**
- * Subscribes the default client to runtime deep links and attempts native-lease recovery before
- * processing the initial URL. Safe to call once; a later call with different `options` logs a dev
- * warning instead of silently keeping the first installation's options (see
- * `deep-link-install.ts`).
- */
-export function installCordieriteDeepLinkBootstrap(
-  options?: InstallCordieriteDeepLinkBootstrapOptions,
-): void {
-  noopIfNativeUnavailable(
-    () => installDeepLinkBootstrap(cordieriteClient, options),
-    () => noop.installCordieriteDeepLinkBootstrap(options),
-  );
-}
 
 /**
  * Register a Cordierite tool on the default client. Same as `cordieriteClient.registerTool` —
@@ -189,8 +88,8 @@ export function addCordieriteListener<Kind extends CordieriteListenerKind>(
  * `true` once a resume attempt has started (not once the daemon has acknowledged it), `false` when
  * there is no valid, unexpired lease to restore or this client is already connecting/active.
  *
- * `installCordieriteDeepLinkBootstrap` (and the `./auto` entry) already calls this at startup, so
- * apps using it need nothing more. Call this explicitly if you handle bootstrap links yourself —
+ * The `./auto` entry already calls this at startup, so apps importing it need nothing more. Call
+ * this explicitly if you handle bootstrap links yourself —
  * custom deep-link routing, QR scanning, a manual `connect()` — because otherwise **nothing** reads
  * the lease, and every Metro reload silently drops a session the native side could still have
  * resumed. Call it once at startup, before your own bootstrap handling: a successful restore means
@@ -216,9 +115,9 @@ export function getCordieriteState(): CordieriteClientState {
 
 /**
  * Manually starts the claim/resume handshake on the default client from a decoded bootstrap payload
- * or explicit connect options. Most apps never call this directly — `installCordieriteDeepLinkBootstrap`
- * (or the `./auto` entry) drives it from incoming deep links — but it is exposed for manual bootstrap
- * flows (custom deep-link handling, QR scanning, tests).
+ * or explicit connect options. Most apps never call this directly — the `./auto` entry drives it
+ * from incoming deep links — but it is exposed for manual bootstrap flows (custom deep-link
+ * handling, QR scanning, tests).
  */
 export function connect(input: CordieriteConnectInput): Promise<void> {
   return noopIfNativeUnavailable(

--- a/packages/react-native/src/noop.ts
+++ b/packages/react-native/src/noop.ts
@@ -19,12 +19,10 @@ import type {
   CordieriteUnifiedListenerMap,
 } from "./Cordierite.types";
 import { CordieriteDisabledError } from "./Cordierite.types";
-import type { InstallCordieriteDeepLinkBootstrapOptions } from "./deep-link-install";
 import type { CordieriteSubscription } from "./public-api";
 import { createUseCordieriteTool } from "./useCordieriteTool";
 
 export * from "./Cordierite.types";
-export type { InstallCordieriteDeepLinkBootstrapOptions } from "./deep-link-install";
 export type { CordierePublicApi, CordieriteSubscription } from "./public-api";
 export type { UseCordieriteToolOptions } from "./useCordieriteTool";
 
@@ -56,11 +54,6 @@ export async function postEvent(
 export function getRegisteredTools(): ToolDescriptor[] {
   return [];
 }
-
-/** No-op: this build never installs deep-link listeners. */
-export function installCordieriteDeepLinkBootstrap(
-  _options?: InstallCordieriteDeepLinkBootstrapOptions,
-): void {}
 
 /** No-op: the returned subscription is inert and the callback never fires. */
 export function addCordieriteListener<Kind extends CordieriteListenerKind>(

--- a/packages/react-native/src/public-api.ts
+++ b/packages/react-native/src/public-api.ts
@@ -10,7 +10,6 @@ import type {
   CordieriteToolRegistration,
   CordieriteUnifiedListenerMap,
 } from "./Cordierite.types";
-import type { InstallCordieriteDeepLinkBootstrapOptions } from "./deep-link-install";
 import type { UseCordieriteToolOptions } from "./useCordieriteTool";
 
 export type CordieriteSubscription = { remove(): void };
@@ -40,10 +39,6 @@ export type CordierePublicApi = {
   postEvent(name: string, payload?: unknown): Promise<void>;
 
   getRegisteredTools(): ToolDescriptor[];
-
-  installCordieriteDeepLinkBootstrap(
-    options?: InstallCordieriteDeepLinkBootstrapOptions,
-  ): void;
 
   addCordieriteListener<Kind extends CordieriteListenerKind>(
     kind: Kind,

--- a/playground/app/_layout.tsx
+++ b/playground/app/_layout.tsx
@@ -8,7 +8,7 @@ import { StatusBar } from "expo-status-bar";
 import "react-native-reanimated";
 // Side-effect entry (ARCHITECTURE.md §11): installs the default deep-link bootstrap listener on
 // import, so opening the host's bootstrap link (QR / `cordierite link --open`) is enough to start
-// a session -- no manual `installCordieriteDeepLinkBootstrap()` call needed in this app.
+// a session. `require("@cordierite/react-native/auto")` would install it lazily instead.
 import "@cordierite/react-native/auto";
 
 import { Colors } from "@/constants/theme";

--- a/skills/cordierite/references/setup.md
+++ b/skills/cordierite/references/setup.md
@@ -11,9 +11,11 @@ Use this file when the task is to add Cordierite to a new React Native project.
 3. Register the app tools you want Cordierite to expose (`registerTool` /
    `useCordieriteTool`).
 4. Import `@cordierite/react-native/auto` once near the app's entry point to install the
-   deep-link bootstrap listener automatically. (If you'd rather drive bootstrap
-   yourself — custom deep-link handling, QR scanning, tests — import the side-effect-free
-   root entry instead and call `installCordieriteDeepLinkBootstrap()` when ready.)
+   deep-link bootstrap listener automatically — or `require()` it at the point you want
+   it installed (e.g. behind `__DEV__`). (If you'd rather drive bootstrap yourself —
+   custom deep-link handling, QR scanning, tests — skip that entry, use the
+   side-effect-free root entry, and call `restoreSession()` at startup before your own
+   bootstrap handling so a Metro reload still recovers the session.)
 5. Generate a TLS private key for the daemon. For a new setup, run `cordierite keygen`
    (non-interactive with `--out <path>`; writes `~/.cordierite/key.pem` by default).
 6. Add the matching `sha256/...` SPKI pin to the app configuration, in a `cliPins` array


### PR DESCRIPTION
**Stacked on #18** — review that one first; this branch targets it.

## `requirePrivateIp` was a JS copy of policy native already owns

`allowPrivateLanOnly` is native build config (`CordieriteAllowPrivateLanOnly` in Info.plist / the Android manifest, default `true`) and native `connect()` enforces it on both platforms:

```swift
if allowPrivateLanOnly && !isLocalIpv4Address(options.ip) {   // CordieriteConnectionManager.swift:424
```
```kotlin
if (allowPrivateLanOnly && !isLocalIpv4Address(options.ip)) { // CordieriteConnectionManager.kt:596
```

So the JS option could only ever *narrow* what native allows — the same invariant the trust/pin config already documents ("config can only narrow trust, never widen it"). Setting `requirePrivateIp: false` without also setting the native key did nothing useful: the payload parsed, then native `connect()` refused the address anyway. A knob that looks like the control and isn't.

The deep-link handler now reads `allowPrivateLanOnly` via the same `getConstants()` path native enforces from, failing closed when it can't be read. One source of truth, flowing one direction.

## `/auto` is now the only install path

With no options left, `installCordieriteDeepLinkBootstrap` no longer configured anything — it only decided *when* the listener and startup restore run. `require("@cordierite/react-native/auto")` expresses that directly (Metro resolves it lazily; installing twice installs once), so the function is internal now and `/auto` is the only way in.

That deletes the machinery that existed solely to police the option: `normalizeOptions`, `optionsEqual`, `installedOptions`, and the "installed with different options" dev warning collapse to a boolean guard.

## `default-client.ts`

The default client singleton and the native-availability gate move out of `index.ts`. `auto.ts` does `export * from "./index"`, so anything `index.ts` exports is public API by construction — leaving them there would have meant `/auto` re-exporting an internal install function right back out. Both entries now import them from a module neither re-exports.

## Surface after this

- `/auto` — installs; `import` it, or `require()` it where you want it gated
- root entry — `restoreSession()`, `connect()`, `parseBootstrapUrl()` for manual flows; installs nothing
- gone: `installCordieriteDeepLinkBootstrap`, `InstallCordieriteDeepLinkBootstrapOptions`, `requirePrivateIp`

## Testing

- New: a non-private address connects only when native reports `allowPrivateLanOnly: false`, and is refused when the build config can't be read (with a follow-up assertion that the listener is actually live, so the negative case can't pass for the wrong reason)
- `root-entry-inert-parity` now covers "importing `/auto` in an inert build installs no `Linking` listener"
- 208 tests pass, `tsc` clean, `turbo build` clean, no new lint warnings
- Docs updated to describe the API as it stands: README, ARCHITECTURE.md §11, the `cordierite` skill's setup reference, and the playground's `_layout.tsx` comment
