### PR TITLE
fix: exclude ios/CordieriteTests from npm package

### DIFF
--- a/packages/react-native/.npmignore
+++ b/packages/react-native/.npmignore
@@ -11,4 +11,5 @@ __tests__
 /android/src/androidTest/
 /android/src/test/
 /android/build/
+/ios/CordieriteTests/
 /example/


### PR DESCRIPTION
## Summary
- `@cordierite/react-native`'s `.npmignore` excluded `__tests__`/`__mocks__` and Android's `androidTest`/`test` dirs, but not the iOS Swift test target, so `ios/CordieriteTests/CordieriteConnectionManagerTests.swift` was shipping in the published tarball.
- Added `/ios/CordieriteTests/` to `.npmignore`.

## Test plan
- [x] `npm pack --dry-run` in `packages/react-native` confirms the file no longer appears in the tarball contents.