### PR TITLE
fix(react-native): register useCordieriteTool once per mount and route calls through a ref (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ useCordieriteTool({
 });
 ```
 
-The hook registers once per mount — re-rendering costs nothing, and the handler always sees the
-latest state it closes over.
+The hook registers once per mount — re-rendering costs nothing for a schema that exports JSON
+Schema (Zod 4, ArkType) or is hoisted out of the component, and the handler always sees the latest
+state it closes over. The [package README](packages/react-native/README.md#5-define-tools-in-app-startup-code)
+covers the one exception, schemas that cannot export JSON Schema.
 
 Call it from your terminal:
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Cordierite lets a terminal, a test runner, or an AI agent call functions inside 
 Register something you want reachable:
 
 ```ts
+import { useCordieriteTool } from "@cordierite/react-native";
+import { z } from "zod";
+
 useCordieriteTool({
   name: "seed_cart",
   description: "Fill the cart with test items.",
@@ -28,6 +31,9 @@ useCordieriteTool({
   handler: async ({ items }) => ({ added: items }),
 });
 ```
+
+The hook registers once per mount — re-rendering costs nothing, and the handler always sees the
+latest state it closes over.
 
 Call it from your terminal:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -392,8 +392,10 @@ Client behavior:
   enforcement point inside the app's own trust boundary (§12). The JSON Schema exporter is
   injected into `createUseCordieriteTool` by the `.` entry and deliberately omitted by
   `./noop`, whose registrar registers nothing: the inert entry keys the effect off
-  `enabled` alone and never imports schema export at all. Signature, arity and observable
-  behavior stay identical, which is what `__tests__/noop-parity.test.ts` pins.
+  `enabled` alone and never imports schema export at all. `__tests__/noop-parity.test.ts`
+  pins the API shape and arity; the behavioral half — that the inert entry never exports,
+  and still honors `enabled` — is pinned by the "inert entry" cases in
+  `__tests__/use-cordierite-tool.test.ts`.
 - `postEvent(name, payload?)` — emits an `event` frame when active; silently drops (dev
   warning) otherwise.
 - Unified listener: `addCordieriteListener(kind, cb)` with kinds `stateChange`,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -372,9 +372,20 @@ Client behavior:
   registration identity, not name). Duplicate name registration logs a dev warning and
   overwrites.
 - `useCordieriteTool(definition, deps?, { enabled? })` — `useEffect` wrapper around
-  `registerTool`/`remove`. `enabled` (default `true`) is the supported way to gate a tool by
-  build variant without breaking the rules of hooks; registration is the app-side allowlist,
-  and it is the only enforcement point inside the app's own trust boundary (§12).
+  `registerTool`/`remove`. It registers **once per mount**: the registered handler is a
+  stable wrapper forwarding to the latest render's `definition.handler`, so a handler
+  closing over component state is fresh on every call without re-registering. With `deps`
+  omitted (the documented default) the effect keys off a derived, fixed-length dependency
+  list of exactly what the daemon can observe — `name`, `description`, `timeoutMs`,
+  stringified `annotations`, the exported input/output JSON Schemas, and `enabled` — so a
+  re-render never emits a `tool_registry_delta` pair or an agent-side
+  `notifications/tools/list_changed`. Schemas are compared by identity first and re-exported
+  only when the identity changed (hoisted/memoized schemas never re-export; an inline
+  `z.object({…})` re-exports once per render and still matches by shape). A caller-supplied
+  `deps` is an explicit override with `useEffect`'s own semantics (`[...deps, enabled]`).
+  `enabled` (default `true`) is the supported way to gate a tool by build variant without
+  breaking the rules of hooks; registration is the app-side allowlist, and it is the only
+  enforcement point inside the app's own trust boundary (§12).
 - `postEvent(name, payload?)` — emits an `event` frame when active; silently drops (dev
   warning) otherwise.
 - Unified listener: `addCordieriteListener(kind, cb)` with kinds `stateChange`,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -376,16 +376,24 @@ Client behavior:
   stable wrapper forwarding to the latest render's `definition.handler`, so a handler
   closing over component state is fresh on every call without re-registering. With `deps`
   omitted (the documented default) the effect keys off a derived, fixed-length dependency
-  list of exactly what the daemon can observe — `name`, `description`, `timeoutMs`,
-  stringified `annotations`, the exported input/output JSON Schemas, and `enabled` — so a
-  re-render never emits a `tool_registry_delta` pair or an agent-side
-  `notifications/tools/list_changed`. Schemas are compared by identity first and re-exported
-  only when the identity changed (hoisted/memoized schemas never re-export; an inline
-  `z.object({…})` re-exports once per render and still matches by shape). A caller-supplied
-  `deps` is an explicit override with `useEffect`'s own semantics (`[...deps, enabled]`).
+  list of everything that changes the registry entry — `name`, `description`,
+  `timeoutMs` (app-side only, but part of the entry), stringified `annotations`, the
+  exported input/output JSON Schemas, and `enabled` — so a re-render never emits a
+  `tool_registry_delta` pair or an agent-side `notifications/tools/list_changed`. Schemas
+  are compared by identity first and re-exported only when the identity changed
+  (hoisted/memoized schemas never re-export; an inline `z.object({…})` re-exports once per
+  render and still matches by shape). A schema that exports no JSON Schema (zod 3, plain
+  valibot) has no shape to compare, so it falls back to identity — "exports nothing" must
+  not collapse into "no schema at all", which is what the entry's `outputSchema` presence
+  and §7's optional `input_schema`/`output_schema` are keyed on. A caller-supplied `deps`
+  is an explicit override with `useEffect`'s own semantics (`[...deps, enabled]`).
   `enabled` (default `true`) is the supported way to gate a tool by build variant without
   breaking the rules of hooks; registration is the app-side allowlist, and it is the only
-  enforcement point inside the app's own trust boundary (§12).
+  enforcement point inside the app's own trust boundary (§12). The JSON Schema exporter is
+  injected into `createUseCordieriteTool` by the `.` entry and deliberately omitted by
+  `./noop`, whose registrar registers nothing: the inert entry keys the effect off
+  `enabled` alone and never imports schema export at all. Signature, arity and observable
+  behavior stay identical, which is what `__tests__/noop-parity.test.ts` pins.
 - `postEvent(name, payload?)` — emits an `event` frame when active; silently drops (dev
   warning) otherwise.
 - Unified listener: `addCordieriteListener(kind, cb)` with kinds `stateChange`,

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -151,29 +151,46 @@ import { useCordieriteTool } from "@cordierite/react-native";
 import { z } from "zod";
 
 export function CordieriteBootstrap() {
-  useCordieriteTool(
-    {
-      name: "sum",
-      description: "Add two numeric values",
-      inputSchema: z.object({
-        a: z.number(),
-        b: z.number(),
-      }),
-      outputSchema: z.object({
-        total: z.number(),
-      }),
-      handler: async ({ a, b }) => ({
-        total: a + b,
-      }),
-    },
-    []
-  );
+  useCordieriteTool({
+    name: "sum",
+    description: "Add two numeric values",
+    inputSchema: z.object({
+      a: z.number(),
+      b: z.number(),
+    }),
+    outputSchema: z.object({
+      total: z.number(),
+    }),
+    handler: async ({ a, b }) => ({
+      total: a + b,
+    }),
+  });
 
   return null;
 }
 ```
 
 Mount that component near app startup, or register from another module that loads on startup. The host can only list and invoke tools that your app has already registered.
+
+**Registration is per mount, not per render.** The hook registers once when the component mounts and re-registers only when something the host can actually see changed: `name`, `description`, the exported input/output JSON Schemas, `annotations`, `timeoutMs`, or `enabled`. Re-rendering the component — including on every keystroke of some unrelated state — sends nothing over the wire and does not make agents re-fetch `tools/list`.
+
+**Your handler is always fresh.** The hook registers a stable wrapper that forwards to the handler from the latest render, so a handler that closes over component state sees the current value on the next call without being re-registered and without `useRef` workarounds:
+
+```ts
+const [cartId, setCartId] = useState<string | null>(null);
+
+useCordieriteTool({
+  name: "seed_cart",
+  description: "Fill the current cart with test items",
+  inputSchema: z.object({ items: z.number() }),
+  // Reads whatever `cartId` was on the most recent render, no re-registration involved.
+  handler: async ({ items }) => ({ cartId, added: items }),
+});
+```
+
+**Hoisting schemas is a small optimization, not a requirement.** Schemas are compared by object identity first, so a schema defined at module scope (or wrapped in `useMemo`) is never re-exported to JSON Schema. A schema built inline in the component body is re-exported once per render to compare its shape — the same cost the old unconditional re-registration already paid — and still does not re-register unless the shape actually changed.
+
+**`deps` is an optional, advanced override.** Passing it replaces the derived key entirely with `useEffect`'s own semantics (`enabled` is still appended), which is occasionally useful — e.g. forcing a re-registration on something the descriptor does not capture. Most call sites should simply omit it. Pass it consistently if you pass it at all: alternating between passing `deps` and omitting it changes the dependency-array length between renders, which React warns about, exactly as it does for a hand-written `useEffect`.
 
 **Cancellation:** `handler(args, context)`'s `context.signal` (an `AbortSignal`) aborts if the caller cancels the call, or if the session's connection is lost mid-call. Forward it into anything that accepts one (`fetch(url, { signal: context.signal })`) or check `context.signal.aborted`/listen for `"abort"` to stop early. Ignoring it is fine — the handler just keeps running and replies normally, as it always has.
 
@@ -193,7 +210,9 @@ useCordieriteTool(
     description: "Destructive: clears the local database",
     handler: async () => wipeLocalDb(),
   },
-  [],
+  // `options` is the third argument, so pass `undefined` for `deps` to keep the default
+  // (register once per mount, re-register only when the descriptor changes).
+  undefined,
   { enabled: process.env.EXPO_PUBLIC_CORDIERITE_TOOLS === "full" }
 );
 ```

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -188,7 +188,9 @@ useCordieriteTool({
 });
 ```
 
-**Hoisting schemas is a small optimization, not a requirement.** Schemas are compared by object identity first, so a schema defined at module scope (or wrapped in `useMemo`) is never re-exported to JSON Schema. A schema built inline in the component body is re-exported once per render to compare its shape — the same cost the old unconditional re-registration already paid — and still does not re-register unless the shape actually changed.
+**Hoisting schemas is a small optimization, not a requirement.** Schemas are compared by object identity first, so a schema defined at module scope (or wrapped in `useMemo`) is never re-exported to JSON Schema. A schema built inline in the component body is re-exported once per render to compare its shape — the same cost the old unconditional re-registration already paid — and still does not re-register unless the shape actually changed. Hoisting is worth a moment's thought for a hot component, and in builds that swap in the inert `./noop` entry, where that export buys nothing.
+
+Because the comparison is on the *exported* JSON Schema, the registry keeps the schema objects from the most recent registration: replacing a schema with an identity-different one that exports the same JSON Schema keeps validating against the earlier object. That only matters for a validation rule JSON Schema cannot express *and* that closes over changing state (a `.refine()` reading component state, say) — pass `deps` for that case.
 
 **`deps` is an optional, advanced override.** Passing it replaces the derived key entirely with `useEffect`'s own semantics (`enabled` is still appended), which is occasionally useful — e.g. forcing a re-registration on something the descriptor does not capture. Most call sites should simply omit it. Pass it consistently if you pass it at all: alternating between passing `deps` and omitting it changes the dependency-array length between renders, which React warns about, exactly as it does for a hand-written `useEffect`.
 

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -172,7 +172,7 @@ export function CordieriteBootstrap() {
 
 Mount that component near app startup, or register from another module that loads on startup. The host can only list and invoke tools that your app has already registered.
 
-**Registration is per mount, not per render.** The hook registers once when the component mounts and re-registers only when something the host can actually see changed: `name`, `description`, the exported input/output JSON Schemas, `annotations`, `timeoutMs`, or `enabled`. Re-rendering the component — including on every keystroke of some unrelated state — sends nothing over the wire and does not make agents re-fetch `tools/list`.
+**Registration is per mount, not per render.** The hook registers once when the component mounts and re-registers only when something that changes the registration itself changed: `name`, `description`, the exported input/output JSON Schemas, `annotations`, `timeoutMs`, or `enabled`. Re-rendering the component — including on every keystroke of some unrelated state — sends nothing over the wire and does not make agents re-fetch `tools/list`.
 
 **Your handler is always fresh.** The hook registers a stable wrapper that forwards to the handler from the latest render, so a handler that closes over component state sees the current value on the next call without being re-registered and without `useRef` workarounds:
 
@@ -188,9 +188,13 @@ useCordieriteTool({
 });
 ```
 
-**Hoisting schemas is a small optimization, not a requirement.** Schemas are compared by object identity first, so a schema defined at module scope (or wrapped in `useMemo`) is never re-exported to JSON Schema. A schema built inline in the component body is re-exported once per render to compare its shape — the same cost the old unconditional re-registration already paid — and still does not re-register unless the shape actually changed. Hoisting is worth a moment's thought for a hot component, and in builds that swap in the inert `./noop` entry, where that export buys nothing.
+**Hoisting schemas is a small optimization, not a requirement.** Schemas are compared by object identity first, so a schema defined at module scope (or wrapped in `useMemo`) is never re-exported to JSON Schema. A schema built inline in the component body is re-exported once per render to compare its shape — the same cost the old unconditional re-registration already paid — and still does not re-register unless the shape actually changed. Hoisting is worth a moment's thought for a hot component. (Builds that swap in the inert `./noop` entry never do any of this: that entry has no exporter at all, so it neither runs nor bundles JSON Schema export.)
 
-Because the comparison is on the *exported* JSON Schema, the registry keeps the schema objects from the most recent registration: replacing a schema with an identity-different one that exports the same JSON Schema keeps validating against the earlier object. That only matters for a validation rule JSON Schema cannot express *and* that closes over changing state (a `.refine()` reading component state, say) — pass `deps` for that case.
+A schema that does **not** export JSON Schema (zod 3, plain valibot — the same ones that get the "shapeless tool" dev warning) has no shape to compare, so it falls back to object identity: adding, swapping or removing one always re-registers, and one rebuilt inline on every render therefore re-registers on every render, exactly as it did before. Hoist it, or move to zod v4, whose built-in exporter puts it back on the cheap by-shape path.
+
+Because exportable schemas are compared by their *exported* JSON Schema, the registry keeps the schema objects from the most recent registration: replacing one with an identity-different schema that exports the same JSON Schema keeps validating against the earlier object. That only matters for a validation rule JSON Schema cannot express *and* that closes over changing state (a `.refine()` reading component state, say) — pass `deps` for that case.
+
+**Two mounted hooks registering the same tool name** were never a supported configuration (the registry dev-warns and the later registration overwrites the earlier). One consequence is worth knowing: when the later hook unmounts, the earlier one no longer re-claims the name on its next render, so the tool stays unregistered until that hook re-registers for its own reasons. Give each tool one owner.
 
 **`deps` is an optional, advanced override.** Passing it replaces the derived key entirely with `useEffect`'s own semantics (`enabled` is still appended), which is occasionally useful — e.g. forcing a re-registration on something the descriptor does not capture. Most call sites should simply omit it. Pass it consistently if you pass it at all: alternating between passing `deps` and omitting it changes the dependency-array length between renders, which React warns about, exactly as it does for a hand-written `useEffect`.
 

--- a/packages/react-native/src/__tests__/use-cordierite-tool.test.ts
+++ b/packages/react-native/src/__tests__/use-cordierite-tool.test.ts
@@ -7,6 +7,7 @@ import type {
   CordieriteToolRegistration,
 } from "../Cordierite.types";
 import type { CordieriteSubscription } from "../public-api";
+import { exportToolSchema } from "../schema";
 
 (globalThis as { __DEV__?: boolean }).__DEV__ = true;
 
@@ -33,7 +34,6 @@ const createFakeReactHost = () => {
   let prevDeps: readonly unknown[] | undefined;
   let hasRunOnce = false;
   let cleanup: EffectCleanup;
-  let effectRunCount = 0;
 
   const useRef = <T>(initial: T): { current: T } => {
     const index = refCursor;
@@ -60,7 +60,6 @@ const createFakeReactHost = () => {
     cleanup?.();
     hasRunOnce = true;
     prevDeps = deps;
-    effectRunCount += 1;
     cleanup = effect();
   };
 
@@ -75,9 +74,6 @@ const createFakeReactHost = () => {
       cleanup?.();
       cleanup = undefined;
     },
-    get effectRunCount() {
-      return effectRunCount;
-    },
   };
 };
 
@@ -88,6 +84,8 @@ type Registration = {
   description: string;
   /** The handler the hook actually registered (the stable wrapper, not the caller's closure). */
   handler: CordieriteToolHandler;
+  /** What tool-invocation's "must not return a result when outputSchema is omitted" rule keys on. */
+  hasOutputSchema: boolean;
 };
 
 const makeRegisterTool = () => {
@@ -106,6 +104,7 @@ const makeRegisterTool = () => {
       name: registration.name,
       description: registration.description,
       handler: registration.handler as CordieriteToolHandler,
+      hasOutputSchema: registration.outputSchema !== undefined,
     };
     registrations.push(entry);
     return {
@@ -125,6 +124,12 @@ const toolDefinition = (
   description: "test tool",
   handler: () => undefined,
 });
+
+/**
+ * What the real (`.`) entry passes: the JSON Schema exporter that makes the derived registration
+ * key possible. The inert (`./noop`) entry deliberately passes nothing -- covered separately below.
+ */
+const realEntryOptions = { exportSchema: exportToolSchema };
 
 /** Enough of an execution context to invoke a registered handler that ignores it. */
 const fakeContext = {} as CordieriteToolExecutionContext;
@@ -148,6 +153,16 @@ const schemaExporting = (
     },
   }) as unknown as CordieriteRuntimeSchema;
 
+/** A Standard Schema with no JSON Schema exporter -- the zod 3 / plain valibot shape. */
+const shapelessSchema = (): CordieriteRuntimeSchema =>
+  ({
+    "~standard": {
+      version: 1,
+      vendor: "test",
+      validate: (value: unknown) => ({ value }),
+    },
+  }) as unknown as CordieriteRuntimeSchema;
+
 describe("createUseCordieriteTool", () => {
   let host: ReturnType<typeof createFakeReactHost>;
 
@@ -163,7 +178,10 @@ describe("createUseCordieriteTool", () => {
   test("registers on mount and disposes on unmount", async () => {
     const { registerTool, registrations } = makeRegisterTool();
     const { createUseCordieriteTool } = await import("../useCordieriteTool");
-    const useCordieriteTool = createUseCordieriteTool(registerTool);
+    const useCordieriteTool = createUseCordieriteTool(
+      registerTool,
+      realEntryOptions,
+    );
 
     host.render(() => {
       useCordieriteTool(toolDefinition(), []);
@@ -180,7 +198,10 @@ describe("createUseCordieriteTool", () => {
   test("does not re-register across re-renders with unchanged deps", async () => {
     const { registerTool, registrations } = makeRegisterTool();
     const { createUseCordieriteTool } = await import("../useCordieriteTool");
-    const useCordieriteTool = createUseCordieriteTool(registerTool);
+    const useCordieriteTool = createUseCordieriteTool(
+      registerTool,
+      realEntryOptions,
+    );
 
     host.render(() => useCordieriteTool(toolDefinition(), [1]));
     host.render(() => useCordieriteTool(toolDefinition(), [1]));
@@ -192,7 +213,10 @@ describe("createUseCordieriteTool", () => {
   test("disposes the old registration and creates a new one when deps change (fast-refresh churn)", async () => {
     const { registerTool, registrations } = makeRegisterTool();
     const { createUseCordieriteTool } = await import("../useCordieriteTool");
-    const useCordieriteTool = createUseCordieriteTool(registerTool);
+    const useCordieriteTool = createUseCordieriteTool(
+      registerTool,
+      realEntryOptions,
+    );
 
     host.render(() => useCordieriteTool(toolDefinition(), [1]));
     host.render(() => useCordieriteTool(toolDefinition(), [2]));
@@ -206,7 +230,10 @@ describe("createUseCordieriteTool", () => {
     test("N re-renders with an unchanged definition produce exactly one registration and no removals", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
-      const useCordieriteTool = createUseCordieriteTool(registerTool);
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
 
       // A fresh definition object (and a fresh handler closure) per render, which is what an
       // inline `useCordieriteTool({ ... })` call inside a component body produces.
@@ -221,7 +248,10 @@ describe("createUseCordieriteTool", () => {
     test("changing description re-registers (remove + upsert)", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
-      const useCordieriteTool = createUseCordieriteTool(registerTool);
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
 
       host.render(() =>
         useCordieriteTool({ ...toolDefinition(), description: "before" }),
@@ -242,7 +272,10 @@ describe("createUseCordieriteTool", () => {
     test("changing annotations or timeoutMs re-registers", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
-      const useCordieriteTool = createUseCordieriteTool(registerTool);
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
 
       host.render(() =>
         useCordieriteTool({
@@ -286,7 +319,10 @@ describe("createUseCordieriteTool", () => {
     test("a handler closing over changed state does not re-register, and the next call sees the new value", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
-      const useCordieriteTool = createUseCordieriteTool(registerTool);
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
 
       // Stands in for component state: each render closes over a different value.
       let state = 1;
@@ -314,7 +350,10 @@ describe("createUseCordieriteTool", () => {
     test("an inline schema rebuilt each render with an equal shape does not re-register", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
-      const useCordieriteTool = createUseCordieriteTool(registerTool);
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
 
       const renderWithShape = (shape: Record<string, unknown>) =>
         host.render(() =>
@@ -353,7 +392,10 @@ describe("createUseCordieriteTool", () => {
     test("a hoisted schema kept by identity re-exports nothing and never re-registers", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
-      const useCordieriteTool = createUseCordieriteTool(registerTool);
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
 
       let exportCount = 0;
       const shape = { type: "object" as const };
@@ -389,6 +431,236 @@ describe("createUseCordieriteTool", () => {
       expect(registrations).toHaveLength(1);
       expect(exportCount).toBe(1);
     });
+
+    test("changing name re-registers under the new name", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
+
+      host.render(() => useCordieriteTool(toolDefinition("before")));
+      host.render(() => useCordieriteTool(toolDefinition("after")));
+
+      expect(registrations.map((entry) => entry.name)).toEqual([
+        "before",
+        "after",
+      ]);
+      expect(registrations[0]?.removed).toBe(true);
+      expect(registrations[1]?.removed).toBe(false);
+    });
+
+    test("changing the output schema's shape re-registers", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
+
+      const renderWithShape = (shape: Record<string, unknown>) =>
+        host.render(() =>
+          useCordieriteTool({
+            name: "t",
+            description: "test tool",
+            outputSchema: schemaExporting(shape),
+            handler: () => undefined,
+          }),
+        );
+
+      renderWithShape({
+        type: "object",
+        properties: { total: { type: "number" } },
+      });
+      renderWithShape({
+        type: "object",
+        properties: { total: { type: "number" } },
+      });
+      expect(registrations).toHaveLength(1);
+
+      renderWithShape({
+        type: "object",
+        properties: { total: { type: "string" } },
+      });
+
+      expect(registrations).toHaveLength(2);
+      expect(registrations[0]?.removed).toBe(true);
+    });
+
+    test("a schema that exports no JSON Schema still re-registers when it is added, swapped or removed", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
+
+      // "exports nothing" and "there is no schema" must not collapse to the same key: the registry
+      // entry still holds the object and validates against it, and `tool-invocation.ts` rejects a
+      // returned result when the entry has no `outputSchema`.
+      let outputSchema: CordieriteRuntimeSchema | undefined;
+      const render = () =>
+        host.render(() =>
+          useCordieriteTool({
+            name: "t",
+            description: "test tool",
+            outputSchema,
+            handler: () => undefined,
+          }),
+        );
+
+      render();
+      outputSchema = shapelessSchema();
+      render();
+      // A different unexportable schema object: nothing to compare by value, so identity decides.
+      outputSchema = shapelessSchema();
+      render();
+      outputSchema = undefined;
+      render();
+
+      expect(registrations).toHaveLength(4);
+      expect(registrations.map((entry) => entry.hasOutputSchema)).toEqual([
+        false,
+        true,
+        true,
+        false,
+      ]);
+      expect(registrations.at(-1)?.removed).toBe(false);
+    });
+
+    test("an unchanged unexportable schema kept by identity does not re-register", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
+
+      const hoisted = shapelessSchema();
+      const render = () =>
+        host.render(() =>
+          useCordieriteTool({
+            name: "t",
+            description: "test tool",
+            inputSchema: hoisted,
+            handler: () => undefined,
+          }),
+        );
+
+      render();
+      render();
+      render();
+
+      expect(registrations).toHaveLength(1);
+    });
+
+    test("a null deps argument (untyped JS callers) behaves like an omitted one", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
+
+      const nullDeps = null as unknown as undefined;
+
+      host.render(() => useCordieriteTool(toolDefinition(), nullDeps));
+      host.render(() => useCordieriteTool(toolDefinition(), nullDeps));
+      expect(registrations).toHaveLength(1);
+
+      host.render(() =>
+        useCordieriteTool(
+          { ...toolDefinition(), description: "changed" },
+          nullDeps,
+        ),
+      );
+
+      expect(registrations).toHaveLength(2);
+    });
+  });
+
+  test("caller-supplied deps override the derived key entirely", async () => {
+    const { registerTool, registrations } = makeRegisterTool();
+    const { createUseCordieriteTool } = await import("../useCordieriteTool");
+    const useCordieriteTool = createUseCordieriteTool(
+      registerTool,
+      realEntryOptions,
+    );
+
+    // `[]` means "register once and never again" -- a description change is deliberately ignored.
+    host.render(() =>
+      useCordieriteTool({ ...toolDefinition(), description: "before" }, []),
+    );
+    host.render(() =>
+      useCordieriteTool({ ...toolDefinition(), description: "after" }, []),
+    );
+
+    expect(registrations).toHaveLength(1);
+    expect(registrations[0]?.description).toBe("before");
+  });
+
+  describe("inert entry: no JSON Schema exporter injected", () => {
+    /**
+     * `./noop` builds the hook without an exporter, so the effect keys off `enabled` alone. Nothing
+     * is observable through its no-op registrar, and it must never run a JSON Schema export to
+     * decide how often to re-run a no-op.
+     */
+    test("never exports JSON Schema and never re-registers on a descriptor change", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(registerTool);
+
+      let exportCount = 0;
+      const countingSchema = {
+        "~standard": {
+          version: 1,
+          vendor: "test",
+          validate: (value: unknown) => ({ value }),
+          jsonSchema: {
+            input: () => {
+              exportCount += 1;
+              return { type: "object" };
+            },
+            output: () => ({ type: "object" }),
+          },
+        },
+      } as unknown as CordieriteRuntimeSchema;
+
+      const renderWithDescription = (description: string) =>
+        host.render(() =>
+          useCordieriteTool({
+            name: "t",
+            description,
+            inputSchema: countingSchema,
+            handler: () => undefined,
+          }),
+        );
+
+      renderWithDescription("before");
+      renderWithDescription("after");
+
+      expect(registrations).toHaveLength(1);
+      expect(exportCount).toBe(0);
+    });
+
+    test("still honours options.enabled", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(registerTool);
+
+      host.render(() =>
+        useCordieriteTool(toolDefinition(), undefined, { enabled: true }),
+      );
+      expect(registrations).toHaveLength(1);
+
+      host.render(() =>
+        useCordieriteTool(toolDefinition(), undefined, { enabled: false }),
+      );
+
+      expect(registrations).toHaveLength(1);
+      expect(registrations[0]?.removed).toBe(true);
+    });
   });
 
   test("a later call always sees the latest definition object, not a stale closure", async () => {
@@ -403,7 +675,10 @@ describe("createUseCordieriteTool", () => {
       return { remove() {} };
     };
     const { createUseCordieriteTool } = await import("../useCordieriteTool");
-    const useCordieriteTool = createUseCordieriteTool(registerTool);
+    const useCordieriteTool = createUseCordieriteTool(
+      registerTool,
+      realEntryOptions,
+    );
 
     host.render(() => useCordieriteTool(toolDefinition("first"), [1]));
     host.render(() => useCordieriteTool(toolDefinition("second"), [2]));
@@ -415,7 +690,10 @@ describe("createUseCordieriteTool", () => {
     test("defaults to enabled: registers on mount", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
-      const useCordieriteTool = createUseCordieriteTool(registerTool);
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
 
       host.render(() => useCordieriteTool(toolDefinition(), []));
 
@@ -426,7 +704,10 @@ describe("createUseCordieriteTool", () => {
     test("enabled: false never registers", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
-      const useCordieriteTool = createUseCordieriteTool(registerTool);
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
 
       host.render(() =>
         useCordieriteTool(toolDefinition(), [], { enabled: false }),
@@ -438,7 +719,10 @@ describe("createUseCordieriteTool", () => {
     test("true -> false removes the registration and leaks nothing", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
-      const useCordieriteTool = createUseCordieriteTool(registerTool);
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
 
       host.render(() =>
         useCordieriteTool(toolDefinition(), [], { enabled: true }),
@@ -457,7 +741,10 @@ describe("createUseCordieriteTool", () => {
     test("false -> true registers", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
-      const useCordieriteTool = createUseCordieriteTool(registerTool);
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
 
       host.render(() =>
         useCordieriteTool(toolDefinition(), [], { enabled: false }),
@@ -475,7 +762,10 @@ describe("createUseCordieriteTool", () => {
     test("toggling twice (true -> false -> true) leaves exactly one live registration", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
-      const useCordieriteTool = createUseCordieriteTool(registerTool);
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
 
       host.render(() =>
         useCordieriteTool(toolDefinition(), [], { enabled: true }),
@@ -495,7 +785,10 @@ describe("createUseCordieriteTool", () => {
     test("unmounting while disabled is a no-op — nothing was registered, so there is nothing to remove", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
-      const useCordieriteTool = createUseCordieriteTool(registerTool);
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
 
       host.render(() =>
         useCordieriteTool(toolDefinition(), [], { enabled: false }),
@@ -509,7 +802,10 @@ describe("createUseCordieriteTool", () => {
     test("toggling enabled re-runs the effect even when deps is omitted", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
-      const useCordieriteTool = createUseCordieriteTool(registerTool);
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
 
       host.render(() =>
         useCordieriteTool(toolDefinition(), undefined, { enabled: true }),
@@ -575,7 +871,10 @@ describe("createUseCordieriteTool", () => {
       }));
       const { createUseCordieriteTool: createA } =
         await import("../useCordieriteTool");
-      const useCordieriteToolA = createA(registry.registerTool);
+      const useCordieriteToolA = createA(
+        registry.registerTool,
+        realEntryOptions,
+      );
       hostA.render(() =>
         useCordieriteToolA(toolDefinition("shared"), [], { enabled: true }),
       );
@@ -587,7 +886,10 @@ describe("createUseCordieriteTool", () => {
       }));
       const { createUseCordieriteTool: createB } =
         await import("../useCordieriteTool");
-      const useCordieriteToolB = createB(registry.registerTool);
+      const useCordieriteToolB = createB(
+        registry.registerTool,
+        realEntryOptions,
+      );
       hostB.render(() =>
         useCordieriteToolB(toolDefinition("shared"), [], { enabled: true }),
       );

--- a/packages/react-native/src/__tests__/use-cordierite-tool.test.ts
+++ b/packages/react-native/src/__tests__/use-cordierite-tool.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, vi, test } from "vitest";
 
 import type {
   CordieriteRuntimeSchema,
+  CordieriteToolExecutionContext,
+  CordieriteToolHandler,
   CordieriteToolRegistration,
 } from "../Cordierite.types";
 import type { CordieriteSubscription } from "../public-api";
@@ -13,24 +15,31 @@ type EffectCallback = () => EffectCleanup;
 
 /**
  * A minimal, controllable stand-in for React's `useRef`/`useEffect` that implements exactly the
- * one contract `useCordieriteTool` depends on (run the effect on the first call, and again only
- * when `deps` shallowly changes, disposing the previous effect first) -- without needing a real
- * reconciler. "react-native"'s own source cannot be parsed under a Node test runner (Flow-typed), and
- * pulling in a full React renderer just to drive one `useEffect` call is unnecessary; mocking "react"
- * itself follows the same pattern `deep-link-install.test.ts` uses for `Linking`.
+ * one contract `useCordieriteTool` depends on (stable ref slots in call order, run the effect on
+ * the first call and again only when `deps` shallowly changes, disposing the previous effect
+ * first) -- without needing a real reconciler. "react-native"'s own source cannot be parsed under a
+ * Node test runner (Flow-typed), and pulling in a full React renderer just to drive one `useEffect`
+ * call is unnecessary; mocking "react" itself follows the same pattern `deep-link-install.test.ts`
+ * uses for `Linking`.
  *
  * Represents a *single* component instance: each `render()` call is one re-render of that instance.
  */
 const createFakeReactHost = () => {
-  let ref: { current: unknown } | undefined;
+  // Ref slots are keyed by call order within a render, exactly as React keys its own hook state --
+  // the hook calls `useRef` more than once (latest definition, stable handler wrapper, schema-key
+  // memos), so a single shared slot would alias them together.
+  const refs: { current: unknown }[] = [];
+  let refCursor = 0;
   let prevDeps: readonly unknown[] | undefined;
   let hasRunOnce = false;
   let cleanup: EffectCleanup;
   let effectRunCount = 0;
 
   const useRef = <T>(initial: T): { current: T } => {
-    ref ??= { current: initial };
-    return ref as { current: T };
+    const index = refCursor;
+    refCursor += 1;
+    refs[index] ??= { current: initial };
+    return refs[index] as { current: T };
   };
 
   const useEffect = (
@@ -59,6 +68,7 @@ const createFakeReactHost = () => {
     useRef,
     useEffect,
     render(runHook: () => void) {
+      refCursor = 0;
       runHook();
     },
     unmount() {
@@ -71,7 +81,14 @@ const createFakeReactHost = () => {
   };
 };
 
-type Registration = { id: number; removed: boolean };
+type Registration = {
+  id: number;
+  removed: boolean;
+  name: string;
+  description: string;
+  /** The handler the hook actually registered (the stable wrapper, not the caller's closure). */
+  handler: CordieriteToolHandler;
+};
 
 const makeRegisterTool = () => {
   const registrations: Registration[] = [];
@@ -81,9 +98,15 @@ const makeRegisterTool = () => {
     TInputSchema extends CordieriteRuntimeSchema | undefined,
     TOutputSchema extends CordieriteRuntimeSchema | undefined,
   >(
-    _registration: CordieriteToolRegistration<TInputSchema, TOutputSchema>,
+    registration: CordieriteToolRegistration<TInputSchema, TOutputSchema>,
   ): CordieriteSubscription => {
-    const entry: Registration = { id: nextId++, removed: false };
+    const entry: Registration = {
+      id: nextId++,
+      removed: false,
+      name: registration.name,
+      description: registration.description,
+      handler: registration.handler as CordieriteToolHandler,
+    };
     registrations.push(entry);
     return {
       remove() {
@@ -102,6 +125,28 @@ const toolDefinition = (
   description: "test tool",
   handler: () => undefined,
 });
+
+/** Enough of an execution context to invoke a registered handler that ignores it. */
+const fakeContext = {} as CordieriteToolExecutionContext;
+
+/**
+ * A Standard Schema whose JSON Schema exporter returns `shape` -- the shape (not the object
+ * identity) is what the daemon observes, so it is what the derived registration key compares.
+ */
+const schemaExporting = (
+  shape: Record<string, unknown>,
+): CordieriteRuntimeSchema =>
+  ({
+    "~standard": {
+      version: 1,
+      vendor: "test",
+      validate: (value: unknown) => ({ value }),
+      jsonSchema: {
+        input: () => shape,
+        output: () => shape,
+      },
+    },
+  }) as unknown as CordieriteRuntimeSchema;
 
 describe("createUseCordieriteTool", () => {
   let host: ReturnType<typeof createFakeReactHost>;
@@ -157,16 +202,193 @@ describe("createUseCordieriteTool", () => {
     expect(registrations[1]?.removed).toBe(false);
   });
 
-  test("re-registers on every render when deps is omitted", async () => {
-    const { registerTool, registrations } = makeRegisterTool();
-    const { createUseCordieriteTool } = await import("../useCordieriteTool");
-    const useCordieriteTool = createUseCordieriteTool(registerTool);
+  describe("derived registration key (deps omitted)", () => {
+    test("N re-renders with an unchanged definition produce exactly one registration and no removals", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(registerTool);
 
-    host.render(() => useCordieriteTool(toolDefinition()));
-    host.render(() => useCordieriteTool(toolDefinition()));
+      // A fresh definition object (and a fresh handler closure) per render, which is what an
+      // inline `useCordieriteTool({ ... })` call inside a component body produces.
+      host.render(() => useCordieriteTool(toolDefinition()));
+      host.render(() => useCordieriteTool(toolDefinition()));
+      host.render(() => useCordieriteTool(toolDefinition()));
 
-    expect(registrations).toHaveLength(2);
-    expect(registrations[0]?.removed).toBe(true);
+      expect(registrations).toHaveLength(1);
+      expect(registrations[0]?.removed).toBe(false);
+    });
+
+    test("changing description re-registers (remove + upsert)", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(registerTool);
+
+      host.render(() =>
+        useCordieriteTool({ ...toolDefinition(), description: "before" }),
+      );
+      host.render(() =>
+        useCordieriteTool({ ...toolDefinition(), description: "after" }),
+      );
+
+      expect(registrations).toHaveLength(2);
+      expect(registrations[0]?.removed).toBe(true);
+      expect(registrations[1]?.removed).toBe(false);
+      expect(registrations.map((entry) => entry.description)).toEqual([
+        "before",
+        "after",
+      ]);
+    });
+
+    test("changing annotations or timeoutMs re-registers", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(registerTool);
+
+      host.render(() =>
+        useCordieriteTool({
+          ...toolDefinition(),
+          annotations: { readOnlyHint: true },
+          timeoutMs: 1_000,
+        }),
+      );
+      // Equal-by-value annotations, new object: no re-registration.
+      host.render(() =>
+        useCordieriteTool({
+          ...toolDefinition(),
+          annotations: { readOnlyHint: true },
+          timeoutMs: 1_000,
+        }),
+      );
+      expect(registrations).toHaveLength(1);
+
+      host.render(() =>
+        useCordieriteTool({
+          ...toolDefinition(),
+          annotations: { readOnlyHint: false },
+          timeoutMs: 1_000,
+        }),
+      );
+      expect(registrations).toHaveLength(2);
+
+      host.render(() =>
+        useCordieriteTool({
+          ...toolDefinition(),
+          annotations: { readOnlyHint: false },
+          timeoutMs: 2_000,
+        }),
+      );
+      expect(registrations).toHaveLength(3);
+      expect(registrations[0]?.removed).toBe(true);
+      expect(registrations[1]?.removed).toBe(true);
+      expect(registrations[2]?.removed).toBe(false);
+    });
+
+    test("a handler closing over changed state does not re-register, and the next call sees the new value", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(registerTool);
+
+      // Stands in for component state: each render closes over a different value.
+      let state = 1;
+      const renderWithState = () =>
+        host.render(() =>
+          useCordieriteTool({
+            name: "t",
+            description: "test tool",
+            handler: () => state,
+          }),
+        );
+
+      renderWithState();
+      expect(registrations).toHaveLength(1);
+      expect(await registrations[0]?.handler(undefined, fakeContext)).toBe(1);
+
+      state = 2;
+      renderWithState();
+
+      expect(registrations).toHaveLength(1);
+      expect(registrations[0]?.removed).toBe(false);
+      expect(await registrations[0]?.handler(undefined, fakeContext)).toBe(2);
+    });
+
+    test("an inline schema rebuilt each render with an equal shape does not re-register", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(registerTool);
+
+      const renderWithShape = (shape: Record<string, unknown>) =>
+        host.render(() =>
+          useCordieriteTool({
+            name: "t",
+            description: "test tool",
+            // A brand-new schema object every render, as `z.object({ ... })` written inline in a
+            // component body produces.
+            inputSchema: schemaExporting(shape),
+            handler: () => undefined,
+          }),
+        );
+
+      renderWithShape({
+        type: "object",
+        properties: { a: { type: "number" } },
+      });
+      renderWithShape({
+        type: "object",
+        properties: { a: { type: "number" } },
+      });
+
+      expect(registrations).toHaveLength(1);
+      expect(registrations[0]?.removed).toBe(false);
+
+      renderWithShape({
+        type: "object",
+        properties: { a: { type: "string" } },
+      });
+
+      expect(registrations).toHaveLength(2);
+      expect(registrations[0]?.removed).toBe(true);
+      expect(registrations[1]?.removed).toBe(false);
+    });
+
+    test("a hoisted schema kept by identity re-exports nothing and never re-registers", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(registerTool);
+
+      let exportCount = 0;
+      const shape = { type: "object" as const };
+      const hoisted = {
+        "~standard": {
+          version: 1,
+          vendor: "test",
+          validate: (value: unknown) => ({ value }),
+          jsonSchema: {
+            input: () => {
+              exportCount += 1;
+              return shape;
+            },
+            output: () => shape,
+          },
+        },
+      } as unknown as CordieriteRuntimeSchema;
+
+      const render = () =>
+        host.render(() =>
+          useCordieriteTool({
+            name: "t",
+            description: "test tool",
+            inputSchema: hoisted,
+            handler: () => undefined,
+          }),
+        );
+
+      render();
+      render();
+      render();
+
+      expect(registrations).toHaveLength(1);
+      expect(exportCount).toBe(1);
+    });
   });
 
   test("a later call always sees the latest definition object, not a stale closure", async () => {
@@ -284,7 +506,7 @@ describe("createUseCordieriteTool", () => {
       expect(registrations).toHaveLength(0);
     });
 
-    test("toggling enabled re-runs the effect even when deps is otherwise omitted", async () => {
+    test("toggling enabled re-runs the effect even when deps is omitted", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");
       const useCordieriteTool = createUseCordieriteTool(registerTool);

--- a/packages/react-native/src/__tests__/use-cordierite-tool.test.ts
+++ b/packages/react-native/src/__tests__/use-cordierite-tool.test.ts
@@ -782,6 +782,53 @@ describe("createUseCordieriteTool", () => {
       expect(registrations[1]?.removed).toBe(false);
     });
 
+    test("a disabled hook never exports JSON Schema, however often it re-renders", async () => {
+      const { registerTool, registrations } = makeRegisterTool();
+      const { createUseCordieriteTool } = await import("../useCordieriteTool");
+      const useCordieriteTool = createUseCordieriteTool(
+        registerTool,
+        realEntryOptions,
+      );
+
+      // A disabled tool never reaches `registerTool`, so there is nothing for a registration key
+      // to describe -- deriving one would export JSON Schema every render for no reason.
+      let exportCount = 0;
+      const render = () =>
+        host.render(() =>
+          useCordieriteTool(
+            {
+              name: "t",
+              description: "test tool",
+              // Rebuilt inline every render, so identity never hits the memo.
+              inputSchema: {
+                "~standard": {
+                  version: 1,
+                  vendor: "test",
+                  validate: (value: unknown) => ({ value }),
+                  jsonSchema: {
+                    input: () => {
+                      exportCount += 1;
+                      return { type: "object" };
+                    },
+                    output: () => ({ type: "object" }),
+                  },
+                },
+              } as unknown as CordieriteRuntimeSchema,
+              handler: () => undefined,
+            },
+            undefined,
+            { enabled: false },
+          ),
+        );
+
+      render();
+      render();
+      render();
+
+      expect(registrations).toHaveLength(0);
+      expect(exportCount).toBe(0);
+    });
+
     test("unmounting while disabled is a no-op — nothing was registered, so there is nothing to remove", async () => {
       const { registerTool, registrations } = makeRegisterTool();
       const { createUseCordieriteTool } = await import("../useCordieriteTool");

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -15,6 +15,7 @@ import {
 import { parseBootstrapPayload, parseBootstrapUrl } from "./bootstrap";
 import { cordieriteClient, noopIfNativeUnavailable } from "./default-client";
 import * as noop from "./noop";
+import { exportToolSchema } from "./schema";
 import { createUseCordieriteTool } from "./useCordieriteTool";
 
 export * from "./Cordierite.types";
@@ -141,9 +142,17 @@ export function getCordieriteBuildConfig(): CordieriteBuildConfig {
 }
 
 /**
- * `useEffect` wrapper around `registerTool`: registers on mount and whenever `deps` changes,
- * disposing the previous registration first (identity-safe — see `registerTool`'s doc comment).
- * `options.enabled` (default `true`) gates registration without breaking the rules of hooks —
- * see the README's "Define tools in app startup code" section.
+ * `useEffect` wrapper around `registerTool`: registers once per mount and re-registers only when
+ * the registration itself changed (name, description, exported schemas, annotations, `timeoutMs`,
+ * `enabled`), disposing the previous registration first (identity-safe — see `registerTool`'s doc
+ * comment). Calls are routed through the latest render's handler, so `deps` is an optional
+ * override rather than something every call site has to remember. `options.enabled` (default
+ * `true`) gates registration without breaking the rules of hooks — see the README's "Define tools
+ * in app startup code" section.
+ *
+ * `exportToolSchema` is injected (rather than imported by the hook) so the inert `./noop` entry
+ * below does not pull JSON Schema export into a bundle that registers nothing.
  */
-export const useCordieriteTool = createUseCordieriteTool(registerTool);
+export const useCordieriteTool = createUseCordieriteTool(registerTool, {
+  exportSchema: exportToolSchema,
+});

--- a/packages/react-native/src/noop.ts
+++ b/packages/react-native/src/noop.ts
@@ -40,8 +40,11 @@ export function registerTool<
   return noopSubscription;
 }
 
-/** `useEffect` wrapper around the inert `registerTool` above — same mount/deps/`options.enabled`
- * behavior as the real entry, no-op body. */
+/** `useEffect` wrapper around the inert `registerTool` above — same signature, arity and observable
+ * behavior as the real entry, no-op body. No JSON Schema exporter is injected: with a registrar
+ * that registers nothing, deriving a registration key would export JSON Schema on every render to
+ * decide how often to re-run a no-op, and the import alone would pull `schema.ts` into a bundle
+ * whose whole purpose is to carry no Cordierite work. */
 export const useCordieriteTool = createUseCordieriteTool(registerTool);
 
 /** No-op: never sends anything. */

--- a/packages/react-native/src/useCordieriteTool.ts
+++ b/packages/react-native/src/useCordieriteTool.ts
@@ -188,10 +188,18 @@ export function createUseCordieriteTool(
     // spreading it.
     const hasDeps = deps !== undefined && deps !== null;
 
-    // The key is only derived when `deps` is omitted: a caller who passed `deps` opted out of it
-    // entirely and should not pay for a JSON Schema export they did not ask for.
+    // Which branch the dependency array takes -- deliberately independent of `enabled`, so the
+    // array's length never changes between renders. The key is only derived when `deps` is
+    // omitted: a caller who passed `deps` opted out of it entirely and should not pay for a JSON
+    // Schema export they did not ask for.
     const derivesKey = !hasDeps && exportSchema !== undefined;
-    const inputSchemaKey = derivesKey
+
+    // Whether to actually do that work this render. A disabled tool never reaches `registerTool`,
+    // so there is nothing for a key to describe: leave every entry `undefined` and skip the
+    // export. Re-enabling always re-runs the effect anyway, because `enabled` is itself a
+    // dependency, and the memos are untouched meanwhile so an unchanged schema still hits them.
+    const derivesKeyNow = derivesKey && enabled;
+    const inputSchemaKey = derivesKeyNow
       ? schemaKey(
           definition.inputSchema,
           "input",
@@ -199,7 +207,7 @@ export function createUseCordieriteTool(
           schemaKeyMemosRef.current.input,
         )
       : undefined;
-    const outputSchemaKey = derivesKey
+    const outputSchemaKey = derivesKeyNow
       ? schemaKey(
           definition.outputSchema,
           "output",
@@ -208,7 +216,7 @@ export function createUseCordieriteTool(
         )
       : undefined;
     const annotationsKey =
-      derivesKey && definition.annotations !== undefined
+      derivesKeyNow && definition.annotations !== undefined
         ? JSON.stringify(definition.annotations)
         : undefined;
 

--- a/packages/react-native/src/useCordieriteTool.ts
+++ b/packages/react-native/src/useCordieriteTool.ts
@@ -93,6 +93,12 @@ export function createUseCordieriteTool(registerTool: ToolRegistrar) {
    * between passing `deps` and omitting it changes the dependency-array length between renders,
    * which React warns about, exactly as it does for a hand-written `useEffect`.
    *
+   * Consequence of keying on the *exported* schema: the registry keeps the schema objects from the
+   * most recent registration, so a schema replaced by an identity-different one that exports the
+   * same JSON Schema keeps validating against the earlier object. That only matters for a
+   * validation rule the JSON Schema cannot express *and* that closes over changing state (a
+   * `.refine()` over component state, say) — pass `deps` for that case.
+   *
    * Re-registration relies on the registry's identity-safe disposer, so remount / Fast Refresh
    * churn — and toggling `enabled` — never leaks a stale registration or clobbers a newer one
    * under the same tool name.
@@ -169,7 +175,7 @@ export function createUseCordieriteTool(registerTool: ToolRegistrar) {
         // so toggling it re-runs the effect.
         // eslint-disable-next-line react-hooks/exhaustive-deps
       },
-      derivesKey
+      deps === undefined
         ? [
             definition.name,
             definition.description,
@@ -179,7 +185,7 @@ export function createUseCordieriteTool(registerTool: ToolRegistrar) {
             outputSchemaKey,
             enabled,
           ]
-        : [...(deps as DependencyList), enabled],
+        : [...deps, enabled],
     );
   };
 }

--- a/packages/react-native/src/useCordieriteTool.ts
+++ b/packages/react-native/src/useCordieriteTool.ts
@@ -2,9 +2,13 @@ import { useEffect, useRef, type DependencyList } from "react";
 
 import type {
   CordieriteRuntimeSchema,
+  CordieriteToolHandler,
   CordieriteToolRegistration,
+  InferToolArgs,
+  InferToolResult,
 } from "./Cordierite.types";
 import type { CordieriteSubscription } from "./public-api";
+import { exportToolSchema } from "./schema";
 
 type ToolRegistrar = <
   TInputSchema extends CordieriteRuntimeSchema | undefined,
@@ -28,16 +32,70 @@ export type UseCordieriteToolOptions = {
 };
 
 /**
+ * Per-hook, per-slot memo for the derived registration key: the schema object last seen and the
+ * JSON Schema string it exported to. Identity is checked first, so a hoisted or memoized schema
+ * never re-exports; a schema rebuilt inline on every render exports once per render (what an
+ * unconditional re-registration already cost) but only changes the key when its *shape* changed.
+ */
+type SchemaKeyMemo = {
+  schema: CordieriteRuntimeSchema | undefined;
+  exported: string | undefined;
+};
+
+const createSchemaKeyMemo = (): SchemaKeyMemo => ({
+  schema: undefined,
+  exported: undefined,
+});
+
+const schemaKey = (
+  schema: CordieriteRuntimeSchema | undefined,
+  mode: "input" | "output",
+  memo: SchemaKeyMemo,
+): string | undefined => {
+  if (schema === memo.schema) {
+    return memo.exported;
+  }
+
+  // `exportToolSchema` already returns `undefined` for a schema without a JSON Schema exporter
+  // (zod 3, plain valibot), which is exactly what the daemon would observe for it. The tool name
+  // is deliberately not passed: this runs during render, and the "shapeless tool" dev warning
+  // belongs to the registration path, not to key derivation.
+  const exported =
+    schema === undefined
+      ? undefined
+      : JSON.stringify(exportToolSchema(schema, mode));
+
+  memo.schema = schema;
+  memo.exported = exported;
+
+  return exported;
+};
+
+/**
  * Builds `useCordieriteTool` on top of a `registerTool` implementation. Both the real (`.`) and
  * inert (`./noop`) entries call this with their own `registerTool`, so the hook's remount/dependency
  * behavior can never drift between the two (ARCHITECTURE.md §11).
  */
 export function createUseCordieriteTool(registerTool: ToolRegistrar) {
   /**
-   * `useEffect` wrapper around `registerTool`: registers on mount and whenever `deps` (or
-   * `options.enabled`) changes, disposing the previous registration first. Relies on the
-   * registry's identity-safe disposer so remount / fast-refresh churn — and toggling `enabled`
-   * — never leaks a stale registration or clobbers a newer one under the same tool name.
+   * `useEffect` wrapper around `registerTool` that registers **once per mount** and re-registers
+   * only when something the daemon can actually observe changed — `name`, `description`, the
+   * exported input/output JSON Schemas, `annotations`, `timeoutMs`, or `options.enabled`. Omitting
+   * `deps` is therefore the correct, cheap default: re-rendering the hosting component does not
+   * produce `tool_registry_delta` traffic or agent-side `tools/list_changed` notifications.
+   *
+   * Handler freshness: the registered handler is a stable wrapper that forwards to
+   * `definitionRef.current.handler`, so a handler closing over component state always sees the
+   * latest render's values on the next call, with no re-registration and no ref workarounds.
+   *
+   * `deps` remains as an advanced, explicit override with `useEffect`'s own semantics (it fully
+   * replaces the derived key; `enabled` is still appended). Pass it consistently — alternating
+   * between passing `deps` and omitting it changes the dependency-array length between renders,
+   * which React warns about, exactly as it does for a hand-written `useEffect`.
+   *
+   * Re-registration relies on the registry's identity-safe disposer, so remount / Fast Refresh
+   * churn — and toggling `enabled` — never leaks a stale registration or clobbers a newer one
+   * under the same tool name.
    */
   return function useCordieriteTool<
     TInputSchema extends CordieriteRuntimeSchema | undefined,
@@ -47,13 +105,48 @@ export function createUseCordieriteTool(registerTool: ToolRegistrar) {
     deps?: DependencyList,
     options?: UseCordieriteToolOptions,
   ): void {
-    // Keeps the latest definition available to the effect without making it part of the effect's
-    // own dependency list — callers control re-registration explicitly via `deps`, matching
-    // `registerTool`'s own explicit-identity contract rather than re-registering on every render.
+    // Keeps the latest definition available to the effect and to the stable handler wrapper
+    // without making it part of the effect's own dependency list.
     const definitionRef = useRef(definition);
     definitionRef.current = definition;
 
+    // Created once per hook instance and never replaced, so the registered handler's identity is
+    // stable across renders while the handler it forwards to is always the latest one.
+    const stableHandlerRef = useRef<
+      CordieriteToolHandler<
+        InferToolArgs<TInputSchema>,
+        InferToolResult<TOutputSchema>
+      >
+    >((args, context) => definitionRef.current.handler(args, context));
+
+    const schemaKeyMemosRef = useRef<{
+      input: SchemaKeyMemo;
+      output: SchemaKeyMemo;
+    }>({ input: createSchemaKeyMemo(), output: createSchemaKeyMemo() });
+
     const enabled = options?.enabled ?? true;
+
+    // Only derived when `deps` is omitted: a caller who passed `deps` opted out of the derived key
+    // entirely and should not pay for a JSON Schema export they did not ask for.
+    const derivesKey = deps === undefined;
+    const inputSchemaKey = derivesKey
+      ? schemaKey(
+          definition.inputSchema,
+          "input",
+          schemaKeyMemosRef.current.input,
+        )
+      : undefined;
+    const outputSchemaKey = derivesKey
+      ? schemaKey(
+          definition.outputSchema,
+          "output",
+          schemaKeyMemosRef.current.output,
+        )
+      : undefined;
+    const annotationsKey =
+      derivesKey && definition.annotations !== undefined
+        ? JSON.stringify(definition.annotations)
+        : undefined;
 
     useEffect(
       () => {
@@ -62,15 +155,31 @@ export function createUseCordieriteTool(registerTool: ToolRegistrar) {
           // below to remove — the disabled state simply skips `registerTool` entirely.
           return;
         }
-        const registration = registerTool(definitionRef.current);
+        // The caller's own handler is never registered: the stable wrapper is, so re-renders that
+        // only change the closure do not need (and do not cause) a re-registration.
+        const registration = registerTool({
+          ...definitionRef.current,
+          handler: stableHandlerRef.current,
+        });
         return () => {
           registration.remove();
         };
-        // `deps` is caller-controlled (mirrors `useEffect`'s own contract); `enabled` is appended
-        // explicitly so toggling it re-runs the effect even when `deps` is omitted or unchanged.
+        // The derived branch has a fixed length (7). `deps`, when provided, is caller-controlled
+        // (mirrors `useEffect`'s own contract); `enabled` is appended explicitly in both branches
+        // so toggling it re-runs the effect.
         // eslint-disable-next-line react-hooks/exhaustive-deps
       },
-      deps ? [...deps, enabled] : undefined,
+      derivesKey
+        ? [
+            definition.name,
+            definition.description,
+            definition.timeoutMs,
+            annotationsKey,
+            inputSchemaKey,
+            outputSchemaKey,
+            enabled,
+          ]
+        : [...(deps as DependencyList), enabled],
     );
   };
 }

--- a/packages/react-native/src/useCordieriteTool.ts
+++ b/packages/react-native/src/useCordieriteTool.ts
@@ -1,3 +1,4 @@
+import type { ToolSchemaDescriptor } from "@cordierite/shared";
 import { useEffect, useRef, type DependencyList } from "react";
 
 import type {
@@ -8,7 +9,6 @@ import type {
   InferToolResult,
 } from "./Cordierite.types";
 import type { CordieriteSubscription } from "./public-api";
-import { exportToolSchema } from "./schema";
 
 type ToolRegistrar = <
   TInputSchema extends CordieriteRuntimeSchema | undefined,
@@ -31,44 +31,84 @@ export type UseCordieriteToolOptions = {
   enabled?: boolean;
 };
 
+/** Shape of `schema.ts`'s `exportToolSchema`, injected rather than imported (see below). */
+type ToolSchemaExporter = (
+  schema: CordieriteRuntimeSchema,
+  mode: "input" | "output",
+) => ToolSchemaDescriptor | undefined;
+
+/** Options for `createUseCordieriteTool` (library-internal, not part of the public API). */
+export type CreateUseCordieriteToolOptions = {
+  /**
+   * JSON Schema exporter used to derive the registration key when the caller omits `deps`.
+   * Injected by the real (`.`) entry and deliberately omitted by the inert (`./noop`) one: with a
+   * registrar that registers nothing, deriving a key would export JSON Schema on every render to
+   * decide how often to re-run a no-op, and a static import would pull `schema.ts` into a bundle
+   * whose whole purpose is to carry no Cordierite work. Without it the effect keys off `enabled`
+   * alone; the returned hook's signature, arity and observable behavior are identical either way
+   * (ARCHITECTURE.md §11).
+   */
+  exportSchema?: ToolSchemaExporter;
+};
+
 /**
  * Per-hook, per-slot memo for the derived registration key: the schema object last seen and the
- * JSON Schema string it exported to. Identity is checked first, so a hoisted or memoized schema
- * never re-exports; a schema rebuilt inline on every render exports once per render (what an
- * unconditional re-registration already cost) but only changes the key when its *shape* changed.
+ * key it produced. Identity is checked first, so a hoisted or memoized schema never re-exports; a
+ * schema rebuilt inline on every render exports once per render (what an unconditional
+ * re-registration already cost) but only changes the key when its *shape* changed.
  */
 type SchemaKeyMemo = {
   schema: CordieriteRuntimeSchema | undefined;
-  exported: string | undefined;
+  key: string | undefined;
+  /** Bumped for each new *unexportable* schema object, which has no shape to compare by value. */
+  shapelessSeq: number;
 };
 
 const createSchemaKeyMemo = (): SchemaKeyMemo => ({
   schema: undefined,
-  exported: undefined,
+  key: undefined,
+  shapelessSeq: 0,
 });
 
 const schemaKey = (
   schema: CordieriteRuntimeSchema | undefined,
   mode: "input" | "output",
+  exportSchema: ToolSchemaExporter,
   memo: SchemaKeyMemo,
 ): string | undefined => {
   if (schema === memo.schema) {
-    return memo.exported;
+    return memo.key;
   }
 
-  // `exportToolSchema` already returns `undefined` for a schema without a JSON Schema exporter
-  // (zod 3, plain valibot), which is exactly what the daemon would observe for it. The tool name
-  // is deliberately not passed: this runs during render, and the "shapeless tool" dev warning
-  // belongs to the registration path, not to key derivation.
-  const exported =
-    schema === undefined
-      ? undefined
-      : JSON.stringify(exportToolSchema(schema, mode));
+  let key: string | undefined;
+  if (schema === undefined) {
+    key = undefined;
+  } else {
+    // `exportToolSchema` returns `undefined` for a schema that does not export JSON Schema (zod 3,
+    // plain valibot). The tool name is deliberately not passed: this runs during render, and the
+    // "shapeless tool" dev warning belongs to the registration path, not to key derivation.
+    const exported = exportSchema(schema, mode);
+    if (exported === undefined) {
+      // No shape to compare by value, and "exports nothing" must not collide with "no schema at
+      // all" -- the registry entry still holds the object and validates against it, and
+      // `tool-invocation.ts` keys its "must not return a result when outputSchema is omitted" rule
+      // on the entry's `outputSchema` being present. So fall back to identity: a new unexportable
+      // schema object always produces a new key, which does mean an unexportable schema rebuilt
+      // inline every render re-registers every render (exactly what it did before). Hoist it, or
+      // move to zod v4, whose built-in exporter puts it back on the by-shape path.
+      memo.shapelessSeq += 1;
+      // Cannot collide with the branch below: `JSON.stringify` of an exported schema is always a
+      // JSON object literal, so it always starts with `{`.
+      key = `shapeless:${memo.shapelessSeq}`;
+    } else {
+      key = JSON.stringify(exported);
+    }
+  }
 
   memo.schema = schema;
-  memo.exported = exported;
+  memo.key = key;
 
-  return exported;
+  return key;
 };
 
 /**
@@ -76,13 +116,18 @@ const schemaKey = (
  * inert (`./noop`) entries call this with their own `registerTool`, so the hook's remount/dependency
  * behavior can never drift between the two (ARCHITECTURE.md §11).
  */
-export function createUseCordieriteTool(registerTool: ToolRegistrar) {
+export function createUseCordieriteTool(
+  registerTool: ToolRegistrar,
+  { exportSchema }: CreateUseCordieriteToolOptions = {},
+) {
   /**
    * `useEffect` wrapper around `registerTool` that registers **once per mount** and re-registers
-   * only when something the daemon can actually observe changed — `name`, `description`, the
+   * only when something that changes the registry entry changed — `name`, `description`, the
    * exported input/output JSON Schemas, `annotations`, `timeoutMs`, or `options.enabled`. Omitting
    * `deps` is therefore the correct, cheap default: re-rendering the hosting component does not
    * produce `tool_registry_delta` traffic or agent-side `tools/list_changed` notifications.
+   * (`timeoutMs` is app-side only — the daemon never sees it — but it is part of the entry, so a
+   * change to it has to reach the registry.)
    *
    * Handler freshness: the registered handler is a stable wrapper that forwards to
    * `definitionRef.current.handler`, so a handler closing over component state always sees the
@@ -93,11 +138,17 @@ export function createUseCordieriteTool(registerTool: ToolRegistrar) {
    * between passing `deps` and omitting it changes the dependency-array length between renders,
    * which React warns about, exactly as it does for a hand-written `useEffect`.
    *
-   * Consequence of keying on the *exported* schema: the registry keeps the schema objects from the
-   * most recent registration, so a schema replaced by an identity-different one that exports the
-   * same JSON Schema keeps validating against the earlier object. That only matters for a
-   * validation rule the JSON Schema cannot express *and* that closes over changing state (a
-   * `.refine()` over component state, say) — pass `deps` for that case.
+   * Two consequences of registering once, both of which `deps` opts out of:
+   *
+   * - The registry keeps the schema objects from the most recent registration, so a schema
+   *   replaced by an identity-different one that exports the *same* JSON Schema keeps validating
+   *   against the earlier object. That only matters for a validation rule JSON Schema cannot
+   *   express *and* that closes over changing state (a `.refine()` over component state, say).
+   * - Two mounted hooks registering the same tool name: the later registration wins (with the
+   *   registry's dev warning), and when it unmounts the earlier hook no longer re-claims the name
+   *   on its next render — the name stays unregistered until that hook re-registers for its own
+   *   reasons. Duplicate names were never a supported configuration; this makes the existing dev
+   *   warning the thing to fix rather than a race to lose.
    *
    * Re-registration relies on the registry's identity-safe disposer, so remount / Fast Refresh
    * churn — and toggling `enabled` — never leaks a stale registration or clobbers a newer one
@@ -132,13 +183,19 @@ export function createUseCordieriteTool(registerTool: ToolRegistrar) {
 
     const enabled = options?.enabled ?? true;
 
-    // Only derived when `deps` is omitted: a caller who passed `deps` opted out of the derived key
+    // `null` is not a legal `DependencyList`, but untyped JS callers pass it, and the previous
+    // truthiness check treated it exactly like an omitted argument. Keep doing that rather than
+    // spreading it.
+    const hasDeps = deps !== undefined && deps !== null;
+
+    // The key is only derived when `deps` is omitted: a caller who passed `deps` opted out of it
     // entirely and should not pay for a JSON Schema export they did not ask for.
-    const derivesKey = deps === undefined;
+    const derivesKey = !hasDeps && exportSchema !== undefined;
     const inputSchemaKey = derivesKey
       ? schemaKey(
           definition.inputSchema,
           "input",
+          exportSchema,
           schemaKeyMemosRef.current.input,
         )
       : undefined;
@@ -146,6 +203,7 @@ export function createUseCordieriteTool(registerTool: ToolRegistrar) {
       ? schemaKey(
           definition.outputSchema,
           "output",
+          exportSchema,
           schemaKeyMemosRef.current.output,
         )
       : undefined;
@@ -170,22 +228,24 @@ export function createUseCordieriteTool(registerTool: ToolRegistrar) {
         return () => {
           registration.remove();
         };
-        // The derived branch has a fixed length (7). `deps`, when provided, is caller-controlled
-        // (mirrors `useEffect`'s own contract); `enabled` is appended explicitly in both branches
-        // so toggling it re-runs the effect.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
       },
-      deps === undefined
-        ? [
-            definition.name,
-            definition.description,
-            definition.timeoutMs,
-            annotationsKey,
-            inputSchemaKey,
-            outputSchemaKey,
-            enabled,
-          ]
-        : [...deps, enabled],
+      // Each branch has a fixed length across renders (caller-supplied `deps` mirrors
+      // `useEffect`'s own contract); `enabled` is appended explicitly in all three so toggling it
+      // re-runs the effect. The dependency list is built by hand on purpose, so do not let an
+      // `exhaustive-deps` autofix "complete" it.
+      hasDeps
+        ? [...deps, enabled]
+        : derivesKey
+          ? [
+              definition.name,
+              definition.description,
+              definition.timeoutMs,
+              annotationsKey,
+              inputSchemaKey,
+              outputSchemaKey,
+              enabled,
+            ]
+          : [enabled],
     );
   };
 }

--- a/playground/README.md
+++ b/playground/README.md
@@ -60,6 +60,7 @@ The **Status** tab should flip to `active` with an alias once the app claims the
 pnpm run playground:cordierite -- ls
 pnpm run playground:cordierite -- tools
 pnpm run playground:cordierite -- invoke sum --input '{"a":1,"b":2}'
+pnpm run playground:cordierite -- invoke call_count --input '{}'      # reads state a handler closes over
 pnpm run playground:cordierite -- invoke reset_counter --input '{}'   # destructive; denied if policy.destructive=deny
 pnpm run playground:cordierite -- invoke slow_task --input '{}'       # watch progress with events --follow
 pnpm run playground:cordierite -- invoke throwing_tool --input '{}'   # exercises tool_execution_error

--- a/playground/app/(tabs)/index.tsx
+++ b/playground/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { ScrollView, StyleSheet, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { z } from "zod";
@@ -43,87 +43,70 @@ export default function ToolsScreen() {
   const [callCount, setCallCount] = useState(0);
   const [tools, setTools] = useState<RegisteredTool[]>([]);
 
-  // A ref (not `callCount` state) so the "sum" and "slow_task" handlers below always see the
-  // latest count without needing to be re-registered on every increment.
-  const callCountRef = useRef(0);
+  // Plain state: `useCordieriteTool` registers a stable wrapper that forwards to the latest
+  // render's handler, so these handlers read the current `callCount` without a ref workaround
+  // and without being re-registered on every increment.
   const bumpCallCount = () => {
-    callCountRef.current += 1;
-    setCallCount(callCountRef.current);
+    setCallCount((count) => count + 1);
   };
 
-  useCordieriteTool(
-    {
-      name: "sum",
-      description: "Adds two numbers.",
-      inputSchema: z.object({
-        a: z.number(),
-        b: z.number(),
-      }),
-      outputSchema: z.object({
-        total: z.number(),
-      }),
-      handler: (args) => {
-        bumpCallCount();
-        return { total: args.a + args.b };
-      },
+  useCordieriteTool({
+    name: "sum",
+    description: "Adds two numbers.",
+    inputSchema: z.object({
+      a: z.number(),
+      b: z.number(),
+    }),
+    outputSchema: z.object({
+      total: z.number(),
+    }),
+    handler: (args) => {
+      bumpCallCount();
+      return { total: args.a + args.b };
     },
-    []
-  );
+  });
 
-  useCordieriteTool(
-    {
-      name: "reset_counter",
-      description: "Resets the playground's call counter to zero.",
-      annotations: { destructiveHint: true },
-      outputSchema: z.object({
-        count: z.number(),
-      }),
-      handler: () => {
-        callCountRef.current = 0;
-        setCallCount(0);
-        return { count: 0 };
-      },
+  useCordieriteTool({
+    name: "reset_counter",
+    description: "Resets the playground's call counter to zero.",
+    annotations: { destructiveHint: true },
+    outputSchema: z.object({
+      count: z.number(),
+    }),
+    handler: () => {
+      setCallCount(0);
+      return { count: 0 };
     },
-    []
-  );
+  });
 
-  useCordieriteTool(
-    {
-      name: "slow_task",
-      description: "Takes ~1.5s and reports progress along the way.",
-      outputSchema: z.object({
-        done: z.boolean(),
-      }),
-      timeoutMs: 5_000,
-      handler: async (
-        _args,
-        context: CordieriteToolExecutionContext
-      ) => {
-        for (const [progress, message] of [
-          [0.33, "warming up"],
-          [0.66, "almost there"],
-          [1, "done"],
-        ] as const) {
-          await delay(500);
-          await context.reportProgress(progress, message);
-        }
-        bumpCallCount();
-        return { done: true };
-      },
+  useCordieriteTool({
+    name: "slow_task",
+    description: "Takes ~1.5s and reports progress along the way.",
+    outputSchema: z.object({
+      done: z.boolean(),
+    }),
+    timeoutMs: 5_000,
+    handler: async (_args, context: CordieriteToolExecutionContext) => {
+      for (const [progress, message] of [
+        [0.33, "warming up"],
+        [0.66, "almost there"],
+        [1, "done"],
+      ] as const) {
+        await delay(500);
+        await context.reportProgress(progress, message);
+      }
+      bumpCallCount();
+      return { done: true };
     },
-    []
-  );
+  });
 
-  useCordieriteTool(
-    {
-      name: "throwing_tool",
-      description: "Always throws, to exercise tool_execution_error.",
-      handler: () => {
-        throw new Error("throwing_tool always fails on purpose.");
-      },
+  useCordieriteTool({
+    name: "throwing_tool",
+    description: "Always throws, to exercise tool_execution_error.",
+    handler: () => {
+      throw new Error("throwing_tool always fails on purpose.");
     },
-    []
-  );
+  });
 
   // Reads the client's own registry after the tool-registering effects above have run (React runs
   // effects in declaration order on mount), so this list is never a hand-maintained duplicate.

--- a/playground/app/(tabs)/index.tsx
+++ b/playground/app/(tabs)/index.tsx
@@ -43,9 +43,9 @@ export default function ToolsScreen() {
   const [callCount, setCallCount] = useState(0);
   const [tools, setTools] = useState<RegisteredTool[]>([]);
 
-  // Plain state: `useCordieriteTool` registers a stable wrapper that forwards to the latest
-  // render's handler, so these handlers read the current `callCount` without a ref workaround
-  // and without being re-registered on every increment.
+  // Plain state, no ref: `useCordieriteTool` registers a stable wrapper that forwards to the
+  // latest render's handler, so `call_count` below reads the current `callCount` on every call
+  // without being re-registered on each increment.
   const bumpCallCount = () => {
     setCallCount((count) => count + 1);
   };
@@ -64,6 +64,18 @@ export default function ToolsScreen() {
       bumpCallCount();
       return { total: args.a + args.b };
     },
+  });
+
+  useCordieriteTool({
+    name: "call_count",
+    description: "Reports how many times the playground's counted tools have run.",
+    annotations: { readOnlyHint: true },
+    outputSchema: z.object({
+      count: z.number(),
+    }),
+    // Closes directly over `callCount` state. Registered once on mount, yet every call sees the
+    // value from the most recent render -- that is the freshness guarantee, demonstrated.
+    handler: () => ({ count: callCount }),
   });
 
   useCordieriteTool({
@@ -168,8 +180,9 @@ export default function ToolsScreen() {
             <ThemedText type="subtitle">{callCount}</ThemedText>
           </View>
           <ThemedText type="caption" style={styles.cardHint}>
-            Bumped by sum/slow_task; reset_counter (destructive) sets it back to zero. Try denying
-            destructive tools in the daemon config to see it get rejected instead.
+            Bumped by sum/slow_task; call_count reads it back (a handler closing over state, never
+            re-registered); reset_counter (destructive) sets it to zero. Try denying destructive
+            tools in the daemon config to see it get rejected instead.
           </ThemedText>
         </View>
       </ScrollView>


### PR DESCRIPTION
`createUseCordieriteTool` passed `undefined` deps to `useEffect` when the caller omitted `deps`, so every render of the hosting component ran `remove()` + `registerTool()`. That produced two `tool_registry_delta` frames, a daemon `tools_changed`, and an agent-side `notifications/tools/list_changed` on every state change — including for the copy-paste example on the front page, which omits `deps`.

Follows the plan approved in https://github.com/callstackincubator/cordierite/issues/28#issuecomment-5554286334 (stable wrapper handler via ref; hybrid key: identity first, exported JSON Schema string only when the identity changed; `deps` stays as an explicit override). `registry.ts`, `client/index.ts` and `schema.ts` are untouched; `index.ts` and `noop.ts` change by one argument each (see review item 2).

## Changes

**`packages/react-native/src/useCordieriteTool.ts`**

- Registers a **stable wrapper handler**, created once per hook instance, that forwards to `definitionRef.current.handler`. The caller's own closure is never registered, so a handler reading component state is fresh on the next call with no re-registration and no ref workaround.
- When `deps` is omitted, the effect keys off a derived, **fixed-length (7)** dependency list of everything that changes the registry entry: `name`, `description`, `timeoutMs`, stringified `annotations`, the exported input/output JSON Schemas, and `enabled`.
- Schemas use a per-hook, per-slot memo: identity first, and only on an identity change is the schema exported and the result stringified. A hoisted or `useMemo`'d schema never re-exports; an inline `z.object({ … })` rebuilt each render exports once per render (what an unconditional re-registration already cost) and still resolves to the same key unless the shape changed. A schema that exports **no** JSON Schema falls back to identity — see review item 1. A disabled hook does no export work at all — see follow-up item 1.
- When `deps` **is** provided, today's `[...deps, enabled]` semantics are unchanged — an explicit, advanced override. `null` deps is treated as omitted, as the previous truthiness check did.
- The JSON Schema exporter is **injected** rather than imported, so the inert `./noop` entry neither runs nor bundles it — see review item 2.
- `enabled: false` behaviour and the identity-safe stale-disposer guarantees are unchanged.

**Tests (`use-cordierite-tool.test.ts`)** — the existing fake React host is kept; its `useRef` now keys slots by call order, since the hook takes more than one ref. The test pinning `"re-registers on every render when deps is omitted"` is replaced by the new contract:

- 3 renders with a fresh definition object each time → exactly 1 registration, 0 removals.
- `description` change → 2 registrations, first removed (remove + upsert). Same for `name`.
- `annotations` / `timeoutMs`: equal-by-value new object → no re-registration; a changed value → re-registration.
- Handler closing over changed state → still 1 registration, and invoking the registered handler after the second render returns the second render's value.
- Inline schema rebuilt per render with an equal shape → 1 registration; a differing shape → 2. Covered for both `inputSchema` and `outputSchema`.
- Hoisted schema kept by identity → 1 registration and exactly 1 export across 3 renders.
- Unexportable (zod 3 / valibot-shaped) schema: added → swapped → removed each re-register, with the entry's `outputSchema` presence asserted; the same object kept by identity does not.
- Caller-supplied `deps: []` overrides the derived key (a `description` change is ignored).
- `null` deps behaves like an omitted argument.
- A disabled hook with an inline schema, re-rendered three times → the exporter is never called.
- Inert variant (no exporter injected): never exports, never re-registers on a descriptor change, still honours `enabled`.
- All `enabled` tests, the stale-disposer test and `noop-parity`'s arity test are untouched and green.

**Docs**

- Root `README.md`: the no-`deps` form stays (it is now correct) and gains the `import` lines it needs to compile as shown, plus a qualified line on register-once.
- `packages/react-native/README.md` §5: examples drop the `[]`; notes on per-mount registration, handler freshness (with a `useState` example needing no ref), hoisting, unexportable schemas, the schema-object caveat, duplicate tool names, and `deps` as an advanced override.
- `docs/ARCHITECTURE.md` §11: the derived key, the freshness guarantee, the unexportable-schema fallback, and the injected exporter.
- `playground/app/(tabs)/index.tsx`: the `callCountRef` workaround is gone, the four registrations no longer pass `[]`, and a new `call_count` tool closes over `callCount` state directly so the playground demonstrates the freshness guarantee rather than only describing it. Listed in `playground/README.md`.

## Acceptance criteria

| From the issue | Where |
| --- | --- |
| N re-renders, unchanged definition → one registration, zero deltas | `"N re-renders with an unchanged definition produce exactly one registration and no removals"` |
| Changing `description` → remove + upsert | `"changing description re-registers (remove + upsert)"` |
| Changing only a closed-over value → no re-registration, next call sees the new value | `"a handler closing over changed state does not re-register, and the next call sees the new value"` |
| `/noop` keeps parity | shared `createUseCordieriteTool`; `noop-parity.test.ts` unchanged and green; `"inert entry: no JSON Schema exporter injected"` |
| Stale-disposer guarantees kept | `"disabling hook A never removes hook B's still-active registration…"` unchanged |
| README examples + doc comment updated | root README, RN README §5, ARCHITECTURE §11, hook doc comment |

## Validation

Run at the repo root on the final commit (`92be630`):

- `pnpm build` — 3/3 tasks successful.
- `pnpm typecheck` — 3/3 tasks successful.
- `pnpm lint` — 2/2 tasks successful, 0 errors (194 pre-existing warnings repo-wide; the four changed source files and the playground screen lint clean).
- `pnpm test` — all green on `2ddf17c`: `@cordierite/shared` 122/122, `@cordierite/react-native` 225/225, `cordierite` 318/318 (665 total). `92be630` touches only the react-native package and docs: `@cordierite/react-native` **226/226**.
  - `e2e/daemon-restart.e2e.test.ts` and `e2e/client.e2e.test.ts` each failed intermittently in earlier full runs in this environment and pass now; both are flaky rather than broken, and neither loads code this change touches.

## Review findings

### External adversarial review (verdict: needs-fixes) — all resolved in `2ddf17c`

1. **Unexportable schemas collapsed into "no schema"** (`useCordieriteTool.ts`). A schema with no JSON Schema exporter (zod 3, plain valibot) exported `undefined`, so its key equalled "no schema at all": adding, swapping or removing one never re-registered, the registry kept validating with the mount-time schema, and `tool-invocation.ts`'s "must not return a result when `outputSchema` is omitted" rule kept keying on the mount-time `outputSchema` presence. **Fixed** — the key now distinguishes the three cases, with a per-slot counter bumped whenever an identity change yields no export, so unexportable schemas fall back to identity. The cost is that one rebuilt inline each render re-registers each render, exactly as it did before this branch; the doc comment, ARCHITECTURE §11 and the README all say so and point at hoisting or zod v4. Two new tests cover add/swap/remove and the hoisted case.
2. **`./noop` ran JSON Schema exports for nothing.** **Fixed** — `createUseCordieriteTool` takes an optional `exportSchema`; `index.ts` injects `exportToolSchema`, `noop.ts` injects nothing and keys the effect off `enabled` alone. The compiled `build/useCordieriteTool.js` now imports only `react`, so the inert entry's graph no longer contains `schema.ts` at all. The public hook's signature, arity and observable behaviour are identical (`noop-parity.test.ts` unchanged and green), plus two tests pinning the inert variant.
3. **`null` deps crashed on `[...null]`.** **Fixed** — nullish check restores the previous truthiness behaviour (treated as omitted); regression test added.
4. **Two mounted hooks sharing a name: the survivor never re-claims it.** **Documented as an accepted narrowing**, per the reviewer's stated preference. Duplicate names were never supported — the registry already dev-warns and the later registration overwrites — and a caller who wants the old behaviour can pass `deps`. Called out in the hook doc comment and the package README.
5. **Playground comment described a freshness demo that did not exist.** **Fixed** — new `call_count` tool whose handler closes over `callCount` state directly; comment and the on-screen hint corrected, and the tool listed in `playground/README.md`.
6. **`timeoutMs` described as "what the daemon can observe"** — it is app-side only. **Fixed** — ARCHITECTURE §11 and the doc comment now say "what changes the registry entry" and name the exception.
7. **Stale `eslint-disable-next-line react-hooks/exhaustive-deps`.** **Fixed** — verified the rule does not fire on this file at all, so the directive suppressed nothing; the claim is removed and the explanation kept.
8. **Test gaps.** **Fixed** — `name` change, `outputSchema` shape change, `deps: []` overriding the derived key, and the shapeless-schema cases are all covered; the dead `effectRunCount` getter is gone from the fake host.

### Second-round review (verdict: ready) — optional items, all taken in `92be630`

1. **A disabled hook still exported JSON Schema every render.** **Fixed** — the export work is now gated on `enabled`, while the choice of dependency-array branch deliberately is not, so the array's length still never changes between renders. Re-enabling re-runs the effect regardless (`enabled` is itself a dependency) and the memos are untouched meanwhile, so an unchanged schema still hits them. New test: a disabled hook with an inline schema re-rendered three times calls the exporter zero times.
2. **Root README's "re-rendering costs nothing" was unqualified.** **Fixed** — it now states what it holds for (schemas that export JSON Schema — Zod 4, ArkType — or are hoisted) and links to the package README for the zod 3 / plain valibot exception.
3. **ARCHITECTURE §11 attributed inert-entry behavioural parity to `noop-parity.test.ts`,** which only pins the API shape and arity. **Fixed** — the sentence now credits the "inert entry" cases in `use-cordierite-tool.test.ts` for the behavioural half.

### Earlier self-review

- `deps as DependencyList` cast paired with an alias that could drift — replaced with a direct branch (now `hasDeps`).
- Registry keeps the schema objects from the most recent registration, so an identity-different schema exporting the same shape keeps validating against the earlier object. Only reachable for a `.refine()`-style rule that JSON Schema cannot express and that closes over changing state; documented with `deps` as the escape hatch.

### Checked, no change needed

- **Rules of hooks** — three `useRef` calls and one `useEffect`, all unconditional; the branches select values, never hook calls.
- **Dependency-array length** — fixed per branch (7 derived, 1 inert, `deps.length + 1` caller-supplied), and independent of `enabled`. Alternating between passing and omitting `deps` still changes the length between renders, exactly as `undefined` → array did before; documented rather than silently papered over.
- **Stale closures** — `definitionRef.current` is written during render (pre-existing, unchanged) and read at effect time and at call time, so the effect registers the committed definition and the wrapper forwards to the latest one.
- **Fast Refresh** — an edited handler body now takes effect without a re-registration at all; when the effect does re-run, the identity-safe disposer still covers remount churn.
- **`annotations` key ordering** — `JSON.stringify` is key-order sensitive, so a caller varying key order between renders would re-register spuriously. Not reachable from an object literal; the plan chose stringify for exactly these three optional booleans.
- **CI** — `pnpm lint` does not fail on warnings; the playground change is TypeScript-only and `expo prebuild` does not bundle JS, so the Android/iOS jobs are unaffected.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkzpDHexc8EuFfsFf8yQyh