### PR TITLE
docs: five-minute READMEs, hardening moved to docs/, markdown link check (#33)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,6 +48,9 @@ jobs:
         run: pnpm build
       - name: Run lint
         run: pnpm lint
+      - name: Check Markdown links
+        # Relative links and heading anchors only, no network — see scripts/check-md-links.mjs.
+        run: pnpm check:links
 
   typecheck:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ npm install @cordierite/react-native zod
 
 From there:
 
-- **[Set up your app](packages/react-native/README.md)** — registering tools, deep-link setup, and how to decide what ships in which build.
+- **[Set up your app](packages/react-native/README.md)** — registering tools, deep-link setup, and the API reference.
 - **[Use the CLI and MCP server](packages/cordierite/README.md)** — connecting to a device, listing and calling tools, and checking a built artifact.
 - **[Try the playground](playground/README.md)** — a working app you can run end to end in a few minutes. Fastest way to see whether this fits your project.
 
@@ -86,10 +86,11 @@ iOS 15.1+ and Android, both on the New Architecture. Web gets a no-op stub so sh
 
 ## Docs
 
-- [`docs/SECURITY.md`](docs/SECURITY.md) — what it protects against, and key rotation
+- [`docs/SECURITY.md`](docs/SECURITY.md) — what it protects against, configuring trust, and key rotation
+- [`docs/BUILD-VARIANTS.md`](docs/BUILD-VARIANTS.md) — which builds carry Cordierite, and how to compile it out
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — how the pieces fit together
 - [`docs/PROTOCOL.md`](docs/PROTOCOL.md) — the wire protocol, if you're implementing a client
-- [`docs/CI.md`](docs/CI.md) — running it in CI
+- [`docs/CI.md`](docs/CI.md) — running it in CI, and the `cordierite doctor` release gate
 
 ## Made with ❤️ at Callstack
 
@@ -104,6 +105,6 @@ Like the project? ⚛️ [Join the team](https://callstack.com/careers/?utm_camp
 [npm-downloads-badge]: https://img.shields.io/npm/dm/cordierite?style=for-the-badge
 [npm-downloads]: https://www.npmjs.com/package/cordierite
 [prs-welcome-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=for-the-badge
-[prs-welcome]: ./CONTRIBUTING.md
+[prs-welcome]: https://github.com/callstackincubator/cordierite/pulls
 [chat-badge]: https://img.shields.io/discord/426714625279524876.svg?style=for-the-badge
 [chat]: https://discord.gg/xgGt7KAjxv

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -340,9 +340,11 @@ config-surface summary):
   it**; and an unrecognized `trust` value is a hard error at both config time and in native
   resolution, so a typo can't silently downgrade `"pin"` into permissive link TOFU.
 
-The full config surface (option names, native keys, recipes) lives in the
-[package README](../packages/react-native/README.md); the threat model lives in
-[SECURITY.md](SECURITY.md).
+The full config surface (option names, native keys, trust recipes) lives in
+[SECURITY.md](SECURITY.md#configuring-trust); the inclusion/compile-out recipes live in
+[BUILD-VARIANTS.md](BUILD-VARIANTS.md); the threat model lives in
+[SECURITY.md](SECURITY.md). The [package README](../packages/react-native/README.md) is the
+getting-started path and API reference.
 
 Client behavior:
 
@@ -354,19 +356,24 @@ Client behavior:
   and re-send the full registry snapshot after every successful resume. Resume attempts
   pause in background and restart on foreground. A `1008` close is terminal in both
   directions — mid-session, and as the rejection of a claim/resume handshake: it is the
-  daemon's "no retry of this frame can succeed" signal (`unknown_session`,
-  `invalid_resume_token`, `link_expired`, …), so the session is lost immediately with the
-  daemon's own reason rather than retried for the remainder of the grace window.
-  Transport-level closes (`1011`, `1001`, `1006`) stay retryable.
+  daemon's "no retry of this frame can succeed" signal (`unknown_session` after a daemon
+  restart, `invalid_resume_token`, `link_expired`, an expired or revoked session, a
+  malformed frame), so the session is lost immediately with the daemon's own reason —
+  surfaced to JS as `sessionChange: lost` — rather than retried for the remainder of the
+  grace window. Transport-level closes stay retryable, including `1011 send_failed` and
+  `1001 daemon_shutdown`: the daemon may well be back before grace expires.
 - Installing the bootstrap explicitly or importing `/auto` registers the runtime URL
   listener first, then restores once from the native lease before considering the initial
   launch URL. A successful restore suppresses that initial URL claim; no lease or an
   unexpected orchestration failure falls back to normal initial-link handling. This lets
   a fresh Metro JS runtime resume automatically with the same alias and no new link.
+  Runtime URLs delivered later still parse the v2 bootstrap payload and call `connect` when
+  the client is idle, so an app on the default flow needs no `Linking` handler of its own.
   Native app process death erases the lease and requires a fresh bootstrap. Apps that
   drive bootstrap themselves and never install the listener must call the exported
-  `restoreSession()` at startup — it is the only other reader of the lease, so skipping it
-  drops a resumable session on every JS runtime replacement.
+  `restoreSession()` (equivalently `cordieriteClient.restoreSession()`) at startup — it is
+  the only other reader of the lease, so skipping it drops a resumable session on every JS
+  runtime replacement.
 - `registerTool({ name, description, inputSchema?, outputSchema?, annotations?, handler })`
   → `{ remove() }`. The disposer removes only its own registration (compare by
   registration identity, not name). Duplicate name registration logs a dev warning and

--- a/docs/BUILD-VARIANTS.md
+++ b/docs/BUILD-VARIANTS.md
@@ -78,7 +78,15 @@ CORDIERITE_ENABLED=0 npx expo prebuild && CORDIERITE_ENABLED=0 npx expo run:ios 
 ```
 
 Accepted values are `1`/`true` and `0`/`false`, case-insensitive; unset or empty means the
-dev-only default described above. Any other value is a config error, raised at prebuild.
+dev-only default described above.
+
+**A value that is neither is only caught on the Expo path.** The config plugin throws at
+prebuild, but nothing else does, and the two platforms then disagree: autolinking's
+`react-native.config.js` swallows the parse error and falls back to linking Cordierite into
+**every** build, while `android/build.gradle` treats anything but `1`/`true` as off and
+compiles the `release` stub. A bare-RN pipeline gets no error at all — check the built
+artifact with `cordierite doctor` ([`CI.md`](CI.md#release-gate-cordierite-doctor)) rather
+than trusting the variable's spelling.
 
 **One variable, every surface.** Cordierite ships its own `react-native.config.js` that
 reads the variable and sets `ios.configurations` in autolinking accordingly;
@@ -225,7 +233,8 @@ module.exports = withCordierite(config);
 
 With no options it reads `CORDIERITE_ENABLED` itself, so the same variable that drops the
 native module strips the JS. Pass `{ include: false }` to force the strip, or
-`{ include: <your own predicate> }` to key it off something else entirely.
+`{ include: yourCondition }` with a boolean you compute yourself to key it off something
+else entirely — `include` is a boolean, not a callback.
 
 When stripping, every specifier this package exposes as a real JS module entry point
 (derived from `package.json`'s `exports`, not a hardcoded `.`/`/auto` list, so a future

--- a/docs/BUILD-VARIANTS.md
+++ b/docs/BUILD-VARIANTS.md
@@ -186,13 +186,14 @@ from the registry instead of resolving the one your build actually uses):
 > `apple` instead (or to both).
 
 > **Excluding on iOS also disables codegen for this package.** `expo-modules-autolinking`
-> only generates `CordieriteSpec` (the TurboModule codegen output `RCTNativeCordierite.mm`
-> imports) for packages it actually autolinks. If your app excludes
-> `@cordierite/react-native` from iOS autolinking but still references the `Cordierite` pod
-> directly — for example to attach an XCTest target, as this repo's own playground does —
-> the build fails because the generated header no longer exists. This only affects setups
-> that both exclude and hand-add the pod; a normal consumer app that just wants Cordierite
-> gone never hits it.
+> only generates `CordieriteSpec` — the TurboModule codegen output `RCTNativeCordierite.mm`
+> imports — for packages it actually autolinks.
+>
+> So if your app excludes `@cordierite/react-native` from iOS autolinking but still
+> references the `Cordierite` pod directly — for example to attach an XCTest target, as this
+> repo's own playground does — the build fails because the generated header no longer
+> exists. This only affects setups that both exclude and hand-add the pod; a normal consumer
+> app that just wants Cordierite gone never hits it.
 
 There is no corresponding plugin option to keep in sync. Earlier 0.4.0 prereleases had an
 `include` option that only *asserted* the plugin's intent matched autolinking; it was

--- a/docs/BUILD-VARIANTS.md
+++ b/docs/BUILD-VARIANTS.md
@@ -1,8 +1,12 @@
 # Build variants: which builds carry Cordierite
 
-Whether Cordierite's native code and JS ship in a given build is one explicit decision,
-driven by autolinking and the `CORDIERITE_ENABLED` environment variable. It is **not**
-derived from whether the build is debuggable.
+Whether Cordierite's native code ships in a given build is decided by autolinking and the
+`CORDIERITE_ENABLED` environment variable. It is **not** derived from whether the build is
+debuggable.
+
+The JS half is a separate, opt-in step. `CORDIERITE_ENABLED` strips Cordierite's JS too,
+but only once the `withCordierite` Metro helper is wired into `metro.config.js` — without
+that, the real JS entry is still bundled; it just finds no native module and goes inert.
 
 What a build *trusts* once it does ship is a separate, orthogonal decision — see
 [`SECURITY.md`](SECURITY.md#trust-modes).
@@ -56,11 +60,8 @@ ships at all.
 
 ## `CORDIERITE_ENABLED`
 
-**Debug builds carry Cordierite by default; release builds don't.** On iOS this is
-CocoaPods only linking the `Cordierite` pod into configurations named `Debug`
-(`react-native.config.js`'s `ios.configurations`). On Android, `android/build.gradle`
-compiles the real implementation for `debug` and a no-op stand-in for `release`, driven by
-the same variable. Neither is a runtime check.
+The per-platform mechanism is described above; this section is what to set, and where
+each surface reads it.
 
 A release-signed internal/QA build that still needs Cordierite (an agent-driven CI build,
 for example) opts back in explicitly:
@@ -119,9 +120,13 @@ release build that carries Cordierite by mistake, which is the failure that matt
 ## Compiling Cordierite out of production builds
 
 Removing Cordierite entirely takes two independent halves — the native module and the JS
-bundle. `CORDIERITE_ENABLED=0` drives both at once, which is what you want to satisfy an
-app-store reviewer who expects no "remote control" surface whatsoever, not just an inert
-one.
+bundle. `CORDIERITE_ENABLED=0` drives both at once **provided `withCordierite` is wired
+into `metro.config.js`** (see [JS — swap the module at bundle
+time](#js--swap-the-module-at-bundle-time)); without that helper the variable removes only
+the native half.
+
+Both halves are what satisfies an app-store reviewer who expects no "remote control"
+surface whatsoever, not just an inert one.
 
 **Either half alone still yields a working, inert app.** The `/noop` Metro swap alone
 gives you an app with no Cordierite JS running but the native pod still compiled in

--- a/docs/BUILD-VARIANTS.md
+++ b/docs/BUILD-VARIANTS.md
@@ -1,0 +1,263 @@
+# Build variants: which builds carry Cordierite
+
+Whether Cordierite's native code and JS ship in a given build is one explicit decision,
+driven by autolinking and the `CORDIERITE_ENABLED` environment variable. It is **not**
+derived from whether the build is debuggable.
+
+What a build *trusts* once it does ship is a separate, orthogonal decision — see
+[`SECURITY.md`](SECURITY.md#trust-modes).
+
+- [Inclusion is an autolinking decision](#inclusion-is-an-autolinking-decision)
+- [`CORDIERITE_ENABLED`](#cordierite_enabled)
+- [Verifying against the artifact](#verifying-against-the-artifact)
+- [Compiling Cordierite out of production builds](#compiling-cordierite-out-of-production-builds)
+- [Excluding it permanently, without the environment variable](#excluding-it-permanently-without-the-environment-variable)
+- [JS — swap the module at bundle time](#js--swap-the-module-at-bundle-time)
+
+## Inclusion is an autolinking decision
+
+Inclusion is decided entirely by autolinking, not by anything this package does at
+runtime. By default the native module is present in **debug** builds and absent from
+**release** builds.
+
+The mechanism differs by platform. On iOS, CocoaPods' `:configurations` is restricted to
+`Debug` — a real per-variant *linking* decision.
+
+Android can't use the equivalent `buildTypes` lever the same way, for a package with
+static Java registration (`packageInstance`). React Native's Gradle autolinking generates
+`PackageList.java` once, shared unfiltered across every variant, so restricting *linking*
+by variant would leave that shared file referencing a class absent from an unlisted
+variant's classpath — a compile error, not an inert build.
+
+Android therefore links this project into every variant unconditionally, and
+`android/build.gradle` instead swaps which Kotlin source set compiles for the `release`
+build type, based on `CORDIERITE_ENABLED`. `debug` always compiles the real
+implementation; `release` compiles either the same real files (opted in) or a no-op
+`CordieritePackage` (the default) that registers nothing.
+
+Either way, the real implementation is genuinely absent from the compiled output it is
+excluded from — not a `#if DEBUG`/`FLAG_DEBUGGABLE` check baked into code that ships
+regardless. `CordieritePackage.getModule` (Android) and
+`CordieriteTurboBridge.swift`/`RCTNativeCordierite.mm` (iOS) contain no build-type check
+at all: if the real implementation is compiled/linked into a variant, it is in that
+variant's build, full stop. Whether it is is what `CORDIERITE_ENABLED` controls.
+
+**Resulting matrix (`CORDIERITE_ENABLED` × build variant, `trust` orthogonal to both):**
+
+| `CORDIERITE_ENABLED` | Debug / `debug` | Release / `release` |
+| --- | --- | --- |
+| unset (default) | Native code ships | Native code excluded |
+| `1` / `true` | Native code ships | Native code ships |
+| `0` / `false` | Native code excluded | Native code excluded |
+
+`trust` (`"link"` vs `"pin"`, resolved as described in
+[`SECURITY.md`](SECURITY.md#trust-modes)) only matters in a variant where the native code
+ships at all.
+
+## `CORDIERITE_ENABLED`
+
+**Debug builds carry Cordierite by default; release builds don't.** On iOS this is
+CocoaPods only linking the `Cordierite` pod into configurations named `Debug`
+(`react-native.config.js`'s `ios.configurations`). On Android, `android/build.gradle`
+compiles the real implementation for `debug` and a no-op stand-in for `release`, driven by
+the same variable. Neither is a runtime check.
+
+A release-signed internal/QA build that still needs Cordierite (an agent-driven CI build,
+for example) opts back in explicitly:
+
+```bash
+CORDIERITE_ENABLED=1 npx expo prebuild && CORDIERITE_ENABLED=1 npx expo run:ios --configuration Release
+```
+
+To go the other direction — strip Cordierite from a **debug** build too, or from every
+variant regardless of name — set `CORDIERITE_ENABLED=0`:
+
+```bash
+CORDIERITE_ENABLED=0 npx expo prebuild && CORDIERITE_ENABLED=0 npx expo run:ios --configuration Release
+```
+
+Accepted values are `1`/`true` and `0`/`false`, case-insensitive; unset or empty means the
+dev-only default described above. Any other value is a config error, raised at prebuild.
+
+**One variable, every surface.** Cordierite ships its own `react-native.config.js` that
+reads the variable and sets `ios.configurations` in autolinking accordingly;
+`android/build.gradle` reads the same variable directly to pick the `release` source set;
+and `@cordierite/react-native/metro` reads it too, to strip the JS (see
+[JS — swap the module at bundle time](#js--swap-the-module-at-bundle-time)). Metro's own
+dev/release split does not thread through to this, so an explicit `CORDIERITE_ENABLED=0`
+is still how you strip Cordierite JS from a release bundle.
+
+**It must be set when autolinking resolves** — `pod install` and gradle configure — not
+merely when the app compiles. Flipping it and rebuilding without re-running install does
+nothing, silently.
+
+**Keyed to build type by name, not by a compiled-in check.** CocoaPods restricts linking
+to Xcode configurations literally named `Debug`/`Release`; Gradle restricts it to build
+types literally named `debug`/`release`. A custom build-type/configuration name (a
+`staging` flavor, say) gets neither — set `CORDIERITE_ENABLED=1` for that pipeline if it
+should carry Cordierite. This replaces the `debuggable`/`#if DEBUG` gate removed in 0.4.0
+with a real per-variant linking decision instead of a runtime check compiled into every
+variant.
+
+## Verifying against the artifact
+
+Verify the result against the artifact rather than the build log:
+
+```bash
+cordierite doctor path/to/app-release.apk --assert-absent
+```
+
+When Cordierite *is* linked, its podspec and `build.gradle` print
+`[cordierite] native module INCLUDED in this build` during pod install / gradle configure.
+Nothing prints when it is excluded, because nothing runs — the line exists to catch a
+release build that carries Cordierite by mistake, which is the failure that matters. Treat
+`doctor` as the authority; the log is an early warning.
+
+`doctor`'s exit codes, its Android detection signals, and the CI wiring live in
+[`CI.md`](CI.md#release-gate-cordierite-doctor).
+
+## Compiling Cordierite out of production builds
+
+Removing Cordierite entirely takes two independent halves — the native module and the JS
+bundle. `CORDIERITE_ENABLED=0` drives both at once, which is what you want to satisfy an
+app-store reviewer who expects no "remote control" surface whatsoever, not just an inert
+one.
+
+**Either half alone still yields a working, inert app.** The `/noop` Metro swap alone
+gives you an app with no Cordierite JS running but the native pod still compiled in
+(unused). The autolinking exclude alone gives you an app with no native Cordierite code
+but that still imports the real JS entry, which finds no native module and degrades to the
+same `/noop`-equivalent behavior described in
+[`SECURITY.md`](SECURITY.md#what-a-build-without-the-native-module-does).
+
+## Excluding it permanently, without the environment variable
+
+If a project should never carry Cordierite on a given platform — regardless of pipeline —
+declare the exclusion in the app instead. In a `react-native.config.js` at your app root:
+
+```js
+module.exports = {
+  dependencies: {
+    "@cordierite/react-native": {
+      platforms: {
+        ios: null,
+        android: null,
+      },
+    },
+  },
+};
+```
+
+The Expo-managed equivalent is `expo.autolinking`'s per-platform `exclude` list — but it
+must live in **`package.json`**, not `app.json` / `app.config.*`.
+`expo-modules-autolinking` reads this config straight from `package.json` at
+pod-install/gradle time; an `expo.autolinking` block in `app.json` is silently ignored, so
+the exclusion never happens and the native module still ships. This has already shipped as
+a bug once, so double-check with the resolver command below after adding it.
+
+```json
+{
+  "expo": {
+    "autolinking": {
+      "ios": { "exclude": ["@cordierite/react-native"] },
+      "android": { "exclude": ["@cordierite/react-native"] }
+    }
+  }
+}
+```
+
+Verify the exclusion actually took effect — this is the only way to catch the `app.json`
+mistake above. Run it from your app root after `npm`/`pnpm`/`yarn install`, using the
+locally installed binary rather than `npx` (which can silently fetch an unrelated version
+from the registry instead of resolving the one your build actually uses):
+
+```sh
+./node_modules/.bin/expo-modules-autolinking react-native-config --json --platform ios
+```
+
+`@cordierite/react-native` must be absent from the printed `dependencies`.
+
+> **`expo.autolinking.apple` overrides `expo.autolinking.ios`, not merges with it.** The
+> CocoaPods driver `pod install` actually invokes always resolves with `--platform apple`,
+> and when an `apple` sub-object is present under `expo.autolinking`, it wins outright over
+> `ios` — `ios` is only used as a fallback when `apple` is absent. If your app also has an
+> `expo.autolinking.apple` block (for reasons unrelated to Cordierite), an `ios`-only
+> exclude for `@cordierite/react-native` is silently ignored on iOS; add the exclude to
+> `apple` instead (or to both).
+
+> **Excluding on iOS also disables codegen for this package.** `expo-modules-autolinking`
+> only generates `CordieriteSpec` (the TurboModule codegen output `RCTNativeCordierite.mm`
+> imports) for packages it actually autolinks. If your app excludes
+> `@cordierite/react-native` from iOS autolinking but still references the `Cordierite` pod
+> directly — for example to attach an XCTest target, as this repo's own playground does —
+> the build fails because the generated header no longer exists. This only affects setups
+> that both exclude and hand-add the pod; a normal consumer app that just wants Cordierite
+> gone never hits it.
+
+There is no corresponding plugin option to keep in sync. Earlier 0.4.0 prereleases had an
+`include` option that only *asserted* the plugin's intent matched autolinking; it was
+removed once `CORDIERITE_ENABLED` drove autolinking directly, since there were no longer
+two sources to reconcile. Passing it now throws at prebuild, naming the replacement.
+
+## JS — swap the module at bundle time
+
+Strip the JS too, so no Cordierite JS (deep-link listener, tool registry, client state
+machine) ends up in the bundle either. Excluding the native module alone does not do this:
+the real JS entry is still bundled, it just finds no native module and goes inert.
+
+Use the `withCordierite` Metro helper from `@cordierite/react-native/metro` in
+`metro.config.js`:
+
+```js
+const { getDefaultConfig } = require("expo/metro-config");
+const { withCordierite } = require("@cordierite/react-native/metro");
+
+const config = getDefaultConfig(__dirname);
+
+module.exports = withCordierite(config);
+```
+
+With no options it reads `CORDIERITE_ENABLED` itself, so the same variable that drops the
+native module strips the JS. Pass `{ include: false }` to force the strip, or
+`{ include: <your own predicate> }` to key it off something else entirely.
+
+When stripping, every specifier this package exposes as a real JS module entry point
+(derived from `package.json`'s `exports`, not a hardcoded `.`/`/auto` list, so a future
+entry point is covered automatically) is redirected to `@cordierite/react-native/noop`,
+which has no side effect on import, matching `/auto`'s shape without installing anything.
+`/noop` itself is never redirected.
+
+If `config.resolver.resolveRequest` is already set — as it typically will be, e.g. the
+playground's own workspace-symlink-dedup resolver — `withCordierite` **chains to it** for
+every resolution, redirected or not, instead of replacing it; it only falls back to
+`context.resolveRequest` when no existing resolver is present. Your existing resolver's
+return value is what callers see.
+
+**Call `withCordierite` last**, after anything else that sets
+`config.resolver.resolveRequest` — it captures the existing resolver by reference when
+called, so a later assignment overwrites (and silently discards) the strip instead of
+composing with it.
+
+If you'd rather not touch Metro config, a conditional `require` at each import site works
+too (module identity differs per call site, so this is more repetitive but avoids any
+bundler-level indirection):
+
+```ts
+const { registerTool, useCordieriteTool } = __DEV__
+  ? require("@cordierite/react-native")
+  : require("@cordierite/react-native/noop");
+```
+
+Either way, `/noop` is typed identically to the root entry — both implement the same
+shared interface, see `src/public-api.ts` and `src/__tests__/noop-parity.test.ts` — so
+switching between them is a drop-in swap. `registerTool` still returns a disposer,
+`connect()` still returns a `Promise<void>` (it just always rejects with a
+`CordieriteDisabledError`, `code: "cordierite_disabled"`), and `getCordieriteState()`
+always reports `"idle"`.
+
+## Related
+
+- [`SECURITY.md`](SECURITY.md) — trust modes, pins, and the threat model
+- [`CI.md`](CI.md#release-gate-cordierite-doctor) — the `cordierite doctor` release gate
+- [`ARCHITECTURE.md`](ARCHITECTURE.md#11-react-native-sdk) — SDK entry points and client behavior
+- [`@cordierite/react-native` README](../packages/react-native/README.md) — getting started and API reference

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -31,18 +31,34 @@
 
 ## Release gate: `cordierite doctor`
 
-Opt-in hardening removes the runtime `debuggable`/`#if DEBUG` check that used to catch a
-production build that forgot to exclude Cordierite via autolinking (docs/tasks/00-overview.md,
-docs/tasks/08-cordierite-doctor.md). `cordierite doctor <artifact> [--assert-present |
---assert-absent]` (packages/cordierite/README.md, "Release gate") is the replacement: it inspects
-a built `.app`/`.ipa`/`.apk`/`.aab` directly, rather than trusting the config that's supposed to
-have produced it, and exits non-zero when the assertion fails.
+Cordierite's inclusion in a build is controlled entirely by autolinking exclusion (see
+[`BUILD-VARIANTS.md`](BUILD-VARIANTS.md)) — there is no runtime `debuggable`/`#if DEBUG`
+check to catch a pipeline that forgot to exclude the package
+(docs/tasks/00-overview.md, docs/tasks/08-cordierite-doctor.md).
 
-  - `0`: the artifact matches the asserted expectation (or no assertion was given).
-  - `3`: inspection succeeded, but the artifact didn't match `--assert-present`/`--assert-absent`.
-  - `66`: the artifact could not be inspected at all (missing `unzip`, unreadable/corrupt
-    artifact) — always a distinct failure from `3`, and never silently treated as "absent" or "the
-    check passed".
+`cordierite doctor <artifact> [--assert-present | --assert-absent]` is the replacement: an
+artifact-level assertion you run against the thing you're about to ship, not the config you
+think produced it.
+
+```bash
+cordierite doctor ./build/MyApp.ipa --assert-absent
+cordierite doctor ./build/app-release.apk --assert-absent
+```
+
+It inspects a built `.app`/`.ipa`/`.apk`/`.aab` for Cordierite's native code — the
+`RCTNativeCordierite` Objective-C class and the plugin-authored `Info.plist` keys on iOS;
+the `com.callstackincubator.cordierite` dex package and `AndroidManifest.xml` meta-data
+keys on Android — and reports `present`/`absent`.
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | inspection succeeded; no assertion was given, or the assertion held |
+| `3` | inspection succeeded, but `--assert-present`/`--assert-absent` did not hold |
+| `64` | usage error (bad flags, or an artifact extension that isn't `.app`/`.ipa`/`.apk`/`.aab`) |
+| `66` | the artifact could not be inspected — a required external tool (`unzip`) was missing, or the artifact was unreadable/corrupt. **Never treated as "absent"**: a broken check must fail loudly, not rubber-stamp a release. |
+
+`66` is always a distinct failure from `3`, and never silently treated as "absent" or "the
+check passed".
 
 CI snippet, run against the production release build right before it's distributed:
 
@@ -52,6 +68,52 @@ CI snippet, run against the production release build right before it's distribut
 - name: Assert Cordierite is excluded from the production build (iOS)
   run: npx cordierite doctor ./build/MyApp.ipa --assert-absent
 ```
+
+For an internally-distributed "testing" build that an agent drives, invert the assertion
+(`--assert-present`) so a forgotten inclusion — not just a forgotten exclusion — fails CI
+too.
+
+### Android detection
+
+**Android detection is marker-only.** The default release build's no-op
+`CordieritePackage` stub necessarily lives at the exact same fully-qualified class name the
+real implementation uses (that is what keeps `PackageList.java` compiling — see
+[`BUILD-VARIANTS.md`](BUILD-VARIANTS.md#inclusion-is-an-autolinking-decision)), and the
+config plugin writes the same `AndroidManifest.xml` meta-data regardless of build variant.
+Both would otherwise look like "Cordierite is present" to a naive scan.
+
+`doctor` accounts for this: only the `CordieriteNativeMarker` keep-rule signal decides
+`present`/`absent` on Android. The other two signals are still reported for corroboration
+but can't flip the verdict on their own.
+
+The three signals, in order of reliability:
+
+1. `CordieriteNativeMarker`, kept unminified by the keep rule `@cordierite/react-native`
+   ships via `consumerProguardFiles`. It reaches every consuming app's R8 run without the
+   app authoring any rule, so it holds for bare-RN apps that never touch the Expo config
+   plugin.
+2. The dex package name — survives ordinary minification but not R8 full mode's
+   repackaging.
+3. The config plugin's `AndroidManifest.xml` meta-data keys — only present if the plugin
+   ran.
+
+Signals 2 and 3 are retained as fallbacks for artifacts built before the marker existed.
+See `packages/cordierite/src/artifact-inspect.ts`'s file-level comment for the full
+detection writeup.
+
+**Verified** against a real R8-minified release APK
+(`assembleRelease -Pandroid.enableMinifyInReleaseBuilds=true`): the R8 mapping shows
+sibling classes obfuscated (`CordieriteBuildConfig -> …cordierite.a`) while
+`CordieriteNativeMarker` keeps its fully-qualified name, and `doctor --assert-present`
+passes on that artifact.
+
+**Still not covered:** R8 *full mode* with `-repackageclasses` was not exercised, and no
+artifact was tested from a bare-RN app that uses neither Expo nor the config plugin — the
+configuration the marker most directly targets. The marker should hold in both (a `-keep`
+rule prevents renaming and removal regardless of mode), but that is reasoning, not a
+measurement.
+
+### This repo's own CI wiring
 
 **This repo's own CI wires the gate** (`test.yaml`'s `android` job) against all three
 `CORDIERITE_ENABLED` states: after the existing `testDebugUnitTest`/`assembleDebug` step (unset

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -45,10 +45,12 @@ cordierite doctor ./build/MyApp.ipa --assert-absent
 cordierite doctor ./build/app-release.apk --assert-absent
 ```
 
-It inspects a built `.app`/`.ipa`/`.apk`/`.aab` for Cordierite's native code — the
-`RCTNativeCordierite` Objective-C class and the plugin-authored `Info.plist` keys on iOS;
-the `com.callstackincubator.cordierite` dex package and `AndroidManifest.xml` meta-data
-keys on Android — and reports `present`/`absent`.
+It inspects a built `.app`/`.ipa`/`.apk`/`.aab` for Cordierite's native code and reports
+`present`/`absent`. On iOS it looks for the `RCTNativeCordierite` Objective-C class and the
+plugin-authored `Info.plist` keys. On Android the verdict is decided by the
+`CordieriteNativeMarker` keep-rule signal alone; the `com.callstackincubator.cordierite`
+dex package and the `AndroidManifest.xml` meta-data keys are reported alongside it but
+cannot flip it (see [Android detection](#android-detection)).
 
 | Exit code | Meaning |
 | --- | --- |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -115,8 +115,8 @@ torn down, so a malformed or expired link costs the existing session nothing.
 configuration alone. Set `cliPins` (which makes `trust: "pin"` the default) on any build you
 don't want accepting a link-carried pin. Separately, if you don't want Cordierite's native
 code present in a build at all — regardless of trust mode — exclude it from autolinking (see
-[Compile out of a build you don't want carrying Cordierite at all](#production-guidance)
-below and [`BUILD-VARIANTS.md`](BUILD-VARIANTS.md)); `cordierite doctor`
+[Compiling Cordierite out of production
+builds](BUILD-VARIANTS.md#compiling-cordierite-out-of-production-builds)); `cordierite doctor`
 ([`CI.md`](CI.md#release-gate-cordierite-doctor)) verifies that exclusion actually took
 effect in a built artifact, rather than trusting the config that was supposed to produce
 it.
@@ -391,11 +391,16 @@ not as the mechanism that keeps a destructive tool out of reach of a hostile one
 - **Compile out of a build you don't want carrying Cordierite at all.** Being present and
   trusting nothing (`trust: "pin"` with a `cliPins` set that has no matching daemon, or an
   app that simply never mints a bootstrap link for that build) still ships the native code
-  and JS bundle inside the binary. Stripping it takes two independent steps — exclude the
-  package from **autolinking** (the only thing that removes the compiled native
-  pod/module) and swap the **JS** entries for `/noop` at bundle time (the only thing that
-  removes the deep-link listener and tool registry from the bundle). Neither alone removes
-  both; `CORDIERITE_ENABLED=0` drives both at once.
+  and JS bundle inside the binary.
+
+  Stripping it takes two independent steps. Excluding the package from **autolinking** is
+  the only thing that removes the compiled native pod/module; swapping the **JS** entries
+  for `/noop` at bundle time is the only thing that removes the deep-link listener and tool
+  registry from the bundle.
+
+  Neither alone removes both. `CORDIERITE_ENABLED=0` drives both at once, but only once
+  the `withCordierite` Metro helper is wired into `metro.config.js` — without it the
+  variable removes the native half only.
 
   The exact snippets, the `package.json`-only placement of `expo.autolinking`, the
   `apple`-overrides-`ios` rule and the iOS codegen coupling live in

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -373,12 +373,16 @@ not as the mechanism that keeps a destructive tool out of reach of a hostile one
   restricts CocoaPods linking to the `Debug` configuration; Android swaps in a no-op
   `CordieritePackage` for `release`. Both are real per-variant decisions, not a
   `debuggable`/`#if DEBUG` gate compiled into every variant, and neither quietly depends on
-  a custom build-type/configuration name being spelled `debug`/`Debug`. A release pipeline
-  that wants Cordierite anyway (an agent-driven, release-signed internal build) sets
-  `CORDIERITE_ENABLED=1`; one that wants it gone even from debug sets `CORDIERITE_ENABLED=0`.
+  a custom build-type/configuration name being spelled `debug`/`Debug`.
+
+  A release pipeline that wants Cordierite anyway (an agent-driven, release-signed internal
+  build) sets `CORDIERITE_ENABLED=1`; one that wants it gone even from debug sets
+  `CORDIERITE_ENABLED=0`.
   [`BUILD-VARIANTS.md`](BUILD-VARIANTS.md#inclusion-is-an-autolinking-decision) has the full
-  mechanism. Verify the outcome against the built artifact (`cordierite doctor`,
-  [`CI.md`](CI.md#release-gate-cordierite-doctor)) — on Android, `doctor` deliberately trusts
+  mechanism.
+
+  Verify the outcome against the built artifact (`cordierite doctor`,
+  [`CI.md`](CI.md#release-gate-cordierite-doctor)). On Android, `doctor` deliberately trusts
   only its `CordieriteNativeMarker` keep-rule signal, since the release-default no-op stub
   shares the real implementation's package name and would otherwise look present to a naive
   scan. When the module genuinely isn't present, the JS public API degrades to the exact

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,8 +1,14 @@
 # Security model
 
-One page: what pinning defends against, what it doesn't, how to handle keys, and what
-production deployments should turn on. See `docs/PROTOCOL.md` for wire-level detail and
-`docs/ARCHITECTURE.md` §12 for the policy/audit implementation.
+One page: what pinning defends against, what it doesn't, how to configure trust, how to
+handle keys, and what production deployments should turn on. See
+[`PROTOCOL.md`](PROTOCOL.md) for wire-level detail,
+[`ARCHITECTURE.md`](ARCHITECTURE.md#12-policy--audit) for the policy/audit implementation,
+and [`BUILD-VARIANTS.md`](BUILD-VARIANTS.md) for whether Cordierite's code ships in a given
+build at all.
+
+**In one line:** TLS is required for the Cordierite socket, and pins are SHA-256 over SPKI
+(`sha256/...`), so only *your* host keys match.
 
 ## Threat model
 
@@ -109,9 +115,163 @@ torn down, so a malformed or expired link costs the existing session nothing.
 configuration alone. Set `cliPins` (which makes `trust: "pin"` the default) on any build you
 don't want accepting a link-carried pin. Separately, if you don't want Cordierite's native
 code present in a build at all — regardless of trust mode — exclude it from autolinking (see
-"Compile out of a build you don't want carrying Cordierite at all" below); `cordierite doctor` (`docs/CI.md`) verifies that
-exclusion actually took effect in a built artifact, rather than trusting the config that was
-supposed to produce it.
+[Compile out of a build you don't want carrying Cordierite at all](#production-guidance)
+below and [`BUILD-VARIANTS.md`](BUILD-VARIANTS.md)); `cordierite doctor`
+([`CI.md`](CI.md#release-gate-cordierite-doctor)) verifies that exclusion actually took
+effect in a built artifact, rather than trusting the config that was supposed to produce
+it.
+
+## Configuring trust
+
+Nothing here is required for a zero-config app: with no pins configured, `trust: "link"`
+is the default and the flow above just works — in any build type. Configure the values
+below when you want a build to trust only keys you embedded ahead of time.
+
+Generate the pin with `cordierite keygen`, which prints the exact `sha256/...` fingerprint
+value to use. After changing any of this, run your normal prebuild / rebuild flow so
+native config receives the values.
+
+### Expo
+
+Add the **`@cordierite/react-native`** config plugin to Expo config:
+
+```json
+{
+  "expo": {
+    "scheme": "myapp",
+    "plugins": [
+      [
+        "@cordierite/react-native",
+        {
+          "cliPins": ["sha256/REPLACE_WITH_KEYGEN_OUTPUT"],
+          "trust": "pin",
+          "allowPrivateLanOnly": true,
+          "deepLinkScheme": "myapp"
+        }
+      ]
+    ]
+  }
+}
+```
+
+| Option | Required? | Meaning |
+| --- | --- | --- |
+| `cliPins` | Optional in general; **required** — non-empty, each a `sha256/` + 44-character base64 SPKI pin — whenever `trust: "pin"` is set or implied by `cliPins` being non-empty. The plugin throws naming the offending value. | The pin set this build trusts |
+| `trust` | Optional | `"link"` \| `"pin"`, defaulted as described under [Trust modes](#trust-modes). Any other value is a config-time error |
+| `allowPrivateLanOnly` | Optional, defaults to `true` (fail-closed) | Bootstrap must target a local IPv4 address |
+| `deepLinkScheme` | Optional | Warns at prebuild time if it isn't declared in `expo.scheme` |
+
+Leave `cliPins`/`trust` unset entirely if you're fine with link-per-session trust — it's
+the default, and a plain zero-config setup can skip this whole plugin entry.
+
+### Bare React Native — native keys
+
+Autolink the module and set the equivalent native keys. Field names and semantics mirror
+the Expo plugin (see
+[`app.plugin.js`](../packages/react-native/app.plugin.js)).
+
+iOS `Info.plist`:
+
+| Key | Purpose |
+| --- | ------- |
+| `CordieriteCliPins` | String array of `sha256/...` SPKI pins |
+| `CordieriteTrust` | `"link"` \| `"pin"` — any other value is a hard error at connect time |
+| `CordieriteAllowPrivateLanOnly` | Boolean; if true, bootstrap host must be a local IPv4 address |
+
+Android `<application>` meta-data:
+
+| Name | Purpose |
+| --- | ------- |
+| `com.callstackincubator.cordierite.CLI_PINS` | JSON array string of pin values |
+| `com.callstackincubator.cordierite.TRUST` | `"link"` \| `"pin"` — any other value is a hard error at connect time |
+| `com.callstackincubator.cordierite.ALLOW_PRIVATE_LAN_ONLY` | Boolean meta-data value (a `"true"`/`"false"` String is also accepted); defaults to `true` (fail-closed) when absent |
+
+Wire **deep links** so the OS can open your app with the host's bootstrap URL, and make
+sure the app scheme matches the one `cordierite link` (or the `deepLinkScheme` plugin
+option, or `config.json`) uses to compose that link.
+
+### `allowPrivateLanOnly`
+
+When enabled, bootstrap must target a **local IPv4** address — RFC1918 private ranges or
+`127.0.0.1`. It is a **dev-hardening** switch, not a claim that Cordierite is LAN-only.
+
+There is nothing to configure for this in JS: which addresses a bootstrap link may point
+at is native build config, enforced by native `connect()` and read from the same place by
+the deep-link handler. JS can only ever narrow what native allows, never widen it.
+
+### `trust: "pin"` needs pins
+
+`trust: "pin"` requires non-empty `cliPins` (bare RN: `CordieriteTrust`/`TRUST` set to
+`"pin"` **and** `CordieriteCliPins`/`CLI_PINS` non-empty). A build that only ever trusts
+embedded pins but has none configured would have no way to trust anything, so the plugin
+refuses that combination at config time, and the native readers refuse it again if that
+check is ever bypassed by hand.
+
+### Reading the effective configuration at runtime
+
+**`getCordieriteBuildConfig()`** reports the effective trust configuration a running build
+actually has — `{ trust, hasEmbeddedPins, allowPrivateLanOnly }`. It is read via
+`getConstants()` from the exact same native manifest/plist parse `connect()`'s
+`resolveTrustedPins` uses, never a second parse path, so it can never disagree with what a
+real connect attempt would do.
+
+`trust` reports the *effective* bucket — `"pin"` whenever embedded pins are present, since
+they always win; `"link"` otherwise — not the raw config string. On `./noop` it reports the
+documented absent shape: `{ trust: "absent", hasEmbeddedPins: false, allowPrivateLanOnly: true }`.
+Pin fingerprints themselves are never exposed, only whether any are embedded.
+
+## What a build without the native module does
+
+With the native module absent — excluded via autolinking, Expo Go, or a
+debug-tooling-free JS-only environment — every exported function on the root
+`@cordierite/react-native` entry degrades to the exact `./noop` entry's behavior: one
+warning log the first time, no throws, `getCordieriteState()` reporting `"idle"`, and
+`connect()` always rejecting with `CordieriteDisabledError` (`code: "cordierite_disabled"`).
+
+See [`ARCHITECTURE.md`](ARCHITECTURE.md#11-react-native-sdk) §11 for the parity contract
+between the two entries, and [`BUILD-VARIANTS.md`](BUILD-VARIANTS.md) for how to produce
+such a build deliberately.
+
+## Gating a tool by build variant
+
+Registration is the app-side allowlist, and it is the only control that sits inside the
+app's own trust boundary. `useCordieriteTool` takes a third `options` argument,
+`{ enabled?: boolean }` (default `true`).
+
+`enabled: false` never registers the tool, and removing it (or a hook that was already
+mounted) leaves no registration behind. Toggling `enabled` at runtime registers and
+unregisters cleanly — so put the condition in the argument instead of wrapping the hook
+call in an `if`, which is a rules-of-hooks violation:
+
+```ts
+useCordieriteTool(
+  {
+    name: "wipe-local-db",
+    description: "Destructive: clears the local database",
+    handler: async () => wipeLocalDb(),
+  },
+  [],
+  { enabled: process.env.EXPO_PUBLIC_CORDIERITE_TOOLS === "full" }
+);
+```
+
+The recommended predicate is an app-owned build flag inlined by the bundler at build time
+(`EXPO_PUBLIC_*` env vars, a Babel define plugin, etc.) — something your release pipeline
+controls explicitly, like `process.env.EXPO_PUBLIC_CORDIERITE_TOOLS === "full"` above.
+
+**`__DEV__` is the wrong default here**, for the same reason a `debuggable` build-type
+check is the wrong native gate: `__DEV__` is `false` in *any* release-bundled JS, including
+the release-signed, internally-distributed "testing" variant agents actually drive in CI.
+Gating a destructive tool on `__DEV__` removes it exactly where it is needed.
+
+`__DEV__` is still fine for tools that are genuinely debug-only — a "dump internal state"
+tool with no purpose outside a local dev loop, say. It just should not be the example every
+app copies for hardening.
+
+**Consequence for agents and E2E flows:** because registration is the app-side allowlist,
+`tools/list` legitimately differs per build artifact. A CI testing build may expose a
+different tool set than a local dev build or a hardened production build. Automated flows
+should discover tools via `tools/list` rather than assume a fixed set is always present.
 
 ## Key handling rules
 
@@ -166,7 +326,7 @@ audited by its own audit log; policy/audit shape what a *legitimate* CLI/MCP cal
 to an *honest* daemon can do, they do not defend the app against the operator machine
 itself. The control that actually sits inside the app, on the app's side of the trust
 boundary, is **which tools the app registers at all** — `useCordieriteTool`'s `enabled`
-option (see the package README's "Gating a tool by build variant") lets an app conditionally
+option (see [Gating a tool by build variant](#gating-a-tool-by-build-variant)) lets an app conditionally
 withhold a destructive tool's registration based on its own release-pipeline-controlled
 build flag, independent of whatever the operator machine's daemon policy says. Treat policy
 and audit below as convenience for a trusted operator working across many tools/sessions,
@@ -209,64 +369,38 @@ not as the mechanism that keeps a destructive tool out of reach of a hostile one
   there's no flag to disable it. Check `daemon.status`'s `audit.failedWrites` if you
   need to confirm the log is actually landing on disk (e.g. under a read-only or full
   filesystem).
-- **Inclusion defaults to dev builds only — not a compiled-in build-type check.** On iOS,
-  `react-native.config.js` sets CocoaPods' `:configurations` so the `Debug` configuration
-  links Cordierite and `Release` doesn't, by default: a real per-variant linking decision.
-  Android can't use the equivalent `buildTypes` lever for a package with static Java
-  registration (`packageInstance`) — the Gradle plugin's generated `PackageList.java` is
-  shared, unfiltered, across every variant, so restricting *linking* by variant there is a
-  compile error, not an inert build. Android instead links this project into every variant
-  unconditionally and swaps which Kotlin source set `android/build.gradle` compiles for
-  `release`: the real implementation by default for `debug`, and either the same real files
-  or a no-op `CordieritePackage` for `release`, driven by the same `CORDIERITE_ENABLED`.
-  Either way there is still no `debuggable`/`#if DEBUG` gate anywhere in
-  `CordieritePackage.getModule` (Android) or `CordieriteTurboBridge.swift`/
-  `RCTNativeCordierite.mm` (iOS) — both register/compile in unconditionally whenever the real
-  implementation is linked/compiled into a given variant; whether it is is what the
-  CocoaPods/Gradle config above decides. A release pipeline that wants Cordierite anyway (an
-  agent-driven, release-signed internal build, for example) sets `CORDIERITE_ENABLED=1`; one
-  that wants it gone even from debug sets `CORDIERITE_ENABLED=0`. Either way this is something
-  you can verify against the built artifact (`cordierite doctor`, `docs/CI.md`) — on Android,
-  `doctor` deliberately trusts only its `CordieriteNativeMarker` keep-rule signal for this
-  reason, since the release-default no-op stub shares the real implementation's package name
-  and would otherwise look present to a naive scan. Not something that quietly depends on a
-  custom build-type/configuration name being spelled `debug`/`Debug`. When the module
-  genuinely isn't present (excluded, or no native support at all — e.g. Expo Go), the JS
-  public API degrades to the exact `./noop` entry's behavior (one warning, no throws) — see
-  `docs/ARCHITECTURE.md` §11.
+- **Inclusion defaults to dev builds only — not a compiled-in build-type check.** iOS
+  restricts CocoaPods linking to the `Debug` configuration; Android swaps in a no-op
+  `CordieritePackage` for `release`. Both are real per-variant decisions, not a
+  `debuggable`/`#if DEBUG` gate compiled into every variant, and neither quietly depends on
+  a custom build-type/configuration name being spelled `debug`/`Debug`. A release pipeline
+  that wants Cordierite anyway (an agent-driven, release-signed internal build) sets
+  `CORDIERITE_ENABLED=1`; one that wants it gone even from debug sets `CORDIERITE_ENABLED=0`.
+  [`BUILD-VARIANTS.md`](BUILD-VARIANTS.md#inclusion-is-an-autolinking-decision) has the full
+  mechanism. Verify the outcome against the built artifact (`cordierite doctor`,
+  [`CI.md`](CI.md#release-gate-cordierite-doctor)) — on Android, `doctor` deliberately trusts
+  only its `CordieriteNativeMarker` keep-rule signal, since the release-default no-op stub
+  shares the real implementation's package name and would otherwise look present to a naive
+  scan. When the module genuinely isn't present, the JS public API degrades to the exact
+  `./noop` entry's behavior — see [What a build without the native module
+  does](#what-a-build-without-the-native-module-does).
 - **Compile out of a build you don't want carrying Cordierite at all.** Being present and
   trusting nothing (`trust: "pin"` with a `cliPins` set that has no matching daemon, or an
   app that simply never mints a bootstrap link for that build) still ships the native code
-  and JS bundle inside the binary. To strip it out entirely, combine two independent
-  steps — neither one alone removes native code:
-  1. **Native:** exclude `@cordierite/react-native` from autolinking. This is what
-     actually removes the compiled native pod/module from the app binary. Bare RN:
-     app-root `react-native.config.js`, `dependencies["@cordierite/react-native"].platforms
-     = { ios: null, android: null }`. Expo-managed equivalent: `expo.autolinking.ios.exclude`
-     / `expo.autolinking.android.exclude` — but this must live in **`package.json`**, not
-     `app.json` or `app.config.*`. `expo-modules-autolinking` reads this config from
-     `package.json` only; the same block anywhere else is a silent no-op that still ships
-     the native module. Note also that `expo-modules-autolinking`'s CocoaPods driver
-     resolves iOS with `--platform apple`, and an `expo.autolinking.apple` block, if
-     present, wins outright over `expo.autolinking.ios` rather than merging with it — put
-     the exclude under `apple` too if your app declares that key. Excluding on iOS also
-     stops that package's codegen from running, so an app that excludes it there but still
-     references the `Cordierite` pod by hand (a maintainer-only shape, e.g. attaching an
-     XCTest target) will fail to compile.
-  2. **JS:** swap the module at bundle time with a Metro `resolveRequest` override that
-     resolves `@cordierite/react-native` (and `/auto`) to `@cordierite/react-native/noop`
-     instead. This removes the deep-link listener and tool registry from the JS bundle.
+  and JS bundle inside the binary. Stripping it takes two independent steps — exclude the
+  package from **autolinking** (the only thing that removes the compiled native
+  pod/module) and swap the **JS** entries for `/noop` at bundle time (the only thing that
+  removes the deep-link listener and tool registry from the bundle). Neither alone removes
+  both; `CORDIERITE_ENABLED=0` drives both at once.
 
-  See the package README's "Compiling Cordierite out of production builds" section for
-  the exact snippets, and `docs/CI.md` for `cordierite doctor`, which verifies the
+  The exact snippets, the `package.json`-only placement of `expo.autolinking`, the
+  `apple`-overrides-`ios` rule and the iOS codegen coupling live in
+  [`BUILD-VARIANTS.md`](BUILD-VARIANTS.md#compiling-cordierite-out-of-production-builds).
+  [`CI.md`](CI.md#release-gate-cordierite-doctor)'s `cordierite doctor` verifies the
   exclusion actually took effect in a built artifact rather than trusting the config that
   was supposed to produce it — this whole area was a config recipe that never worked once
-  before (see `docs/tasks/02-fix-autolinking-exclusion.md`), which is why it's now checked
-  by CI, not just documented. Either half alone still yields a working, inert-with-respect-
-  to-that-half app — the autolinking exclude alone leaves the real JS entry importable but
-  with no native module to find (so it degrades to `/noop`-equivalent behavior); the Metro
-  swap alone leaves the native pod compiled in but unused. Combine both when you want
-  neither surface present at all.
+  before (see [`tasks/02-fix-autolinking-exclusion.md`](tasks/02-fix-autolinking-exclusion.md)),
+  which is why it's now checked by CI, not just documented.
 - **App-store-review note.** An always-installed deep-link listener that can open a
   pinned socket and let an external process invoke code is a legitimate "remote control"
   surface from a reviewer's point of view, even though it can't be exercised without a

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
+    "check:links": "node scripts/check-md-links.mjs",
     "clean": "turbo run clean",
     "lint": "turbo run lint",
     "test": "turbo run test",

--- a/packages/cordierite/README.md
+++ b/packages/cordierite/README.md
@@ -17,8 +17,10 @@ The **`cordierite`** package is the operator/agent side of Cordierite: a long-li
 
 ```bash
 npm install cordierite
-cordierite link --qr
+cordierite link --scheme myapp --qr
 ```
+
+`link` needs your app's deep-link scheme: pass `--scheme` (the app's `expo.scheme`, or its bare-RN equivalent), or set `"scheme"` once in `~/.cordierite/config.json` and omit the flag. Without either, the command exits with a usage error.
 
 Scan the QR (or open the deep link) in a Cordierite-enabled app, then:
 

--- a/packages/cordierite/README.md
+++ b/packages/cordierite/README.md
@@ -16,7 +16,7 @@ The **`cordierite`** package is the operator/agent side of Cordierite: a long-li
 ## Getting started
 
 ```bash
-npm install cordierite
+npm install -g cordierite
 cordierite link --scheme myapp --qr
 ```
 
@@ -118,7 +118,7 @@ const { events, cursor } = await app.events();               // pull: what alrea
 const next = await app.waitForEvent("checkout_done", { since: cursor });
 ```
 
-For everything else, the package exports `runCli` and the command handlers from [`src/index.ts`](src/index.ts), so you can embed the same behavior in Node or Bun scripts without shelling out.
+For everything else, the package exports `runCli` and the command handlers from [`src/index.ts`](https://github.com/callstackincubator/cordierite/blob/main/packages/cordierite/src/index.ts), so you can embed the same behavior in Node or Bun scripts without shelling out.
 
 ## Keys and pins
 
@@ -153,8 +153,8 @@ Exit codes, what it inspects per platform, the Android marker-only detection rul
 
 ## Related packages
 
-- **[@cordierite/react-native](../react-native/README.md)** — native app client + Expo plugin.
-- **[@cordierite/shared](../shared/README.md)** — wire protocol v2 types used by this package and the React Native client.
+- **[@cordierite/react-native](https://github.com/callstackincubator/cordierite/blob/main/packages/react-native/README.md)** — native app client + Expo plugin.
+- **[@cordierite/shared](https://github.com/callstackincubator/cordierite/blob/main/packages/shared/README.md)** — wire protocol v2 types used by this package and the React Native client.
 
 ## Documentation
 
@@ -163,7 +163,7 @@ Exit codes, what it inspects per platform, the Android marker-only detection rul
 - [Security model & key rotation][security]
 - [Build variants][build-variants]
 - [CI and the release gate][ci]
-- [Monorepo README](../../README.md)
+- [Monorepo README](https://github.com/callstackincubator/cordierite/blob/main/README.md)
 
 ## Made with ❤️ at Callstack
 

--- a/packages/cordierite/README.md
+++ b/packages/cordierite/README.md
@@ -4,26 +4,30 @@
 
 [![MIT license][license-badge]][license] [![npm downloads][npm-downloads-badge]][npm-downloads] [![PRs Welcome][prs-welcome-badge]][prs-welcome]
 
-The **`cordierite`** package is the operator/agent side of Cordierite: a long-lived **daemon** that owns a TLS-terminated `wss://` listener and any number of device sessions, a **CLI** and an **MCP server** that are both thin RPC clients of that daemon, and the **key management** that ties it all together — so **developers, QA, and agents** can steer app state from a terminal or an MCP-speaking client **instead of a hidden in-app debug menu**.
+The **`cordierite`** package is the operator/agent side of Cordierite: a long-lived **daemon** owning a TLS-terminated `wss://` listener and any number of device sessions, a **CLI** and an **MCP server** that are thin RPC clients of it, and the **key management** tying it together — so **developers, QA, and agents** steer app state from a terminal or an MCP client **instead of a hidden debug menu**.
 
 ## Why use this package
 
-- **One daemon, many devices**: `cordierite` auto-spawns its daemon on first use; it serves every connected device on one `wss://` port and survives Metro reloads, backgrounding, and network flaps by suspending and resuming sessions instead of dying with them.
-- **Same surface for humans and agents**: the CLI (`tools`, `invoke`, `events`, ...) and `cordierite mcp` both talk to the daemon over the same RPC methods — an agent sees the same tools a human operator does.
-- **Hardened control plane**: the CLI/MCP never touch sockets, keys, or state files directly; everything goes through a Unix-domain-socket RPC surface gated by filesystem permissions (see [docs/SECURITY.md][security]).
-- **Fits production-minded apps**: the app still only exposes what you register; trust boundaries are pins + TLS, and production deployments can gate tools with policy and get every call audited (see [docs/ARCHITECTURE.md][architecture] §12).
+- **One daemon, many devices**: it auto-spawns on first use, serves every device on one `wss://` port, and survives Metro reloads, backgrounding, and network flaps by suspending and resuming sessions rather than dying with them.
+- **Same surface for humans and agents**: the CLI (`tools`, `invoke`, `events`, ...) and `cordierite mcp` use the same RPC methods — an agent sees the tools a human operator does.
+- **Hardened control plane**: the CLI/MCP never touch sockets, keys, or state files directly; everything goes through a Unix-domain-socket RPC surface gated by filesystem permissions ([docs/SECURITY.md][security]).
+- **Fits production-minded apps**: the app only exposes what you register; trust boundaries are pins + TLS, and production deployments can gate tools with policy and audit every call ([docs/ARCHITECTURE.md][architecture] §12).
 
-## Key setup
-
-For a **debug build** app, you can skip this entirely: the daemon auto-generates its own `key.pem` the first time it starts if one isn't already there (mode `0600`), and prints its `sha256/...` fingerprint on that first run. `cordierite link` (below) carries that fingerprint on the deep link itself for the app to pick up — see the app-side dev-mode flow in the root README and `docs/SECURITY.md`'s "Dev trust mode" section.
-
-For a **release build** (or any build where you want a real embedded pin instead of trusting whatever link shows up), generate a daemon key explicitly with:
+## Getting started
 
 ```bash
-cordierite keygen
+npm install cordierite
+cordierite link --qr
 ```
 
-The command writes an unencrypted PEM private key (PKCS#8) to `<state-dir>/key.pem` by default (override with `--out`; add `--force` to overwrite) and prints the exact `sha256/...` SPKI fingerprint your app should place into `cliPins`. It runs non-interactively — safe to call from CI or a setup script.
+Scan the QR (or open the deep link) in a Cordierite-enabled app, then:
+
+```bash
+cordierite tools
+cordierite invoke sum --input '{"a":2,"b":3}'
+```
+
+That is the whole loop. There is no host process to start: `cordierite` auto-spawns its daemon the first time any command needs it.
 
 ## Commands
 
@@ -42,12 +46,6 @@ The command writes an unencrypted PEM private key (PKCS#8) to `<state-dir>/key.p
 
 Every command that targets a session accepts an optional `selector` (a session id or an alias from `cordierite ls`); omit it when exactly one session is active. Global flags: `--json` (machine-readable output), `--no-color`, `--state-dir <path>` (default `~/.cordierite`). Run `cordierite <command> --help` for the exact flags of any command, or `cordierite --help` for the full list.
 
-`cordierite link`'s deep link is `<scheme>:///?cordierite=<payload>&pin=<sha256/...>`: the `cordierite` param is the existing binary v2 bootstrap payload (address, session id, token, expiry — unchanged), and `pin` is a separate, out-of-band query param carrying the daemon's current SPKI fingerprint for apps that want to pick it up. An app build with embedded `cliPins` ignores `pin` outright — embedded pins always win. A debug build with no embedded pins trusts it for that session only (see `docs/SECURITY.md`'s "Dev trust mode" section); a release build with the module enabled never accepts it, embedded pins only.
-
-## Daemon lifecycle
-
-The daemon auto-starts the first time any CLI or MCP command needs it — you don't normally run `cordierite daemon start` yourself. It writes its state to `<state-dir>/` (`daemon.sock`, `daemon.pid`, `daemon.log`, `key.pem`, `config.json`, `audit/`), holds a single-instance lock via the pidfile, and keeps running independently of any one device's connection so a reload or crash on the device side never costs you the daemon process. Use `cordierite daemon status` to see what's running (version, pid, `wssPort`, pinned keys, live sessions, effective policy) and `cordierite daemon stop` to shut it down explicitly.
-
 ## MCP setup (Claude Code, Cursor, and similar)
 
 Add `cordierite mcp` to the agent's MCP server config — no separate server process to manage; it auto-spawns the daemon the same way the CLI does:
@@ -63,54 +61,15 @@ Add `cordierite mcp` to the agent's MCP server config — no separate server pro
 }
 ```
 
-Once configured, the connected app's tools appear as MCP tools automatically: `tools/list` mirrors the live registry (namespaced `<alias>__<name>` when more than one session is active), and `tools/call` proxies straight to the app with progress and errors preserved. Two built-in management tools let an agent bootstrap a session without shell access: `cordierite_connect` mints a link and, by default, delivers it to whichever `android`/`ios-sim` device it detects (pass `target`/`device` to choose, or `target: "none"` to force the human flow) — falling back to a QR code, plus instructions to show it, only when there is nothing to deliver to; and `cordierite_wait_for_session` waits for that session to be claimed. Two more built-in tools give an agent a pull surface over `postEvent()`-pushed app events: `cordierite_events` drains everything retained since a cursor, and `cordierite_wait_for_event` blocks for a matching event (checking what's already retained before waiting live), rejecting with `tool_timeout` if none arrives in time.
+Once configured, the connected app's tools appear as MCP tools automatically: `tools/list` mirrors the live registry (namespaced `<alias>__<name>` when more than one session is active), and `tools/call` proxies straight to the app with progress and errors preserved.
 
-## Release gate: `cordierite doctor`
+Four built-in tools cover what an agent can't do through the app's own registry. `cordierite_connect` mints a link and, by default, delivers it to whichever `android`/`ios-sim` device it detects — pass `target`/`device` to choose, or `target: "none"` to force the human flow — falling back to a QR code, plus instructions to show it, only when there is nothing to deliver to. `cordierite_wait_for_session` then waits for that session to be claimed.
 
-Cordierite's inclusion in a build is controlled entirely by autolinking exclusion (see the root README and `docs/SECURITY.md`) — there is no runtime `debuggable` check to catch a pipeline that forgot to exclude the package. `cordierite doctor` is the replacement: an artifact-level assertion you run against the thing you're about to ship, not the config you think produced it.
+The other two give an agent a pull surface over `postEvent()`-pushed app events: `cordierite_events` drains everything retained since a cursor, and `cordierite_wait_for_event` blocks for a matching event (checking what's already retained before waiting live), rejecting with `tool_timeout` if none arrives in time.
 
-```bash
-cordierite doctor ./build/MyApp.ipa --assert-absent
-cordierite doctor ./build/app-release.apk --assert-absent
-```
+## Test runners: `cordierite/client`
 
-It inspects a built `.app`/`.ipa`/`.apk`/`.aab` for Cordierite's native code (the `RCTNativeCordierite` Objective-C class and the plugin-authored `Info.plist` keys on iOS; the `com.callstackincubator.cordierite` dex package and `AndroidManifest.xml` meta-data keys on Android) and reports `present`/`absent` — or, with `--assert-present`/`--assert-absent`, exits non-zero when the artifact doesn't match what you expected:
-
-| Exit code | Meaning |
-| --- | --- |
-| `0` | inspection succeeded; no assertion was given, or the assertion held |
-| `3` | inspection succeeded, but `--assert-present`/`--assert-absent` did not hold |
-| `64` | usage error (bad flags, or an artifact extension that isn't `.app`/`.ipa`/`.apk`/`.aab`) |
-| `66` | the artifact could not be inspected — a required external tool (`unzip`) was missing, or the artifact was unreadable/corrupt. **Never treated as "absent"**: a broken check must fail loudly, not rubber-stamp a release. |
-
-CI snippet, run against your production release build right before you ship it:
-
-```yaml
-- name: Assert Cordierite is excluded from the production build
-  run: npx cordierite doctor ./build/app-release.apk --assert-absent
-- name: Assert Cordierite is excluded from the production build (iOS)
-  run: npx cordierite doctor ./build/MyApp.ipa --assert-absent
-```
-
-For an internally-distributed "testing" build that an agent drives, invert the assertion (`--assert-present`) so a forgotten inclusion — not just a forgotten exclusion — fails CI too.
-
-**Android detection** has three signals, in order of reliability:
-
-1. `CordieriteNativeMarker`, kept unminified by the keep rule `@cordierite/react-native` ships via `consumerProguardFiles`. It reaches every consuming app's R8 run without the app authoring any rule, so it holds for bare-RN apps that never touch the Expo config plugin.
-2. The dex package name — survives ordinary minification but not R8 full mode's repackaging.
-3. The config plugin's `AndroidManifest.xml` meta-data keys — only present if the plugin ran.
-
-Signals 2 and 3 are retained as fallbacks for artifacts built before the marker existed.
-
-**Verified** against a real R8-minified release APK (`assembleRelease -Pandroid.enableMinifyInReleaseBuilds=true`): the R8 mapping shows sibling classes obfuscated (`CordieriteBuildConfig -> …cordierite.a`) while `CordieriteNativeMarker` keeps its fully-qualified name, and `doctor --assert-present` passes on that artifact.
-
-**Still not covered:** R8 *full mode* with `-repackageclasses` was not exercised, and no artifact was tested from a bare-RN app that uses neither Expo nor the config plugin — the configuration the marker most directly targets. The marker should hold in both (a `-keep` rule prevents renaming and removal regardless of mode), but that is reasoning, not a measurement.
-
-## Programmatic use
-
-### Test runners: `cordierite/client`
-
-A thin typed wrapper over the same daemon RPC the CLI and MCP server use — for a Jest/Vitest/Detox spec that wants to drive a running app without spawning `cordierite invoke ... --json` and parsing stdout:
+A thin typed wrapper over the same daemon RPC the CLI and MCP server use — for a Jest/Vitest/Detox spec that drives a running app without spawning `cordierite invoke ... --json` and parsing stdout:
 
 ```ts
 import { connect } from "cordierite/client";
@@ -139,7 +98,7 @@ const { sessionId } = await link({ target: "ios-sim" });
 const app = await waitForSession(sessionId, { timeoutMs: 60_000 });
 ```
 
-`app.call`'s tool name and args/result types can't be inferred automatically (tools are registered by the connected app at runtime) — declare your own tool map once for typed calls throughout a suite:
+`app.call`'s tool name and args/result types can't be inferred automatically — tools are registered by the connected app at runtime — so declare your own tool map once for typed calls throughout a suite:
 
 ```ts
 type Tools = {
@@ -150,16 +109,45 @@ const app = await connect<Tools>();
 const { total } = await app.call("sum", { a: 2, b: 3 }); // typed
 ```
 
-`waitForEvent` first drains the daemon's per-session retained buffer for an already-arrived match before falling back to a live wait, so it's safe to call after the action that emits the event too — no need to call it first. Pass `since` (the `cursor` from a previous `app.events()`/`waitForEvent()` call) to skip events already handled and wait only for a new one:
+`waitForEvent` first drains the daemon's per-session retained buffer for an already-arrived match before falling back to a live wait, so it's safe to call after the action that emits the event. Pass `since` (the `cursor` from a previous `app.events()`/`waitForEvent()` call) to skip events already handled:
 
 ```ts
 const { events, cursor } = await app.events();               // pull: what already happened
 const next = await app.waitForEvent("checkout_done", { since: cursor });
 ```
 
-### Everything else: `runCli`
+For everything else, the package exports `runCli` and the command handlers from [`src/index.ts`](src/index.ts), so you can embed the same behavior in Node or Bun scripts without shelling out.
 
-The package also exports `runCli` and command handlers from [`src/index.ts`](src/index.ts) so you can embed the same behavior in Node or Bun scripts that need to drive Cordierite without shelling out.
+## Keys and pins
+
+You can skip this entirely while your app has no `cliPins` configured — the zero-config default, in **any** build type. The daemon auto-generates its own `key.pem` the first time it starts if one isn't already there (mode `0600`) and prints its `sha256/...` fingerprint on that first run; `cordierite link` carries that fingerprint on the deep link for the app to pick up. See [`docs/SECURITY.md`][security]'s "Trust modes" for what that does and does not protect.
+
+For a build that should trust only a key you embedded ahead of time, generate one explicitly:
+
+```bash
+cordierite keygen
+```
+
+The command writes an unencrypted PEM private key (PKCS#8) to `<state-dir>/key.pem` by default (override with `--out`; add `--force` to overwrite) and prints the exact `sha256/...` SPKI fingerprint your app should place into `cliPins`. It runs non-interactively — safe to call from CI or a setup script.
+
+`cordierite link`'s deep link is `<scheme>:///?cordierite=<payload>&pin=<sha256/...>`. The `cordierite` param is the existing binary v2 bootstrap payload (address, session id, token, expiry — unchanged); `pin` is a separate, out-of-band query param carrying the daemon's current SPKI fingerprint for apps that want to pick it up. An app build with embedded `cliPins` ignores `pin` outright — embedded pins always win, in every build type. A build with no embedded pins trusts it for that one session.
+
+## Daemon lifecycle
+
+The daemon auto-starts the first time any CLI or MCP command needs it — you don't normally run `cordierite daemon start` yourself. It writes state to `<state-dir>/` (`daemon.sock`, `daemon.pid`, `daemon.log`, `key.pem`, `config.json`, `audit/`), holds a single-instance lock via the pidfile, and runs independently of any one device's connection, so a reload or crash on the device side never costs you the daemon process.
+
+Use `cordierite daemon status` to see what's running (version, pid, `wssPort`, pinned keys, live sessions, effective policy) and `cordierite daemon stop` to shut it down explicitly.
+
+## Release gate: `cordierite doctor`
+
+Cordierite's inclusion in a build is controlled entirely by autolinking exclusion (see [docs/BUILD-VARIANTS.md][build-variants]) — there is no runtime `debuggable` check to catch a pipeline that forgot to exclude the package. `doctor` is the replacement: an artifact-level assertion you run against the thing you're about to ship, not the config you think produced it.
+
+```bash
+cordierite doctor ./build/MyApp.ipa --assert-absent
+cordierite doctor ./build/app-release.apk --assert-absent
+```
+
+Exit codes, what it inspects per platform, the Android marker-only detection rules and the CI wiring are in [docs/CI.md][ci].
 
 ## Related packages
 
@@ -171,6 +159,8 @@ The package also exports `runCli` and command handlers from [`src/index.ts`](src
 - [Architecture][architecture]
 - [Wire protocol][protocol]
 - [Security model & key rotation][security]
+- [Build variants][build-variants]
+- [CI and the release gate][ci]
 - [Monorepo README](../../README.md)
 
 ## Made with ❤️ at Callstack
@@ -185,11 +175,13 @@ Like the project? ⚛️ [Join the team](https://callstack.com/careers/?utm_camp
 [architecture]: https://github.com/callstackincubator/cordierite/blob/main/docs/ARCHITECTURE.md
 [protocol]: https://github.com/callstackincubator/cordierite/blob/main/docs/PROTOCOL.md
 [security]: https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md
+[build-variants]: https://github.com/callstackincubator/cordierite/blob/main/docs/BUILD-VARIANTS.md
+[ci]: https://github.com/callstackincubator/cordierite/blob/main/docs/CI.md
 [license-badge]: https://img.shields.io/npm/l/cordierite?style=for-the-badge
 [license]: https://github.com/callstackincubator/cordierite/blob/main/LICENSE
 [npm-downloads-badge]: https://img.shields.io/npm/dm/cordierite?style=for-the-badge
 [npm-downloads]: https://www.npmjs.com/package/cordierite
 [prs-welcome-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=for-the-badge
-[prs-welcome]: https://github.com/callstackincubator/cordierite/blob/main/CONTRIBUTING.md
+[prs-welcome]: https://github.com/callstackincubator/cordierite/pulls
 [chat-badge]: https://img.shields.io/discord/426714625279524876.svg?style=for-the-badge
 [chat]: https://discord.gg/xgGt7KAjxv

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -4,114 +4,46 @@
 
 [![MIT license][license-badge]][license] [![npm downloads][npm-downloads-badge]][npm-downloads] [![PRs Welcome][prs-welcome-badge]][prs-welcome]
 
-This package is the **native client** for Cordierite. Your app **registers tools** in JavaScript; **developers, testers, and agents** invoke them from a **CLI or host** after the app opens a bootstrap link and completes a **pinned `wss://`** handshake. You get **production-grade transport** (TLS + SPKI) instead of burying **debug-only screens** in the UI to flip state or trigger flows.
+This package is the **native client** for Cordierite. Your app **registers tools** in JavaScript; **developers, testers, and agents** invoke them from a **CLI or host** once the app opens a bootstrap link and completes a **pinned `wss://`** handshake — **production-grade transport** (TLS + SPKI) instead of **debug-only screens** buried in the UI.
 
 ## Why use it
 
 - **No in-app debug chrome**: influence screens, flags, fixtures, and flows from the **host**, not from hidden menus shipped to users.
 - **Same path for people and automation**: CLI for devs/QA, agents for scripted or LLM-driven control—both use **tool calls** after session claim.
-- **Production-capable**: ship the client in real builds when your pins and operational model say it is acceptable; connectivity still requires a **trusted host**, not public anonymous access.
-
-## Security highlights
-
-- **TLS required** for the Cordierite socket; pins are **SHA-256 over SPKI** (`sha256/...`) so only **your** host keys match.
-- **Optional `allowPrivateLanOnly`**: when enabled, bootstrap must target a **local IPv4** address (RFC1918 private ranges or `127.0.0.1`)—a **dev-hardening** switch, not a claim that Cordierite is LAN-only.
+- **Production-capable**: ship it in real builds when your pins and operational model allow; connecting still requires a **trusted host**, not anonymous public access.
 
 ## Getting started
 
 > [!NOTE]
 > Use a **development build** or bare native app. **Expo Go** is not enough—this library ships native code and pinning configuration.
 
-### 1. Install the package
+### 1. Install
 
-Install the app-side package and a schema library for tool definitions:
+The app-side package plus a schema library:
 
 ```bash
 npm install @cordierite/react-native zod
 ```
 
-Install the CLI separately on the machine that will run the host:
+The CLI, on the machine running the host:
 
 ```bash
 npm install cordierite
 ```
 
-### 2. With no pins configured, that's it for keys and pins
+### 2. Nothing to configure yet
 
-**No key, no pins, and no config plugin needed at all — in any build type.** The daemon auto-generates its own `key.pem` the first time it starts (printing its `sha256/...` fingerprint), and `cordierite link` composes that fingerprint into the deep link as a separate `pin` query param. Whenever no build-time `cliPins`/`CLI_PINS` are configured, the effective `trust` mode is `"link"` by default: the native client trusts that link-carried pin for the session it arrived with, logging unconditionally: `Cordierite: trust=link — trusting the SPKI pin carried by the bootstrap link for this session.` This is no longer tied to whether the build is debuggable — only to whether pins are configured. The moment `cliPins` is configured, that embedded set always wins regardless of `trust`, and the link's `pin` is ignored — see [`docs/SECURITY.md`](../../docs/SECURITY.md)'s "Trust modes" section for the full writeup.
+**No key, no pins, and no config plugin are needed — in any build type.** The daemon auto-generates a key on first start, and `cordierite link` carries its `sha256/...` fingerprint on the deep link for the app to trust for that session.
 
-Skip straight to step 3 (scheme) and step 4 (import) if that's all you need. The rest of this section is for **production and internal-distribution builds that want pinned trust** — debug builds ship Cordierite by default regardless, so this is about tightening what it trusts once it's there (and, separately, about controlling *whether* it ships at all in a given build variant — see "Compiling Cordierite out of production builds" below).
+Wire your deep-link scheme so the OS can open the app with that link, and you are done. To make a build trust only pins you embedded ahead of time, see [Configuring trust](../../docs/SECURITY.md#configuring-trust).
 
-### 3. Configure native pinning and app scheme
-
-#### Expo
-
-Add the **`@cordierite/react-native`** config plugin to Expo config. `cliPins` is optional (omit it and the link-trust flow above applies), but required — non-empty, each a `sha256/` + 44-character base64 SPKI pin, or the plugin throws naming the offending value — whenever `trust: "pin"` is set (or implied by `cliPins` being non-empty). Also optional: `trust` (`"link"` | `"pin"`, defaulted as above — any other value is a config-time error), `allowPrivateLanOnly` (defaults to `true`, fail-closed), and `deepLinkScheme` (warns at prebuild time if it isn't declared in `expo.scheme`):
-
-```json
-{
-  "expo": {
-    "scheme": "myapp",
-    "plugins": [
-      [
-        "@cordierite/react-native",
-        {
-          "cliPins": ["sha256/REPLACE_WITH_KEYGEN_OUTPUT"],
-          "trust": "pin",
-          "allowPrivateLanOnly": true,
-          "deepLinkScheme": "myapp"
-        }
-      ]
-    ]
-  }
-}
-```
-
-Generate the pin with `cordierite keygen`, which prints the exact `sha256/...` fingerprint value to use. Then run your normal prebuild / rebuild flow so native config receives those values.
-
-Leave `cliPins`/`trust` unset entirely if you're fine with link-per-session trust — it's the default, and a plain zero-config setup can skip this whole plugin entry.
-
-#### Bare React Native
-
-Autolink the module and set the equivalent native keys. Field names and semantics mirror the Expo plugin (see [app.plugin.js](app.plugin.js)).
-
-**Bare React Native — native keys**
-
-iOS `Info.plist`:
-
-| Key | Purpose |
-| --- | ------- |
-| `CordieriteCliPins` | String array of `sha256/...` SPKI pins |
-| `CordieriteTrust` | `"link"` \| `"pin"` — any other value is a hard error at connect time |
-| `CordieriteAllowPrivateLanOnly` | Boolean; if true, bootstrap host must be a local IPv4 address |
-
-Android `<application>` meta-data:
-
-| Name | Purpose |
-| --- | ------- |
-| `com.callstackincubator.cordierite.CLI_PINS` | JSON array string of pin values |
-| `com.callstackincubator.cordierite.TRUST` | `"link"` \| `"pin"` — any other value is a hard error at connect time |
-| `com.callstackincubator.cordierite.ALLOW_PRIVATE_LAN_ONLY` | Boolean meta-data value (a `"true"`/`"false"` String is also accepted); defaults to `true` (fail-closed) when absent |
-
-None of the above is required for a zero-config app — see step 2. Wire **deep links** so the OS can open your app with the host's bootstrap URL, and make sure the app scheme matches the one `cordierite link` (or the `deepLinkScheme` plugin option, or `config.json`) uses to compose that link.
-
-### 4. Import Cordierite in the JS entry point
-
-The package has three entries:
-
-| Entry | Behavior |
-| --- | --- |
-| `@cordierite/react-native` | Side-effect-free. Exports `registerTool`, `useCordieriteTool`, `postEvent`, `addCordieriteListener`, `getCordieriteState`, `restoreSession`, `connect`, and types. The native module is looked up **lazily**, on the first actual native call — importing it (even in Expo Go or a misconfigured build) never crashes; only calling a native-requiring function like `connect()` without native support does, with an actionable error. |
-| `@cordierite/react-native/auto` | Same exports, plus a side effect: installs the deep-link bootstrap listener and starts recovery from the native process lease on import. This is the only entry that installs anything. |
-| `@cordierite/react-native/noop` | Same public API, fully inert — for compiling Cordierite out of release builds (see below). |
-
-Most apps just want the deep-link listener installed automatically, so import the side-effect entry once near your app's entry point:
+### 3. Import Cordierite in the JS entry point
 
 ```ts
 import "@cordierite/react-native/auto";
 ```
 
-To control *when* that happens — only in `__DEV__`, behind a QA-build toggle, or after other startup work — `require()` the same entry at that point instead. Metro resolves it lazily, and importing it more than once installs once:
+`/auto` is the only entry that installs anything: the deep-link bootstrap listener plus recovery from the native process lease. To control *when* that happens — in `__DEV__`, behind a QA toggle, after other startup work — `require()` it there instead. Metro resolves it lazily; importing twice installs once:
 
 ```ts
 if (__DEV__) {
@@ -119,31 +51,23 @@ if (__DEV__) {
 }
 ```
 
-There is nothing to configure here: which addresses a bootstrap link may point at is native build config (`allowPrivateLanOnly`, configured through the Expo plugin / `CordieriteAllowPrivateLanOnly` above), enforced by native `connect()` and read from the same place by the deep-link handler.
+The default flow needs no `Linking` handler of your own, and sessions survive Metro reloads and short network flaps — see [ARCHITECTURE.md §11](../../docs/ARCHITECTURE.md#11-react-native-sdk) for lease, resume, and reconnect rules.
 
-If you drive bootstrap entirely yourself (custom deep-link routing, QR scanning, tests) and never import `/auto`, call `restoreSession()` once at startup before your own bootstrap handling — it is then the only thing reading the native resume lease, and without it every Metro reload drops a session the native side could still have resumed:
+If you drive bootstrap yourself and never import `/auto`, call `restoreSession()` first — it is then the only reader of the native resume lease:
 
 ```ts
 import { connect, parseBootstrapUrl, restoreSession } from "@cordierite/react-native";
 
 if (!(await restoreSession())) {
-  await connect(parseBootstrapUrl(url)); // only claim a fresh link if there was nothing to restore
+  await connect(parseBootstrapUrl(url));
 }
 ```
 
-**Bootstrap connection and recovery:** installation registers the runtime URL listener immediately, reads the initial launch URL, and attempts native-lease recovery once. The initial URL waits for recovery: a successful restore suppresses the old launch-link claim, while no lease or an unexpected orchestration failure falls back to the normal initial-link flow. Runtime URLs still parse the v2 bootstrap payload and call `connect` when the client is idle. You do not need your own `Linking` handler for the default flow.
+### 4. Define tools in app startup code
 
-The resume lease is native **process-memory only** and is committed before JS receives each successful claim/resume acknowledgement. That supports Metro reloads and JS runtime replacement with the same alias and no new link, provided the native app process stays alive. It is never persisted to disk; after native process death, open a fresh bootstrap link. The grace window starts when the transport suspends/disconnects, not when the acknowledgement was received. Any flow can trigger the same recovery explicitly with the exported `restoreSession()` (or `cordieriteClient.restoreSession()`).
+Call `registerTool({ ... })` with Standard Schema compatible `inputSchema`/`outputSchema` values and a `handler`. Zod v4 works well here — its built-in JSON Schema exporter means agents see a real tool shape. Zod 3 and plain valibot schemas still register, just with a dev warning and an empty schema.
 
-**Reconnect vs. give up:** socket loss inside the grace window auto-reconnects with jittered backoff (0.5 s → 30 s cap), including transport-level closes such as `1011 send_failed` and `1001 daemon_shutdown` — the daemon may well be back before grace expires. A `1008` close is different: it is how the daemon reports a rejection no retry of the same frame can satisfy (`unknown_session` after a daemon restart, `invalid_resume_token`, an expired or revoked session, a malformed frame). Those end the session immediately with a `sessionChange: lost` carrying the daemon's reason, instead of retrying for the rest of the grace window.
-
-**Errors:** use `addCordieriteListener("error", callback)` for bootstrap-parse, connect, socket, and tool-handler failures — one unified channel.
-
-### 5. Define tools in app startup code
-
-Call `registerTool({ ... })` with Standard Schema compatible `inputSchema` and `outputSchema` values plus a `handler` so the host can invoke your tools after the session is active. `zod` v4 works well here (its built-in JSON Schema exporter means agents see a real tool shape — zod 3 and plain valibot schemas still register, just with a dev warning and an empty schema).
-
-`useCordieriteTool` wraps `registerTool` in a `useEffect` so registration follows the component's lifecycle, including remounts and Fast Refresh:
+`useCordieriteTool` wraps `registerTool` in a `useEffect`, so registration follows the component's lifecycle including remounts and Fast Refresh:
 
 ```ts
 import "@cordierite/react-native/auto";
@@ -155,16 +79,9 @@ export function CordieriteBootstrap() {
     {
       name: "sum",
       description: "Add two numeric values",
-      inputSchema: z.object({
-        a: z.number(),
-        b: z.number(),
-      }),
-      outputSchema: z.object({
-        total: z.number(),
-      }),
-      handler: async ({ a, b }) => ({
-        total: a + b,
-      }),
+      inputSchema: z.object({ a: z.number(), b: z.number() }),
+      outputSchema: z.object({ total: z.number() }),
+      handler: async ({ a, b }) => ({ total: a + b }),
     },
     []
   );
@@ -173,179 +90,63 @@ export function CordieriteBootstrap() {
 }
 ```
 
-Mount that component near app startup, or register from another module that loads on startup. The host can only list and invoke tools that your app has already registered.
+Mount it near app startup, or register from another module that loads then. The host can only list and invoke tools your app already registered.
 
-**Cancellation:** `handler(args, context)`'s `context.signal` (an `AbortSignal`) aborts if the caller cancels the call, or if the session's connection is lost mid-call. Forward it into anything that accepts one (`fetch(url, { signal: context.signal })`) or check `context.signal.aborted`/listen for `"abort"` to stop early. Ignoring it is fine — the handler just keeps running and replies normally, as it always has.
+To keep a destructive tool out of some build variants, pass `{ enabled }` rather than wrapping the hook in an `if` — see [Gating a tool by build variant](../../docs/SECURITY.md#gating-a-tool-by-build-variant).
 
-```ts
-handler: async ({ url }, { signal }) => {
-  const response = await fetch(url, { signal });
-  return { body: await response.text() };
-},
-```
+### 5. Start the daemon and test the flow
 
-**Gating a tool by build variant:** `useCordieriteTool` takes a third `options` argument, `{ enabled?: boolean }` (default `true`). `enabled: false` never registers the tool, and removing it (or a hook that was already mounted) leaves no registration behind. Toggling `enabled` at runtime registers/unregisters cleanly — this is the supported way to make registration conditional, so put the condition in the argument instead of wrapping the hook call in an `if`, which is a rules-of-hooks violation:
-
-```ts
-useCordieriteTool(
-  {
-    name: "wipe-local-db",
-    description: "Destructive: clears the local database",
-    handler: async () => wipeLocalDb(),
-  },
-  [],
-  { enabled: process.env.EXPO_PUBLIC_CORDIERITE_TOOLS === "full" }
-);
-```
-
-The recommended predicate is an app-owned build flag inlined by the bundler at build time (`EXPO_PUBLIC_*` env vars, a Babel define plugin, etc.) — something your release pipeline controls explicitly, like `process.env.EXPO_PUBLIC_CORDIERITE_TOOLS === "full"` above. **`__DEV__` is the wrong default here**, for the same reason a `debuggable` build-type check is the wrong native gate: `__DEV__` is `false` in *any* release-bundled JS, including the release-signed, internally-distributed "testing" variant agents actually drive in CI — gating a destructive tool on `__DEV__` removes it exactly where it is needed. `__DEV__` is still fine for tools that are genuinely debug-only (e.g. a "dump internal state" tool with no purpose outside a local dev loop); it just should not be the example every app copies for hardening.
-
-**Consequence for agents and E2E flows:** because registration is the app-side allowlist, `tools/list` legitimately differs per build artifact — a CI testing build may expose a different tool set than a local dev build or a hardened production build. Automated flows should discover tools via `tools/list` rather than assume a fixed set is always present.
-
-### 6. Start the daemon and test the flow
-
-`cordierite` auto-spawns its daemon on first use, so most CLI commands just work:
+`cordierite` auto-spawns its daemon on first use, so most commands just work:
 
 ```bash
 cordierite link --qr
 ```
 
-Scan the printed QR (or open the deep link) in the app, then inspect and invoke tools:
+Scan the QR (or open the deep link) in the app, then inspect and invoke tools:
 
 ```bash
 cordierite tools
 cordierite invoke sum --input '{"a":2,"b":3}'
 ```
 
-Omit the session selector when you only have one active session — `cordierite` uses it automatically; pass an alias or session id when you have several (`cordierite ls` lists them).
+Omit the session selector when only one session is active; pass an alias or session id when several are (`cordierite ls` lists them).
 
-## Hardening for production / internal builds
+## API reference
 
-Whether Cordierite's native code ships in a build, and what it trusts once it does, are two independent, explicit config decisions — neither is derived from whether the build is debuggable:
+### Entry points
 
-- **Inclusion** is decided entirely by autolinking (see "Compiling Cordierite out of production builds" below), not by anything this package does at runtime. By default the native module is present in **debug** builds and absent from **release** builds. The mechanism differs by platform: iOS restricts CocoaPods' `:configurations` to `Debug`, a real per-variant *linking* decision. Android can't use the equivalent `buildTypes` lever the same way — React Native's Gradle autolinking generates `PackageList.java` once, shared unfiltered across every variant, so restricting *linking* by variant would leave that shared file referencing a class absent from an unlisted variant's classpath (a compile error, not an inert build) — so Android links this project into every variant unconditionally, and `android/build.gradle` instead swaps which Kotlin source set compiles for the `release` build type, based on `CORDIERITE_ENABLED`: `debug` always compiles the real implementation, `release` compiles either the same real files (opted in) or a no-op `CordieritePackage` (default) that registers nothing. Either way, the real implementation is genuinely absent from the compiled output it's excluded from — not a `#if DEBUG`/`FLAG_DEBUGGABLE` check baked into code that ships regardless. `CordieritePackage.getModule` (Android) and `CordieriteTurboBridge.swift`/`RCTNativeCordierite.mm` (iOS) contain no build-type check at all — if the real implementation is compiled/linked into a variant, it's in that variant's build, full stop; whether it is is what `CORDIERITE_ENABLED` controls.
-- **Trust** is decided by the `trust` config value: `"pin"` (only the embedded `cliPins` are trusted) or `"link"` (trust the bootstrap link's carried pin, per session — the "dev mode" flow from step 2 above). Default: `"pin"` when `cliPins` is non-empty, `"link"` otherwise. This resolution is identical in every build type; there is no `#if DEBUG`/`FLAG_DEBUGGABLE` involved anywhere in it.
-- **A `trust` value that is neither `"link"` nor `"pin"`** (a typo, or a hand-edited native config) is a **hard error** — at config/prebuild time from the plugin, and independently in the native trust-resolution logic (`resolveTrustedPins` on both platforms) — so a typo can never silently downgrade an intended `"pin"` config into permissive link TOFU.
-- **JS**: with the native module absent (excluded via autolinking, Expo Go, or a debug-tooling-free JS-only environment), every exported function on the root `@cordierite/react-native` entry degrades to the exact `./noop` entry's behavior — one warning log the first time, no throws, `getCordieriteState()` reporting `"idle"`, `connect()` always rejecting with `CordieriteDisabledError` (`code: "cordierite_disabled"`).
+| Entry | Behavior |
+| --- | --- |
+| `@cordierite/react-native` | Side-effect-free. The native module is looked up **lazily**, on the first native call — importing it (even in Expo Go) never crashes. |
+| `@cordierite/react-native/auto` | Same exports plus one side effect: installs the deep-link bootstrap listener and starts lease recovery. The only entry that installs anything. |
+| `@cordierite/react-native/noop` | Same public API, fully inert — for [compiling Cordierite out of production builds](../../docs/BUILD-VARIANTS.md#compiling-cordierite-out-of-production-builds). |
+| `@cordierite/react-native/metro` | `withCordierite(config, { include })` — swaps the real entries for `/noop` at bundle time. |
 
-`trust: "pin"` requires non-empty `cliPins` (bare RN: `CordieriteTrust`/`TRUST` set to `"pin"` **and** `CordieriteCliPins`/`CLI_PINS` non-empty) — a build that only ever trusts embedded pins but has none configured would have no way to trust anything, so the plugin refuses that combination at config time, and the native readers refuse it again if that check is ever bypassed by hand.
+### Exports
 
-**`getCordieriteBuildConfig()`** reports the effective trust configuration a running build actually has — `{ trust, hasEmbeddedPins, allowPrivateLanOnly }` — read via `getConstants()` from the exact same native manifest/plist parse `connect()`'s `resolveTrustedPins` uses, never a second parse path, so it can never disagree with what a real connect attempt would do. `trust` reports the *effective* bucket (`"pin"` whenever embedded pins are present, since they always win; `"link"` otherwise), not the raw config string. On `./noop`, it reports the documented absent shape: `{ trust: "absent", hasEmbeddedPins: false, allowPrivateLanOnly: true }`.
+| Export | Signature / notes |
+| --- | --- |
+| `registerTool` | `({ name, description, inputSchema?, outputSchema?, annotations?, handler })` → `{ remove() }`. The disposer removes only its own registration. |
+| `useCordieriteTool` | `(definition, deps?, { enabled? })`. `enabled` defaults to `true`; `false` never registers, and removes an existing registration owned by that hook. |
+| `handler` | `(args, context)`. `context.signal` is an `AbortSignal`, aborted when the caller cancels or the connection is lost mid-call. Forward it (`fetch(url, { signal })`) or ignore it — an ignoring handler replies normally. |
+| `postEvent` | `(name, payload?)` — pushes an app event, read by `cordierite events` and the MCP event tools. |
+| `addCordieriteListener` | `(kind, callback)` → `{ remove() }`. Kinds `"stateChange"`, `"sessionChange"`, `"error"` — the last one unified channel for bootstrap-parse, connect, socket, and tool-handler failures. |
+| `getRegisteredTools` | → `ToolDescriptor[]`, the current registry. |
+| `getCordieriteState` | → the client's connection state (`"idle"` with no session). |
+| `restoreSession` | → `Promise<boolean>`. Recovers the native resume lease; also `cordieriteClient.restoreSession()`. |
+| `connect` | `(input)` → `Promise<void>`. Claims a parsed bootstrap payload. Rejects with `CordieriteDisabledError` (`code: "cordierite_disabled"`) when native is absent. |
+| `parseBootstrapUrl` | Parses a v2 bootstrap deep link (and its sibling `pin` param) into `connect` input. |
+| `getCordieriteBuildConfig` | → `{ trust, hasEmbeddedPins, allowPrivateLanOnly }`, this build's [effective trust configuration](../../docs/SECURITY.md#reading-the-effective-configuration-at-runtime). |
 
-**Resulting matrix (`CORDIERITE_ENABLED` × build variant, `trust` orthogonal to both):**
+## Going further
 
-| `CORDIERITE_ENABLED` | Debug / `debug` | Release / `release` |
-| --- | --- | --- |
-| unset (default) | Native code ships | Native code excluded |
-| `1` / `true` | Native code ships | Native code ships |
-| `0` / `false` | Native code excluded | Native code excluded |
-
-`trust` (`"link"` vs `"pin"`, resolved as above) only matters in a variant where the native code ships at all.
-
-## Compiling Cordierite out of production builds
-
-**Debug builds carry Cordierite by default; release builds don't.** On iOS this is CocoaPods only linking the `Cordierite` pod into configurations named `Debug` (`react-native.config.js`'s `ios.configurations`). On Android, `android/build.gradle` compiles the real implementation for `debug` and a no-op stand-in for `release`, driven by the same `CORDIERITE_ENABLED` variable (see above) — the module is always linked as a Gradle project, but which Kotlin source set actually compiles for `release` is what changes. Neither is a runtime check. A release-signed internal/QA build that still needs Cordierite (an agent-driven CI build, for example) opts back in explicitly:
-
-```bash
-CORDIERITE_ENABLED=1 npx expo prebuild && CORDIERITE_ENABLED=1 npx expo run:ios --configuration Release
-```
-
-To go the other direction — strip Cordierite from a **debug** build too, or from every variant regardless of name — set `CORDIERITE_ENABLED=0`:
-
-```bash
-CORDIERITE_ENABLED=0 npx expo prebuild && CORDIERITE_ENABLED=0 npx expo run:ios --configuration Release
-```
-
-Accepted values are `1`/`true` and `0`/`false`, case-insensitive; unset or empty means the dev-only default described above. Any other value is a config error, raised at prebuild.
-
-Cordierite ships its own `react-native.config.js` that reads the variable and sets `ios.configurations` in autolinking accordingly; `android/build.gradle` reads the same variable directly to pick the `release` source set (see above); and `@cordierite/react-native/metro` reads it too, to strip the JS (see "JS — swap the module at bundle time" below — Metro's own dev/release split does not thread through to this, so an explicit `CORDIERITE_ENABLED=0` is still how you strip Cordierite JS from a release bundle). One variable, every surface.
-
-**`cordierite doctor`'s Android detection is marker-only.** The default release build's no-op `CordieritePackage` stub necessarily lives at the exact same fully-qualified class name the real implementation uses (that's what keeps `PackageList.java` compiling — see above), and the config plugin writes the same `AndroidManifest.xml` meta-data regardless of build variant. Both would otherwise look like "Cordierite is present" to a naive scan. `doctor` accounts for this: only the `CordieriteNativeMarker` keep-rule signal (absent from the stub) decides `present`/`absent` on Android; the other two signals are still reported for corroboration but can't flip the verdict on their own. See `packages/cordierite/src/artifact-inspect.ts`'s file-level comment for the full detection writeup.
-
-**It must be set when autolinking resolves** — `pod install` and gradle configure — not merely when the app compiles. Flipping it and rebuilding without re-running install does nothing, silently.
-
-**Keyed to build type by name, not by a compiled-in check.** CocoaPods restricts linking to Xcode configurations literally named `Debug`/`Release`; Gradle restricts it to build types literally named `debug`/`release`. A custom build-type/configuration name (a `staging` flavor, say) gets neither — set `CORDIERITE_ENABLED=1` for that pipeline if it should carry Cordierite. This replaces the `debuggable`/`#if DEBUG` gate removed in 0.4.0 with a real per-variant linking decision instead of a runtime check compiled into every variant.
-
-Verify the result against the artifact rather than the build log:
-
-```bash
-cordierite doctor path/to/app-release.apk --assert-absent
-```
-
-When Cordierite *is* linked, its podspec and `build.gradle` print `[cordierite] native module INCLUDED in this build` during pod install / gradle configure. Nothing prints when it is excluded, because nothing runs — the line exists to catch a release build that carries Cordierite by mistake, which is the failure that matters. Treat `doctor` as the authority; the log is an early warning.
-
-### Excluding it permanently, without the environment variable
-
-If a project should never carry Cordierite on a given platform — regardless of pipeline — declare the exclusion in the app instead. In a `react-native.config.js` at your app root:
-
-```js
-module.exports = {
-  dependencies: {
-    "@cordierite/react-native": {
-      platforms: {
-        ios: null,
-        android: null,
-      },
-    },
-  },
-};
-```
-
-The Expo-managed equivalent is `expo.autolinking`'s per-platform `exclude` list — but it must live in **`package.json`**, not `app.json` / `app.config.*`. `expo-modules-autolinking` reads this config straight from `package.json` at pod-install/gradle time; an `expo.autolinking` block in `app.json` is silently ignored, so the exclusion never happens and the native module still ships. This has already shipped as a bug once, so double-check with the resolver command below after adding it.
-
-```json
-{
-  "expo": {
-    "autolinking": {
-      "ios": { "exclude": ["@cordierite/react-native"] },
-      "android": { "exclude": ["@cordierite/react-native"] }
-    }
-  }
-}
-```
-
-Verify the exclusion actually took effect — this is the only way to catch the `app.json` mistake above. Run it from your app root after `npm`/`pnpm`/`yarn install`, using the locally installed binary rather than `npx` (which can silently fetch an unrelated version from the registry instead of resolving the one your build actually uses):
-
-```sh
-./node_modules/.bin/expo-modules-autolinking react-native-config --json --platform ios
-```
-
-`@cordierite/react-native` must be absent from the printed `dependencies`.
-
-> **`expo.autolinking.apple` overrides `expo.autolinking.ios`, not merges with it.** The CocoaPods driver `pod install` actually invokes always resolves with `--platform apple`, and when an `apple` sub-object is present under `expo.autolinking`, it wins outright over `ios` — `ios` is only used as a fallback when `apple` is absent. If your app also has an `expo.autolinking.apple` block (for reasons unrelated to Cordierite), an `ios`-only exclude for `@cordierite/react-native` is silently ignored on iOS; add the exclude to `apple` instead (or to both).
-
-> **Excluding on iOS also disables codegen for this package.** `expo-modules-autolinking` only generates `CordieriteSpec` (the TurboModule codegen output `RCTNativeCordierite.mm` imports) for packages it actually autolinks. If your app excludes `@cordierite/react-native` from iOS autolinking but still references the `Cordierite` pod directly — for example to attach an XCTest target, as this repo's own playground does — the build fails because the generated header no longer exists. This only affects setups that both exclude and hand-add the pod; a normal consumer app that just wants Cordierite gone never hits it.
-
-There is no corresponding plugin option to keep in sync. Earlier 0.4.0 prereleases had an `include` option that only *asserted* the plugin's intent matched autolinking; it was removed once `CORDIERITE_ENABLED` drove autolinking directly, since there were no longer two sources to reconcile. Passing it now throws at prebuild, naming the replacement.
-
-**JS — swap the module at bundle time**, so no Cordierite JS (deep-link listener, tool registry, client state machine) ends up in the bundle either. Excluding the native module alone does not do this: the real JS entry is still bundled, it just finds no native module and goes inert. Use the `withCordierite` Metro helper from `@cordierite/react-native/metro` in `metro.config.js`:
-
-```js
-const { getDefaultConfig } = require("expo/metro-config");
-const { withCordierite } = require("@cordierite/react-native/metro");
-
-const config = getDefaultConfig(__dirname);
-
-module.exports = withCordierite(getDefaultConfig(__dirname));
-```
-
-With no options it reads `CORDIERITE_ENABLED` itself, so the same variable that drops the native module strips the JS. Pass `{ include: false }` to force the strip, or `{ include: <your own predicate> }` to key it off something else entirely.
-
-When stripping, every specifier this package exposes as a real JS module entry point (derived from `package.json`'s `exports`, not a hardcoded `.`/`/auto` list, so a future entry point is covered automatically) is redirected to `@cordierite/react-native/noop`, which has no side effect on import, matching `/auto`'s shape without installing anything. `/noop` itself is never redirected.
-
-If `config.resolver.resolveRequest` is already set — as it typically will be, e.g. the playground's own workspace-symlink-dedup resolver — `withCordierite` **chains to it** for every resolution, redirected or not, instead of replacing it; it only falls back to `context.resolveRequest` when no existing resolver is present. Your existing resolver's return value is what callers see. **Call `withCordierite` last**, after anything else that sets `config.resolver.resolveRequest` — it captures the existing resolver by reference when called, so a later assignment overwrites (and silently discards) the strip instead of composing with it.
-
-If you'd rather not touch Metro config, a conditional `require` at each import site works too (module identity differs per call site, so this is more repetitive but avoids any bundler-level indirection):
-
-```ts
-const { registerTool, useCordieriteTool } = __DEV__
-  ? require("@cordierite/react-native")
-  : require("@cordierite/react-native/noop");
-```
-
-Either way, `/noop` is typed identically to the root entry (both implement the same shared interface — see `src/public-api.ts` and `src/__tests__/noop-parity.test.ts`), so switching between them is a drop-in swap: `registerTool` still returns a disposer, `connect()` still returns a `Promise<void>` (it just always rejects with a `CordieriteDisabledError`, `code: "cordierite_disabled"`), and `getCordieriteState()` always reports `"idle"`.
-
-**Either half alone still yields a working, inert app.** The `/noop` Metro swap alone gives you an app with no Cordierite JS running but the native pod still compiled in (unused); the autolinking exclude alone gives you an app with no native Cordierite code but that still imports the real JS entry, which finds no native module and degrades to the same `/noop`-equivalent behavior described in "Hardening for production / internal builds" above. `CORDIERITE_ENABLED=0` drives both halves at once, which is what you want to satisfy an app-store reviewer who expects no "remote control" surface whatsoever, not just an inert one.
+- [Trust modes](../../docs/SECURITY.md#trust-modes) and [Configuring trust](../../docs/SECURITY.md#configuring-trust) — `cliPins`, `trust`, `allowPrivateLanOnly`, Expo plugin options, bare-RN native keys.
+- [Gating a tool by build variant](../../docs/SECURITY.md#gating-a-tool-by-build-variant) — `enabled`, and why `__DEV__` is the wrong predicate.
+- [Build variants](../../docs/BUILD-VARIANTS.md) — `CORDIERITE_ENABLED`, autolinking exclusion, **compiling Cordierite out of production builds**.
+- [What a build without the native module does](../../docs/SECURITY.md#what-a-build-without-the-native-module-does).
+- [Release gate: `cordierite doctor`](../../docs/CI.md#release-gate-cordierite-doctor) — assert against the artifact.
+- [ARCHITECTURE.md §11](../../docs/ARCHITECTURE.md#11-react-native-sdk) — resume lease, reconnect, cancellation.
+- [`cordierite` CLI and MCP server](../cordierite/README.md) — the operator/agent side.
 
 ## Platform compatibility
 
@@ -354,7 +155,6 @@ Either way, `/noop` is typed identically to the root entry (both implement the s
 | **iOS** | 15.1+ (`Cordierite.podspec`), New Architecture |
 | **Android** | Autolinked, New Architecture |
 | **Web** | Stub only |
-
 
 ## Made with ❤️ at Callstack
 
@@ -370,6 +170,6 @@ Like the project? ⚛️ [Join the team](https://callstack.com/careers/?utm_camp
 [npm-downloads-badge]: https://img.shields.io/npm/dm/cordierite?style=for-the-badge
 [npm-downloads]: https://www.npmjs.com/package/cordierite
 [prs-welcome-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=for-the-badge
-[prs-welcome]: ./CONTRIBUTING.md
+[prs-welcome]: https://github.com/callstackincubator/cordierite/pulls
 [chat-badge]: https://img.shields.io/discord/426714625279524876.svg?style=for-the-badge
 [chat]: https://discord.gg/xgGt7KAjxv

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -4,13 +4,13 @@
 
 [![MIT license][license-badge]][license] [![npm downloads][npm-downloads-badge]][npm-downloads] [![PRs Welcome][prs-welcome-badge]][prs-welcome]
 
-This package is the **native client** for Cordierite. Your app **registers tools** in JavaScript; **developers, testers, and agents** invoke them from a **CLI or host** once the app opens a bootstrap link and completes a **pinned `wss://`** handshake — **production-grade transport** (TLS + SPKI) instead of **debug-only screens** buried in the UI.
+This package is the **native client** for Cordierite. Your app **registers tools** in JavaScript; **developers, testers, and agents** invoke them from a **CLI or host** once the app opens a bootstrap link and completes a **pinned `wss://`** handshake — TLS + SPKI transport instead of **debug-only screens** buried in the UI.
 
 ## Why use it
 
-- **No in-app debug chrome**: influence screens, flags, fixtures, and flows from the **host**, not from hidden menus shipped to users.
-- **Same path for people and automation**: CLI for devs/QA, agents for scripted or LLM-driven control—both use **tool calls** after session claim.
-- **Production-capable**: ship it in real builds when your pins and operational model allow; connecting still requires a **trusted host**, not anonymous public access.
+- **No in-app debug chrome**: drive screens, flags, fixtures, and flows from the **host**, not from hidden menus shipped to users.
+- **Same path for people and automation**: CLI for devs/QA, agents for scripted or LLM-driven control — both use **tool calls** after session claim.
+- **Production-capable**: ship it in real builds when your pins and operational model allow; connecting still needs a **trusted host**, not anonymous access.
 
 ## Getting started
 
@@ -35,7 +35,9 @@ npm install cordierite
 
 **No key, no pins, and no config plugin are needed — in any build type.** The daemon auto-generates a key on first start, and `cordierite link` carries its `sha256/...` fingerprint on the deep link for the app to trust for that session.
 
-Wire your deep-link scheme so the OS can open the app with that link, and you are done. To make a build trust only pins you embedded ahead of time, see [Configuring trust](../../docs/SECURITY.md#configuring-trust).
+Wire your deep-link scheme so the OS can open the app with that link, and you are done. To make a build trust only pins you embedded ahead of time, see [Configuring trust](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#configuring-trust).
+
+By default the native module ships in **debug** builds only: a Release build has none, so the API is inert and `connect()` rejects `cordierite_disabled` ([Build variants](https://github.com/callstackincubator/cordierite/blob/main/docs/BUILD-VARIANTS.md)).
 
 ### 3. Import Cordierite in the JS entry point
 
@@ -43,7 +45,7 @@ Wire your deep-link scheme so the OS can open the app with that link, and you ar
 import "@cordierite/react-native/auto";
 ```
 
-`/auto` is the only entry that installs anything: the deep-link bootstrap listener and native-lease recovery. To control *when* that happens — in `__DEV__`, behind a QA toggle, after other startup work — `require()` it there instead. Metro resolves it lazily; importing twice installs once:
+`/auto` is the only entry that installs anything: the deep-link bootstrap listener and native-lease recovery. To control *when* that happens — in `__DEV__`, behind a QA toggle — `require()` it there instead. Metro resolves it lazily; importing twice installs once:
 
 ```ts
 if (__DEV__) {
@@ -51,21 +53,13 @@ if (__DEV__) {
 }
 ```
 
-The default flow needs no `Linking` handler of your own, and sessions survive Metro reloads and short network flaps — see [ARCHITECTURE.md §11](../../docs/ARCHITECTURE.md#11-react-native-sdk) for lease, resume, and reconnect rules.
+The default flow needs no `Linking` handler of your own, and sessions survive Metro reloads and short network flaps — see [ARCHITECTURE.md §11](https://github.com/callstackincubator/cordierite/blob/main/docs/ARCHITECTURE.md#11-react-native-sdk) for lease, resume, and reconnect rules.
 
-If you drive bootstrap yourself and never import `/auto`, call `restoreSession()` first — it is then the only reader of the native resume lease:
-
-```ts
-import { connect, parseBootstrapUrl, restoreSession } from "@cordierite/react-native";
-
-if (!(await restoreSession())) {
-  await connect(parseBootstrapUrl(url));
-}
-```
+If you drive bootstrap yourself and never import `/auto`, call `restoreSession()` before your own bootstrap handling — it is then the only reader of the native resume lease.
 
 ### 4. Define tools in app startup code
 
-Call `registerTool({ ... })` with Standard Schema compatible `inputSchema`/`outputSchema` values and a `handler`. Zod v4 works well here — its built-in JSON Schema exporter means agents see a real tool shape. Zod 3 and plain valibot schemas still register, just with a dev warning and an empty schema.
+Call `registerTool({ ... })` with Standard Schema compatible `inputSchema`/`outputSchema` values and a `handler`. Zod v4 works well — its JSON Schema exporter means agents see a real tool shape. Zod 3 and plain valibot schemas still register, with a dev warning and an empty schema.
 
 `useCordieriteTool` wraps `registerTool` in a `useEffect`, so registration follows the component's lifecycle including remounts and Fast Refresh:
 
@@ -92,24 +86,24 @@ export function CordieriteBootstrap() {
 
 Mount it near app startup, or register from another module that loads then. The host can only list and invoke tools your app already registered.
 
-To keep a destructive tool out of some build variants, pass `{ enabled }` rather than wrapping the hook in an `if` — see [Gating a tool by build variant](../../docs/SECURITY.md#gating-a-tool-by-build-variant).
+To keep a destructive tool out of some build variants, pass `{ enabled }` rather than wrapping the hook in an `if` — see [Gating a tool by build variant](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#gating-a-tool-by-build-variant).
 
 ### 5. Start the daemon and test the flow
 
-`cordierite` auto-spawns its daemon on first use, so most commands just work:
+`cordierite` auto-spawns its daemon. `link` needs your app's deep-link scheme: pass `--scheme` (matching `expo.scheme`), or set `scheme` once in `~/.cordierite/config.json`:
 
 ```bash
-cordierite link --qr
+cordierite link --scheme myapp --qr
 ```
 
-Scan the QR (or open the deep link) in the app, then inspect and invoke tools:
+Scan the QR (or open the link) in the app, then inspect and invoke tools:
 
 ```bash
 cordierite tools
 cordierite invoke sum --input '{"a":2,"b":3}'
 ```
 
-Omit the session selector when only one session is active; pass an alias or session id when several are (`cordierite ls` lists them).
+Omit the session selector when only one session is active; pass an alias or session id when several are (`cordierite ls`).
 
 ## API reference
 
@@ -118,8 +112,8 @@ Omit the session selector when only one session is active; pass an alias or sess
 | Entry | Behavior |
 | --- | --- |
 | `@cordierite/react-native` | Side-effect-free. The native module is looked up **lazily**, on the first native call — importing it (even in Expo Go) never crashes. |
-| `@cordierite/react-native/auto` | Same exports plus one side effect: installs the deep-link bootstrap listener and starts lease recovery. The only entry that installs anything. |
-| `@cordierite/react-native/noop` | Same public API, fully inert — for [compiling Cordierite out of production builds](../../docs/BUILD-VARIANTS.md#compiling-cordierite-out-of-production-builds). |
+| `@cordierite/react-native/auto` | Same exports plus one side effect: installs the deep-link bootstrap listener and starts lease recovery — the only entry that installs anything. |
+| `@cordierite/react-native/noop` | Same public API, fully inert — for [compiling Cordierite out of production builds](https://github.com/callstackincubator/cordierite/blob/main/docs/BUILD-VARIANTS.md#compiling-cordierite-out-of-production-builds). |
 | `@cordierite/react-native/metro` | `withCordierite(config, { include })` — swaps the real entries for `/noop` at bundle time. |
 
 ### Exports
@@ -127,26 +121,26 @@ Omit the session selector when only one session is active; pass an alias or sess
 | Export | Signature / notes |
 | --- | --- |
 | `registerTool` | `({ name, description, inputSchema?, outputSchema?, annotations?, handler })` → `{ remove() }`. The disposer removes only its own registration. |
-| `useCordieriteTool` | `(definition, deps?, { enabled? })`. `enabled` defaults to `true`; `false` never registers, and removes an existing registration owned by that hook. |
-| `handler` | `(args, context)`. `context.signal` is an `AbortSignal`, aborted when the caller cancels or the connection is lost mid-call. Forward it (`fetch(url, { signal })`), check `signal.aborted`, or listen for `"abort"`; ignoring it is fine — the handler just replies normally. |
+| `useCordieriteTool` | `(definition, deps?, { enabled? })`. `enabled` defaults to `true`; `false` never registers, and removes any registration that hook owns. |
+| `handler` | `(args, context)`. `context.signal` is an `AbortSignal`, aborted when the caller cancels or the connection drops mid-call. Forward it (`fetch(url, { signal })`), check `signal.aborted`, or listen for `"abort"`; ignoring it is fine — the handler just replies normally. |
 | `postEvent` | `(name, payload?)` — pushes an app event, read by `cordierite events` and the MCP event tools. |
-| `addCordieriteListener` | `(kind, callback)` → `{ remove() }`. Kinds `"stateChange"`, `"sessionChange"`, `"error"` — the last one unified channel for bootstrap-parse, connect, socket, and tool-handler failures. |
+| `addCordieriteListener` | `(kind, callback)` → `{ remove() }`. Kinds `"stateChange"`, `"sessionChange"`, `"error"` — the last one channel for bootstrap-parse, connect, socket, and tool-handler failures. |
 | `getRegisteredTools` | → `ToolDescriptor[]`, the current registry. |
 | `getCordieriteState` | → the client's connection state (`"idle"` with no session). |
 | `restoreSession` | → `Promise<boolean>`. Recovers the native resume lease; also `cordieriteClient.restoreSession()`. |
 | `connect` | `(input)` → `Promise<void>`. Claims a parsed bootstrap payload. Rejects with `CordieriteDisabledError` (`code: "cordierite_disabled"`) when native is absent. |
-| `parseBootstrapUrl` | Parses a v2 bootstrap deep link (and its sibling `pin` param) into `connect` input. |
-| `getCordieriteBuildConfig` | → `{ trust, hasEmbeddedPins, allowPrivateLanOnly }`, this build's [effective trust configuration](../../docs/SECURITY.md#reading-the-effective-configuration-at-runtime). |
+| `parseBootstrapUrl` | Parses a v2 bootstrap deep link (and its sibling `pin` param) for `connect`. |
+| `getCordieriteBuildConfig` | → `{ trust, hasEmbeddedPins, allowPrivateLanOnly }`, this build's [effective trust configuration](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#reading-the-effective-configuration-at-runtime). |
 
 ## Going further
 
-- [Trust modes](../../docs/SECURITY.md#trust-modes) and [Configuring trust](../../docs/SECURITY.md#configuring-trust) — `cliPins`, `trust`, `allowPrivateLanOnly`, Expo plugin options, bare-RN native keys.
-- [Gating a tool by build variant](../../docs/SECURITY.md#gating-a-tool-by-build-variant) — `enabled`, and why `__DEV__` is the wrong predicate.
-- [Build variants](../../docs/BUILD-VARIANTS.md) — `CORDIERITE_ENABLED`, autolinking exclusion, **compiling Cordierite out of production builds**.
-- [What a build without the native module does](../../docs/SECURITY.md#what-a-build-without-the-native-module-does).
-- [Release gate: `cordierite doctor`](../../docs/CI.md#release-gate-cordierite-doctor) — assert against the artifact.
-- [ARCHITECTURE.md §11](../../docs/ARCHITECTURE.md#11-react-native-sdk) — resume lease, reconnect, cancellation.
-- [`cordierite` CLI and MCP server](../cordierite/README.md) — the operator/agent side.
+- [Trust modes](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#trust-modes) and [Configuring trust](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#configuring-trust) — pins, plugin options, bare-RN native keys.
+- [Gating a tool by build variant](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#gating-a-tool-by-build-variant) — `enabled`, and why `__DEV__` is the wrong predicate.
+- [Build variants](https://github.com/callstackincubator/cordierite/blob/main/docs/BUILD-VARIANTS.md) — `CORDIERITE_ENABLED`, autolinking exclusion, **compiling Cordierite out of production builds**.
+- [What a build without the native module does](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#what-a-build-without-the-native-module-does).
+- [Release gate: `cordierite doctor`](https://github.com/callstackincubator/cordierite/blob/main/docs/CI.md#release-gate-cordierite-doctor).
+- [ARCHITECTURE.md §11](https://github.com/callstackincubator/cordierite/blob/main/docs/ARCHITECTURE.md#11-react-native-sdk) — resume lease, reconnect, cancellation.
+- [`cordierite` CLI and MCP server](../cordierite/README.md).
 
 ## Platform compatibility
 

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -43,7 +43,7 @@ Wire your deep-link scheme so the OS can open the app with that link, and you ar
 import "@cordierite/react-native/auto";
 ```
 
-`/auto` is the only entry that installs anything: the deep-link bootstrap listener plus recovery from the native process lease. To control *when* that happens — in `__DEV__`, behind a QA toggle, after other startup work — `require()` it there instead. Metro resolves it lazily; importing twice installs once:
+`/auto` is the only entry that installs anything: the deep-link bootstrap listener and native-lease recovery. To control *when* that happens — in `__DEV__`, behind a QA toggle, after other startup work — `require()` it there instead. Metro resolves it lazily; importing twice installs once:
 
 ```ts
 if (__DEV__) {
@@ -128,7 +128,7 @@ Omit the session selector when only one session is active; pass an alias or sess
 | --- | --- |
 | `registerTool` | `({ name, description, inputSchema?, outputSchema?, annotations?, handler })` → `{ remove() }`. The disposer removes only its own registration. |
 | `useCordieriteTool` | `(definition, deps?, { enabled? })`. `enabled` defaults to `true`; `false` never registers, and removes an existing registration owned by that hook. |
-| `handler` | `(args, context)`. `context.signal` is an `AbortSignal`, aborted when the caller cancels or the connection is lost mid-call. Forward it (`fetch(url, { signal })`) or ignore it — an ignoring handler replies normally. |
+| `handler` | `(args, context)`. `context.signal` is an `AbortSignal`, aborted when the caller cancels or the connection is lost mid-call. Forward it (`fetch(url, { signal })`), check `signal.aborted`, or listen for `"abort"`; ignoring it is fine — the handler just replies normally. |
 | `postEvent` | `(name, payload?)` — pushes an app event, read by `cordierite events` and the MCP event tools. |
 | `addCordieriteListener` | `(kind, callback)` → `{ remove() }`. Kinds `"stateChange"`, `"sessionChange"`, `"error"` — the last one unified channel for bootstrap-parse, connect, socket, and tool-handler failures. |
 | `getRegisteredTools` | → `ToolDescriptor[]`, the current registry. |

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -4,7 +4,7 @@
 
 [![MIT license][license-badge]][license] [![npm downloads][npm-downloads-badge]][npm-downloads] [![PRs Welcome][prs-welcome-badge]][prs-welcome]
 
-This package is the **native client** for Cordierite. Your app **registers tools** in JavaScript; **developers, testers, and agents** invoke them from a **CLI or host** once the app opens a bootstrap link and completes a **pinned `wss://`** handshake — TLS + SPKI transport instead of **debug-only screens** buried in the UI.
+This package is the **native client** for Cordierite. Your app **registers tools** in JavaScript; **developers, testers, and agents** invoke them from a **CLI or host** once the app opens a bootstrap link and completes a **pinned `wss://`** handshake — TLS + SPKI transport instead of **debug-only screens** in the UI.
 
 ## Why use it
 
@@ -28,14 +28,14 @@ npm install @cordierite/react-native zod
 The CLI, on the machine running the host:
 
 ```bash
-npm install cordierite
+npm install -g cordierite
 ```
 
 ### 2. Nothing to configure yet
 
 **No key, no pins, and no config plugin are needed — in any build type.** The daemon auto-generates a key on first start, and `cordierite link` carries its `sha256/...` fingerprint on the deep link for the app to trust for that session.
 
-Wire your deep-link scheme so the OS can open the app with that link, and you are done. To make a build trust only pins you embedded ahead of time, see [Configuring trust](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#configuring-trust).
+Wire your deep-link scheme so the OS can open the app with that link. To make a build trust only pins you embedded ahead of time, see [Configuring trust](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#configuring-trust).
 
 By default the native module ships in **debug** builds only: a Release build has none, so the API is inert and `connect()` rejects `cordierite_disabled` ([Build variants](https://github.com/callstackincubator/cordierite/blob/main/docs/BUILD-VARIANTS.md)).
 
@@ -45,7 +45,7 @@ By default the native module ships in **debug** builds only: a Release build has
 import "@cordierite/react-native/auto";
 ```
 
-`/auto` is the only entry that installs anything: the deep-link bootstrap listener and native-lease recovery. To control *when* that happens — in `__DEV__`, behind a QA toggle — `require()` it there instead. Metro resolves it lazily; importing twice installs once:
+`/auto` is the only entry that installs anything: the deep-link bootstrap listener and native-lease recovery. To control *when* — in `__DEV__`, behind a QA toggle — `require()` it there instead. Metro resolves it lazily; importing twice installs once:
 
 ```ts
 if (__DEV__) {
@@ -53,7 +53,7 @@ if (__DEV__) {
 }
 ```
 
-The default flow needs no `Linking` handler of your own, and sessions survive Metro reloads and short network flaps — see [ARCHITECTURE.md §11](https://github.com/callstackincubator/cordierite/blob/main/docs/ARCHITECTURE.md#11-react-native-sdk) for lease, resume, and reconnect rules.
+The default flow needs no `Linking` handler of your own, and sessions survive Metro reloads and network flaps — see [ARCHITECTURE.md §11](https://github.com/callstackincubator/cordierite/blob/main/docs/ARCHITECTURE.md#11-react-native-sdk) for lease, resume, and reconnect rules.
 
 If you drive bootstrap yourself and never import `/auto`, call `restoreSession()` before your own bootstrap handling — it is then the only reader of the native resume lease.
 
@@ -61,7 +61,7 @@ If you drive bootstrap yourself and never import `/auto`, call `restoreSession()
 
 Call `registerTool({ ... })` with Standard Schema compatible `inputSchema`/`outputSchema` values and a `handler`. Zod v4 works well — its JSON Schema exporter means agents see a real tool shape. Zod 3 and plain valibot schemas still register, with a dev warning and an empty schema.
 
-`useCordieriteTool` wraps `registerTool` in a `useEffect`, so registration follows the component's lifecycle including remounts and Fast Refresh:
+`useCordieriteTool` wraps `registerTool` in a `useEffect`, so registration follows the component's lifecycle, remounts and Fast Refresh included:
 
 ```ts
 import "@cordierite/react-native/auto";
@@ -84,9 +84,9 @@ export function CordieriteBootstrap() {
 }
 ```
 
-Mount it near app startup, or register from another module that loads then. The host can only list and invoke tools your app already registered.
+Mount it near app startup, or register from a module that loads then. The host can only invoke tools your app already registered.
 
-To keep a destructive tool out of some build variants, pass `{ enabled }` rather than wrapping the hook in an `if` — see [Gating a tool by build variant](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#gating-a-tool-by-build-variant).
+To keep a destructive tool out of some build variants, pass `{ enabled }` rather than wrapping the hook in an `if` ([Gating a tool by build variant](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#gating-a-tool-by-build-variant)).
 
 ### 5. Start the daemon and test the flow
 
@@ -96,7 +96,7 @@ To keep a destructive tool out of some build variants, pass `{ enabled }` rather
 cordierite link --scheme myapp --qr
 ```
 
-Scan the QR (or open the link) in the app, then inspect and invoke tools:
+Scan the QR (or open the link) in the app, then list and invoke tools:
 
 ```bash
 cordierite tools
@@ -111,7 +111,7 @@ Omit the session selector when only one session is active; pass an alias or sess
 
 | Entry | Behavior |
 | --- | --- |
-| `@cordierite/react-native` | Side-effect-free. The native module is looked up **lazily**, on the first native call — importing it (even in Expo Go) never crashes. |
+| `@cordierite/react-native` | Side-effect-free. The native module is looked up **lazily**, on the first native call, so importing it (even in Expo Go) never crashes. |
 | `@cordierite/react-native/auto` | Same exports plus one side effect: installs the deep-link bootstrap listener and starts lease recovery — the only entry that installs anything. |
 | `@cordierite/react-native/noop` | Same public API, fully inert — for [compiling Cordierite out of production builds](https://github.com/callstackincubator/cordierite/blob/main/docs/BUILD-VARIANTS.md#compiling-cordierite-out-of-production-builds). |
 | `@cordierite/react-native/metro` | `withCordierite(config, { include })` — swaps the real entries for `/noop` at bundle time. |
@@ -122,25 +122,25 @@ Omit the session selector when only one session is active; pass an alias or sess
 | --- | --- |
 | `registerTool` | `({ name, description, inputSchema?, outputSchema?, annotations?, handler })` → `{ remove() }`. The disposer removes only its own registration. |
 | `useCordieriteTool` | `(definition, deps?, { enabled? })`. `enabled` defaults to `true`; `false` never registers, and removes any registration that hook owns. |
-| `handler` | `(args, context)`. `context.signal` is an `AbortSignal`, aborted when the caller cancels or the connection drops mid-call. Forward it (`fetch(url, { signal })`), check `signal.aborted`, or listen for `"abort"`; ignoring it is fine — the handler just replies normally. |
+| `handler` | `(args, context)`. `context.signal` is an `AbortSignal`, aborted when the caller cancels or the connection drops mid-call. Forward it (`fetch(url, { signal })`), check `signal.aborted`, or listen for `"abort"`; ignoring it is fine — the handler replies normally. |
 | `postEvent` | `(name, payload?)` — pushes an app event, read by `cordierite events` and the MCP event tools. |
-| `addCordieriteListener` | `(kind, callback)` → `{ remove() }`. Kinds `"stateChange"`, `"sessionChange"`, `"error"` — the last one channel for bootstrap-parse, connect, socket, and tool-handler failures. |
+| `addCordieriteListener` | `(kind, callback)` → `{ remove() }`. Kinds `"stateChange"`, `"sessionChange"`, `"error"` — the last one unified channel for bootstrap-parse, connect, socket, and tool-handler failures. |
 | `getRegisteredTools` | → `ToolDescriptor[]`, the current registry. |
 | `getCordieriteState` | → the client's connection state (`"idle"` with no session). |
-| `restoreSession` | → `Promise<boolean>`. Recovers the native resume lease; also `cordieriteClient.restoreSession()`. |
-| `connect` | `(input)` → `Promise<void>`. Claims a parsed bootstrap payload. Rejects with `CordieriteDisabledError` (`code: "cordierite_disabled"`) when native is absent. |
+| `restoreSession` | → `Promise<boolean>`. Recovers the native resume lease; also on `cordieriteClient`. |
+| `connect` | `(input)` → `Promise<void>`. Claims a parsed bootstrap payload; rejects with `CordieriteDisabledError` (`code: "cordierite_disabled"`) when native is absent. |
 | `parseBootstrapUrl` | Parses a v2 bootstrap deep link (and its sibling `pin` param) for `connect`. |
 | `getCordieriteBuildConfig` | → `{ trust, hasEmbeddedPins, allowPrivateLanOnly }`, this build's [effective trust configuration](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#reading-the-effective-configuration-at-runtime). |
 
 ## Going further
 
 - [Trust modes](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#trust-modes) and [Configuring trust](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#configuring-trust) — pins, plugin options, bare-RN native keys.
-- [Gating a tool by build variant](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#gating-a-tool-by-build-variant) — `enabled`, and why `__DEV__` is the wrong predicate.
+- [Gating a tool by build variant](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#gating-a-tool-by-build-variant) — `enabled`, and why `__DEV__` is wrong here.
 - [Build variants](https://github.com/callstackincubator/cordierite/blob/main/docs/BUILD-VARIANTS.md) — `CORDIERITE_ENABLED`, autolinking exclusion, **compiling Cordierite out of production builds**.
 - [What a build without the native module does](https://github.com/callstackincubator/cordierite/blob/main/docs/SECURITY.md#what-a-build-without-the-native-module-does).
 - [Release gate: `cordierite doctor`](https://github.com/callstackincubator/cordierite/blob/main/docs/CI.md#release-gate-cordierite-doctor).
 - [ARCHITECTURE.md §11](https://github.com/callstackincubator/cordierite/blob/main/docs/ARCHITECTURE.md#11-react-native-sdk) — resume lease, reconnect, cancellation.
-- [`cordierite` CLI and MCP server](../cordierite/README.md).
+- [`cordierite` CLI and MCP server](https://github.com/callstackincubator/cordierite/blob/main/packages/cordierite/README.md).
 
 ## Platform compatibility
 

--- a/packages/react-native/metro.d.ts
+++ b/packages/react-native/metro.d.ts
@@ -18,8 +18,8 @@ export interface WithCordieriteOptions {
  * Wraps a Metro config so that, when `options.include` is `false`, imports of
  * `@cordierite/react-native` (and any other entry point this package exports) resolve to the
  * inert `/noop` entry instead. Chains to `config.resolver.resolveRequest` if already set, rather
- * than replacing it -- call this last, after anything else that sets `resolveRequest`. See the
- * package README's "Compiling Cordierite out of production builds" section.
+ * than replacing it -- call this last, after anything else that sets `resolveRequest`. See
+ * `docs/BUILD-VARIANTS.md`'s "Compiling Cordierite out of production builds" section.
  */
 export function withCordierite<TConfig extends Record<string, unknown>>(
   config: TConfig,

--- a/packages/react-native/metro.js
+++ b/packages/react-native/metro.js
@@ -6,7 +6,8 @@
  *
  * The native half — whether the Cordierite pod/module is compiled in at all — is decided by
  * autolinking (`docs/tasks/00-overview.md`'s "Inclusion" contract), not by this file. Neither
- * half alone removes both; see the README's "Compiling Cordierite out of production" section.
+ * half alone removes both; see `docs/BUILD-VARIANTS.md`'s "Compiling Cordierite out of production
+ * builds" section.
  */
 const { isCordieriteAutolinkEnabled } = require("./autolink-env");
 

--- a/packages/react-native/metro.js
+++ b/packages/react-native/metro.js
@@ -82,8 +82,9 @@ function deriveRedirectSpecifiers(exportsField) {
  * called twice for the same resolution. When no existing resolver is set, falls back to
  * `context.resolveRequest`, matching Metro's own default-resolver convention.
  *
- * **Call this last**, after anything else that sets `config.resolver.resolveRequest` (see the
- * README). The existing resolver is captured by reference at call time, not read lazily, so
+ * **Call this last**, after anything else that sets `config.resolver.resolveRequest` (see
+ * `docs/BUILD-VARIANTS.md`'s "JS -- swap the module at bundle time" section). The existing
+ * resolver is captured by reference at call time, not read lazily, so
  * `config.resolver.resolveRequest = myResolver` *after* `withCordierite` silently discards the
  * strip rather than erroring — there is no way to detect that misordering from in here, since a
  * later assignment to the returned config object is invisible to this function.

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -144,6 +144,6 @@ export function getCordieriteBuildConfig(): CordieriteBuildConfig {
  * `useEffect` wrapper around `registerTool`: registers on mount and whenever `deps` changes,
  * disposing the previous registration first (identity-safe — see `registerTool`'s doc comment).
  * `options.enabled` (default `true`) gates registration without breaking the rules of hooks —
- * see the README's "Define tools in app startup code" section.
+ * see `docs/SECURITY.md`'s "Gating a tool by build variant" section.
  */
 export const useCordieriteTool = createUseCordieriteTool(registerTool);

--- a/packages/react-native/src/noop.ts
+++ b/packages/react-native/src/noop.ts
@@ -1,9 +1,9 @@
 /**
  * `@cordierite/react-native/noop` — inert entry (ARCHITECTURE.md §11): identical public API to the
  * root (`.`) entry, but every operation is a no-op. Intended for release-build compile-out via Metro
- * `resolveRequest` or a conditional `require` (see the package README's "Compiling Cordierite out
- * of production" section) — swap `@cordierite/react-native` (and `/auto`) for this entry so no
- * Cordierite code, native or JS, ships in that build.
+ * `resolveRequest` or a conditional `require` (see `docs/BUILD-VARIANTS.md`'s "Compiling
+ * Cordierite out of production builds" section) — swap `@cordierite/react-native` (and `/auto`)
+ * for this entry so no Cordierite code, native or JS, ships in that build.
  *
  * Typed against the same `CordierePublicApi` interface as `./index.ts` (see
  * `__tests__/noop-parity.test.ts`) so the two cannot drift.

--- a/packages/react-native/src/useCordieriteTool.ts
+++ b/packages/react-native/src/useCordieriteTool.ts
@@ -20,8 +20,8 @@ export type UseCordieriteToolOptions = {
    * removes any existing registration owned by this hook instance), so this is the supported way
    * to gate a tool by build variant without violating the rules of hooks — put the condition in
    * the argument instead of wrapping the hook call itself, e.g.
-   * `{ enabled: process.env.EXPO_PUBLIC_CORDIERITE_TOOLS === "full" }`. See the package README's
-   * "Define tools in app startup code" section for the recommended predicate and why `__DEV__`
+   * `{ enabled: process.env.EXPO_PUBLIC_CORDIERITE_TOOLS === "full" }`. See `docs/SECURITY.md`'s
+   * "Gating a tool by build variant" section for the recommended predicate and why `__DEV__`
    * is the wrong default for anything but genuinely debug-only tools.
    */
   enabled?: boolean;

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -19,6 +19,6 @@ Like the project? ⚛️ [Join the team](https://callstack.com/careers/?utm_camp
 [license-badge]: https://img.shields.io/github/license/callstackincubator/cordierite?style=for-the-badge
 [license]: https://github.com/callstackincubator/cordierite/blob/main/LICENSE
 [prs-welcome-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=for-the-badge
-[prs-welcome]: https://github.com/callstackincubator/cordierite/blob/main/CONTRIBUTING.md
+[prs-welcome]: https://github.com/callstackincubator/cordierite/pulls
 [chat-badge]: https://img.shields.io/discord/426714625279524876.svg?style=for-the-badge
 [chat]: https://discord.gg/xgGt7KAjxv

--- a/scripts/check-md-links.mjs
+++ b/scripts/check-md-links.mjs
@@ -15,7 +15,7 @@
  * repo-relative paths so their anchors stay verified. Fenced and inline code spans are ignored so snippets can't
  * produce phantom links.
  *
- * Usage: node scripts/check-md-links.mjs [rootDir]
+ * Usage: node scripts/check-md-links.mjs   (always checks this repository)
  * Exit codes: 0 = every link resolves, 1 = at least one broken link.
  */
 
@@ -23,7 +23,17 @@ import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const ROOT = resolve(process.argv[2] ?? join(dirname(fileURLToPath(import.meta.url)), ".."));
+/**
+ * The repository this script belongs to, derived from its own location rather than from an
+ * argument: every path it reads is built from ROOT, so leaving the root under a caller's control
+ * would let the checker walk and read any tree on the machine. There is one repository to check.
+ */
+const ROOT = resolve(join(dirname(fileURLToPath(import.meta.url)), ".."));
+
+/** Whether `candidate` is ROOT itself or something beneath it. */
+function insideRoot(candidate) {
+  return candidate === ROOT || candidate.startsWith(ROOT + sep);
+}
 
 const IGNORED_DIRS = new Set([
   ".git",
@@ -242,6 +252,13 @@ for (const file of files) {
     let targetPath = anchorHome;
     if (pathPart) {
       targetPath = resolve(base, decodeURIComponent(pathPart));
+      // A relative link is allowed to point anywhere inside the repository and nowhere outside it.
+      // Without this, `](../../../../etc/passwd)` in any Markdown file would have the checker stat
+      // and — for a `.md` target — read a file that has nothing to do with this repository.
+      if (!insideRoot(targetPath)) {
+        problems.push(`${rel}:${line}  link escapes the repository: ${raw}`);
+        continue;
+      }
       let stats;
       try {
         stats = statSync(targetPath);

--- a/scripts/check-md-links.mjs
+++ b/scripts/check-md-links.mjs
@@ -113,6 +113,21 @@ function maskCode(source, { inline = true } = {}) {
 }
 
 /**
+ * Drops inline HTML tags, repeating until the text stops changing. A single pass is not enough:
+ * `<<a>script>` would come back as `<script`, because removing the inner tag re-forms an outer one
+ * — the incomplete-sanitization shape a scanner rightly objects to, even in a checker whose output
+ * only ever becomes a heading slug. Every pass strictly shortens the string, so this terminates.
+ */
+function stripTags(text) {
+  let current = text;
+  for (let previous = ""; previous !== current; ) {
+    previous = current;
+    current = current.replace(/<[^>]+>/g, "");
+  }
+  return current;
+}
+
+/**
  * GitHub's heading-slug rules: strip markdown emphasis/links, drop everything that is not a
  * word character, space or hyphen, lowercase, spaces to hyphens, then `-1`, `-2`, … for
  * repeated slugs within one document.
@@ -130,8 +145,8 @@ function slugify(headingText) {
     .replace(/!?\[([^\]]*)\]\[[^\]]*\]/g, "$1")
     .replace(/\*\*?([^*]+)\*\*?/g, "$1")
     .replace(/__?([^_]+)__?/g, "$1")
-    .replace(/~~([^~]+)~~/g, "$1")
-    .replace(/<[^>]+>/g, "")
+    .replace(/~~([^~]+)~~/g, "$1");
+  plain = stripTags(plain)
     .replace(/\u0000(\d+)\u0000/g, (_match, index) => codeSpans[Number(index)])
     .trim();
   return plain

--- a/scripts/check-md-links.mjs
+++ b/scripts/check-md-links.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+/**
+ * Markdown link checker — relative file links and heading anchors only, no network.
+ *
+ * Checks, across every tracked `.md` file in the repo:
+ *   - inline links `[text](./path/to.md#anchor)` and images `![alt](path.png)`
+ *   - reference definitions `[label]: ./path/to.md#anchor`
+ *   - reference usages `[text][label]` / `[label][]` resolve to a definition
+ *   - same-file anchors `[text](#anchor)`
+ *
+ * Absolute URLs (`https:`, `mailto:`, …) are skipped deliberately: this check must stay
+ * offline and deterministic. Fenced and inline code spans are ignored so snippets can't
+ * produce phantom links.
+ *
+ * Usage: node scripts/check-md-links.mjs [rootDir]
+ * Exit codes: 0 = every link resolves, 1 = at least one broken link.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(process.argv[2] ?? join(dirname(fileURLToPath(import.meta.url)), ".."));
+
+const IGNORED_DIRS = new Set([
+  ".git",
+  "node_modules",
+  "build",
+  "dist",
+  "coverage",
+  ".expo",
+  ".turbo",
+  "Pods",
+  "android",
+  "ios",
+]);
+
+/** Schemes that are out of scope for an offline checker. */
+const EXTERNAL = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+
+/** Collect every `.md` file under `dir`, skipping generated/vendored trees. */
+function collectMarkdown(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith(".") && entry.name !== ".github") continue;
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRS.has(entry.name)) continue;
+      collectMarkdown(full, out);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Blank out fenced code blocks and, unless `inline` is false, inline code spans — preserving
+ * line/column offsets so reported line numbers stay accurate. Heading extraction keeps inline
+ * spans, since `## \`CORDIERITE_ENABLED\`` is a real heading whose text is entirely code.
+ */
+function maskCode(source, { inline = true } = {}) {
+  const lines = source.split("\n");
+  let fence = null;
+  return lines
+    .map((line) => {
+      const fenceMatch = /^\s*(`{3,}|~{3,})/.exec(line);
+      if (fence) {
+        if (fenceMatch && fenceMatch[1][0] === fence[0] && fenceMatch[1].length >= fence.length) {
+          fence = null;
+        }
+        return " ".repeat(line.length);
+      }
+      if (fenceMatch) {
+        fence = fenceMatch[1];
+        return " ".repeat(line.length);
+      }
+      return inline ? line.replace(/`[^`]*`/g, (span) => " ".repeat(span.length)) : line;
+    })
+    .join("\n");
+}
+
+/**
+ * GitHub's heading-slug rules: strip markdown emphasis/links, drop everything that is not a
+ * word character, space or hyphen, lowercase, spaces to hyphens, then `-1`, `-2`, … for
+ * repeated slugs within one document.
+ */
+function slugify(headingText) {
+  // Code spans render literally, so their contents must survive emphasis stripping:
+  // `## \`CORDIERITE_ENABLED\`` slugs to `cordierite_enabled`, underscore intact.
+  const codeSpans = [];
+  let plain = headingText.replace(/`([^`]*)`/g, (_match, inner) => {
+    codeSpans.push(inner);
+    return `\u0000${codeSpans.length - 1}\u0000`;
+  });
+  plain = plain
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/!?\[([^\]]*)\]\[[^\]]*\]/g, "$1")
+    .replace(/\*\*?([^*]+)\*\*?/g, "$1")
+    .replace(/__?([^_]+)__?/g, "$1")
+    .replace(/~~([^~]+)~~/g, "$1")
+    .replace(/<[^>]+>/g, "")
+    .replace(/\u0000(\d+)\u0000/g, (_match, index) => codeSpans[Number(index)])
+    .trim();
+  return plain
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\p{M}\s_-]/gu, "")
+    // One hyphen per space, not per run — GitHub keeps the gap left by removed punctuation.
+    .replace(/\s/g, "-");
+}
+
+/** Every anchor a GitHub-rendered version of this file would expose. */
+function anchorsOf(source) {
+  const anchors = new Set();
+  const seen = new Map();
+  for (const line of maskCode(source, { inline: false }).split("\n")) {
+    const heading = /^(#{1,6})\s+(.*?)\s*#*\s*$/.exec(line);
+    if (!heading) continue;
+    const base = slugify(heading[2]);
+    if (!base) continue;
+    const count = seen.get(base) ?? 0;
+    seen.set(base, count + 1);
+    anchors.add(count === 0 ? base : `${base}-${count}`);
+  }
+  // Explicit anchors authored as HTML, e.g. `<a id="foo"></a>`.
+  for (const match of source.matchAll(/<a\s+(?:id|name)=["']([^"']+)["']/g)) {
+    anchors.add(match[1].toLowerCase());
+  }
+  return anchors;
+}
+
+const files = collectMarkdown(ROOT).sort();
+const anchorCache = new Map();
+
+function anchorsForFile(path) {
+  if (!anchorCache.has(path)) {
+    try {
+      anchorCache.set(path, anchorsOf(readFileSync(path, "utf8")));
+    } catch {
+      anchorCache.set(path, null);
+    }
+  }
+  return anchorCache.get(path);
+}
+
+function lineOf(source, index) {
+  return source.slice(0, index).split("\n").length;
+}
+
+const problems = [];
+
+for (const file of files) {
+  const source = readFileSync(file, "utf8");
+  const masked = maskCode(source);
+  const here = dirname(file);
+  const rel = relative(ROOT, file);
+
+  const definitions = new Map();
+  for (const match of masked.matchAll(/^[ \t]{0,3}\[([^\]^][^\]]*)\]:[ \t]*(\S+)/gm)) {
+    definitions.set(match[1].trim().toLowerCase(), {
+      target: match[2],
+      index: match.index,
+    });
+  }
+
+  /** @type {{target: string, index: number}[]} */
+  const targets = [];
+
+  // Inline links and images: [text](target) / ![alt](target). Nested parens in the label are
+  // tolerated; the destination itself may be wrapped in <>.
+  for (const match of masked.matchAll(/!?\[(?:[^\]\\]|\\.)*\]\(\s*(<[^>]*>|[^()\s]*)(?:\s+"[^"]*")?\s*\)/g)) {
+    targets.push({ target: match[1].replace(/^<|>$/g, ""), index: match.index });
+  }
+
+  // Reference definitions.
+  for (const [, def] of definitions) {
+    targets.push(def);
+  }
+
+  // Reference usages must point at a definition that exists.
+  for (const match of masked.matchAll(/(?<!\!)\[((?:[^\]\\]|\\.)+)\]\[((?:[^\]\\]|\\.)*)\]/g)) {
+    const label = (match[2].trim() || match[1].trim()).toLowerCase();
+    if (!definitions.has(label)) {
+      problems.push(`${rel}:${lineOf(source, match.index)}  undefined link reference [${label}]`);
+    }
+  }
+
+  for (const { target, index } of targets) {
+    const raw = target.trim();
+    if (!raw || EXTERNAL.test(raw)) continue;
+
+    const line = lineOf(source, index);
+    const hashAt = raw.indexOf("#");
+    const pathPart = hashAt === -1 ? raw : raw.slice(0, hashAt);
+    const anchor = hashAt === -1 ? "" : decodeURIComponent(raw.slice(hashAt + 1)).toLowerCase();
+
+    let targetPath = file;
+    if (pathPart) {
+      targetPath = resolve(here, decodeURIComponent(pathPart));
+      let stats;
+      try {
+        stats = statSync(targetPath);
+      } catch {
+        problems.push(`${rel}:${line}  missing target: ${raw}`);
+        continue;
+      }
+      if (stats.isDirectory()) {
+        // A directory link is fine on its own; only a README inside it can carry an anchor.
+        if (!anchor) continue;
+        targetPath = join(targetPath, "README.md");
+        try {
+          statSync(targetPath);
+        } catch {
+          problems.push(`${rel}:${line}  anchor on a directory without README.md: ${raw}`);
+          continue;
+        }
+      }
+    }
+
+    if (!anchor) continue;
+    if (!targetPath.endsWith(".md")) continue;
+
+    const anchors = anchorsForFile(targetPath);
+    if (!anchors) {
+      problems.push(`${rel}:${line}  unreadable target: ${raw}`);
+    } else if (!anchors.has(anchor)) {
+      problems.push(
+        `${rel}:${line}  missing anchor "#${anchor}" in ${relative(ROOT, targetPath).split(sep).join("/")}`,
+      );
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error(`Broken Markdown links (${problems.length}):\n`);
+  for (const problem of problems) console.error(`  ${problem}`);
+  console.error("");
+  process.exit(1);
+}
+
+console.log(`check:links — ${files.length} Markdown files, no broken relative links or anchors.`);

--- a/scripts/check-md-links.mjs
+++ b/scripts/check-md-links.mjs
@@ -136,9 +136,13 @@ function anchorsOf(source) {
   const anchors = new Set();
   const seen = new Map();
   for (const line of maskCode(source, { inline: false }).split("\n")) {
-    const heading = /^(#{1,6})\s+(.*?)\s*#*\s*$/.exec(line);
+    const heading = /^(#{1,6})\s+(.*)$/.exec(line);
     if (!heading) continue;
-    const base = slugify(heading[2]);
+    // The optional closing sequence (`## Title ##`) is stripped with plain string operations
+    // rather than a trailing `\s*#*\s*$` in the pattern above: two whitespace repetitions either
+    // side of a nullable one backtrack quadratically on a heading that is mostly spaces, and this
+    // runs over every line of every Markdown file in the repo.
+    const base = slugify(heading[2].trimEnd().replace(/#+$/, "").trimEnd());
     if (!base) continue;
     const count = seen.get(base) ?? 0;
     seen.set(base, count + 1);
@@ -189,8 +193,10 @@ for (const file of files) {
   const targets = [];
 
   // Inline links and images: [text](target) / ![alt](target). Nested parens in the label are
-  // tolerated; the destination itself may be wrapped in <>.
-  for (const match of masked.matchAll(/!?\[(?:[^\]\\]|\\.)*\]\(\s*(<[^>]*>|[^()\s]*)(?:\s+"[^"]*")?\s*\)/g)) {
+  // tolerated; the destination itself may be wrapped in <>. An optional title is matched as
+  // `"…"` followed by its own trailing whitespace — a leading `\s+` there would be ambiguous
+  // with the `\s*` before `)` and backtrack quadratically on a run of spaces that never closes.
+  for (const match of masked.matchAll(/!?\[(?:[^\]\\]|\\.)*\]\(\s*(<[^>]*>|[^()\s]*)\s*(?:"[^"]*"\s*)?\)/g)) {
     targets.push({ target: match[1].replace(/^<|>$/g, ""), index: match.index });
   }
 

--- a/scripts/check-md-links.mjs
+++ b/scripts/check-md-links.mjs
@@ -7,9 +7,12 @@
  *   - reference definitions `[label]: ./path/to.md#anchor`
  *   - reference usages `[text][label]` / `[label][]` resolve to a definition
  *   - same-file anchors `[text](#anchor)`
+ *   - empty destinations `[text]()`
  *
  * Absolute URLs (`https:`, `mailto:`, …) are skipped deliberately: this check must stay
- * offline and deterministic. Fenced and inline code spans are ignored so snippets can't
+ * offline and deterministic — except this repository's own `blob/main` / `tree/main` URLs, which
+ * package READMEs must use (a relative path 404s on npmjs.com) and which are rewritten back to
+ * repo-relative paths so their anchors stay verified. Fenced and inline code spans are ignored so snippets can't
  * produce phantom links.
  *
  * Usage: node scripts/check-md-links.mjs [rootDir]
@@ -45,12 +48,17 @@ const EXTERNAL = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
  * link; nothing is fetched.
  */
 const SELF_BLOB =
-  /^https:\/\/github\.com\/callstackincubator\/cordierite\/blob\/main\/(.+)$/i;
+  /^https:\/\/(?:www\.)?github\.com\/callstackincubator\/cordierite\/(?:blob|tree)\/main(?:\/(.*)|(#.*))?$/i;
 
-/** Repo-relative form of a self-referencing blob URL, or null if it is a genuinely external one. */
+/**
+ * Repo-relative form of a self-referencing URL, or null if it is a genuinely external one.
+ * Returns "" for a link at the repository root (`.../tree/main`, or `.../blob/main/#anchor`),
+ * which callers resolve against the repo root rather than against the linking file.
+ */
 function selfRelative(url) {
   const match = SELF_BLOB.exec(url);
-  return match ? match[1] : null;
+  if (!match) return null;
+  return match[1] ?? match[2] ?? "";
 }
 
 /** Collect every `.md` file under `dir`, skipping generated/vendored trees. */
@@ -204,10 +212,18 @@ for (const file of files) {
     // A link into this repo's own tree is checkable even when written absolutely.
     const selfPath = selfRelative(raw);
     let base = here;
+    // Where a bare `#anchor` resolves: the linking file normally, the repo's root README for a
+    // rewritten self-link that carried no path of its own.
+    let anchorHome = file;
     if (selfPath !== null) {
       raw = selfPath;
       base = ROOT;
-    } else if (!raw || EXTERNAL.test(raw)) {
+      anchorHome = join(ROOT, "README.md");
+    } else if (EXTERNAL.test(raw)) {
+      continue;
+    } else if (!raw) {
+      // `[text]()` renders as a link that goes nowhere — almost always a dropped destination.
+      problems.push(`${rel}:${lineOf(source, index)}  empty link destination`);
       continue;
     }
     if (!raw) continue;
@@ -217,7 +233,7 @@ for (const file of files) {
     const pathPart = hashAt === -1 ? raw : raw.slice(0, hashAt);
     const anchor = hashAt === -1 ? "" : decodeURIComponent(raw.slice(hashAt + 1)).toLowerCase();
 
-    let targetPath = file;
+    let targetPath = anchorHome;
     if (pathPart) {
       targetPath = resolve(base, decodeURIComponent(pathPart));
       let stats;

--- a/scripts/check-md-links.mjs
+++ b/scripts/check-md-links.mjs
@@ -38,6 +38,21 @@ const IGNORED_DIRS = new Set([
 /** Schemes that are out of scope for an offline checker. */
 const EXTERNAL = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
 
+/**
+ * Package READMEs published to npm must link to docs by absolute URL — a relative `../../docs/…`
+ * 404s on npmjs.com, which renders the README outside the repo tree. Those URLs still name files
+ * in THIS repository, so rewrite them back to repo-relative paths and check them like any other
+ * link; nothing is fetched.
+ */
+const SELF_BLOB =
+  /^https:\/\/github\.com\/callstackincubator\/cordierite\/blob\/main\/(.+)$/i;
+
+/** Repo-relative form of a self-referencing blob URL, or null if it is a genuinely external one. */
+function selfRelative(url) {
+  const match = SELF_BLOB.exec(url);
+  return match ? match[1] : null;
+}
+
 /** Collect every `.md` file under `dir`, skipping generated/vendored trees. */
 function collectMarkdown(dir, out = []) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -185,8 +200,17 @@ for (const file of files) {
   }
 
   for (const { target, index } of targets) {
-    const raw = target.trim();
-    if (!raw || EXTERNAL.test(raw)) continue;
+    let raw = target.trim();
+    // A link into this repo's own tree is checkable even when written absolutely.
+    const selfPath = selfRelative(raw);
+    let base = here;
+    if (selfPath !== null) {
+      raw = selfPath;
+      base = ROOT;
+    } else if (!raw || EXTERNAL.test(raw)) {
+      continue;
+    }
+    if (!raw) continue;
 
     const line = lineOf(source, index);
     const hashAt = raw.indexOf("#");
@@ -195,7 +219,7 @@ for (const file of files) {
 
     let targetPath = file;
     if (pathPart) {
-      targetPath = resolve(here, decodeURIComponent(pathPart));
+      targetPath = resolve(base, decodeURIComponent(pathPart));
       let stats;
       try {
         stats = statSync(targetPath);

--- a/skills/cordierite/SKILL.md
+++ b/skills/cordierite/SKILL.md
@@ -41,16 +41,19 @@ If no session is active yet, mint a bootstrap link. Requires a deep-link scheme;
 cordierite link --scheme myapp --json
 ```
 
-If the project has no daemon key yet, generate one first — this is non-interactive and
-safe to run from an agent or script:
+You do not need to create a key first: the daemon generates one on its first start, and
+`cordierite link` carries its fingerprint on the deep link for an app with no `cliPins`
+configured to trust for that session.
+
+To generate one explicitly — non-interactive and safe to run from an agent or script:
 
 ```bash
 cordierite keygen --out ~/.cordierite/key.pem
 ```
 
-Add the printed `sha256/...` fingerprint to the app's `cliPins` (see **Setup** below if
-you are wiring Cordierite into an app for the first time — that step needs a native
-rebuild, so it isn't a fast in-session action).
+Adding the printed `sha256/...` fingerprint to the app's `cliPins` is what switches a build
+to pinned trust (see **Setup** below if you are wiring Cordierite into an app for the first
+time — that step needs a native rebuild, so it isn't a fast in-session action).
 
 From `link`'s JSON output, use:
 

--- a/skills/cordierite/references/setup.md
+++ b/skills/cordierite/references/setup.md
@@ -30,9 +30,13 @@ Use this file when the task is to add Cordierite to a new React Native project.
 8. Advanced: use `getCordieriteState()` / `addCordieriteListener("stateChange", ...)` for
    manual connection-state UI.
 9. Production builds that shouldn't ship Cordierite at all should be built with
-   `CORDIERITE_ENABLED=0`, which drops the native module and swaps the JS entries for
-   `@cordierite/react-native/noop` (see `docs/BUILD-VARIANTS.md`), rather than relying on
-   a runtime flag.
+   `CORDIERITE_ENABLED=0` rather than gated by a runtime flag. That variable drops the
+   native module on its own.
+10. To strip Cordierite's JS as well, wrap the app's Metro config in the
+   `withCordierite` helper from `@cordierite/react-native/metro` (call it last, after
+   anything else that sets `resolver.resolveRequest`). Without that wiring the real JS
+   entry is still bundled; it just finds no native module and goes inert. See
+   `docs/BUILD-VARIANTS.md`.
 
 ## Expo
 

--- a/skills/cordierite/references/setup.md
+++ b/skills/cordierite/references/setup.md
@@ -16,25 +16,31 @@ Use this file when the task is to add Cordierite to a new React Native project.
    custom deep-link handling, QR scanning, tests — skip that entry, use the
    side-effect-free root entry, and call `restoreSession()` at startup before your own
    bootstrap handling so a Metro reload still recovers the session.)
-5. Generate a TLS private key for the daemon. For a new setup, run `cordierite keygen`
-   (non-interactive with `--out <path>`; writes `~/.cordierite/key.pem` by default).
-6. Add the matching `sha256/...` SPKI pin to the app configuration, in a `cliPins` array
-   (plural — the native clients accept a pin *set*, which is what makes future rotation
-   non-breaking). Use the fingerprint printed by `cordierite keygen`.
+5. Optional, for pinned trust: generate a TLS private key for the daemon with
+   `cordierite keygen` (non-interactive with `--out <path>`; writes `~/.cordierite/key.pem`
+   by default). Skipping this is fine — the daemon generates its own key on first start and
+   `cordierite link` carries the fingerprint on the deep link.
+6. If you generated a key in step 5, add its `sha256/...` SPKI pin to the app
+   configuration, in a `cliPins` array (plural — the native clients accept a pin *set*,
+   which is what makes future rotation non-breaking). Configuring `cliPins` switches the
+   build to `trust: "pin"`, so the link-carried pin is ignored from then on
+   (`docs/SECURITY.md`, "Trust modes").
 7. Optional: use `addCordieriteListener("error", ...)` to observe bootstrap parse
    failures, connect failures, or socket errors — one unified channel for all of them.
 8. Advanced: use `getCordieriteState()` / `addCordieriteListener("stateChange", ...)` for
    manual connection-state UI.
-9. Production builds that shouldn't ship Cordierite at all should import
-   `@cordierite/react-native/noop` instead (see the package README's compile-out
-   recipe) rather than relying on a runtime flag.
+9. Production builds that shouldn't ship Cordierite at all should be built with
+   `CORDIERITE_ENABLED=0`, which drops the native module and swaps the JS entries for
+   `@cordierite/react-native/noop` (see `docs/BUILD-VARIANTS.md`), rather than relying on
+   a runtime flag.
 
 ## Expo
 
 1. Add `@cordierite/react-native` to the app dependencies.
-2. Add the Cordierite Expo config plugin to the Expo config with `cliPins` (required)
-   and, optionally, `allowPrivateLanOnly` (defaults to `true`, fail-closed) and
-   `deepLinkScheme`.
+2. Optional: add the Cordierite Expo config plugin to the Expo config. `cliPins` is
+   required only when `trust: "pin"` is set or implied; `trust`, `allowPrivateLanOnly`
+   (defaults to `true`, fail-closed) and `deepLinkScheme` are optional. A zero-config app
+   can skip the plugin entry entirely (`docs/SECURITY.md`, "Configuring trust").
 3. Make sure `deepLinkScheme` (or `expo.scheme`) matches the scheme you'll pass to
    `cordierite link --scheme ...` (or set once in `~/.cordierite/config.json`'s
    `"scheme"` field).
@@ -45,8 +51,8 @@ Use this file when the task is to add Cordierite to a new React Native project.
 
 1. Add `@cordierite/react-native` to the app dependencies.
 2. Run the normal native dependency installation steps for the project.
-3. Add the trusted daemon pins to native configuration on iOS and Android (see the
-   package README's "Bare React Native — native keys" table).
+3. For pinned trust, add the trusted daemon pins to native configuration on iOS and
+   Android (see `docs/SECURITY.md`'s "Bare React Native — native keys" table).
 4. Add the optional private-LAN-only setting only if the project wants that restriction.
 5. Configure URL schemes / intent filters so bootstrap links (`{scheme}:///?cordierite=…`)
    open your app.
@@ -55,7 +61,8 @@ Use this file when the task is to add Cordierite to a new React Native project.
 ## Final check
 
 - The daemon (`~/.cordierite/key.pem` by default) has a readable, `0600` private key.
-- The app trusts the daemon's current pin in `cliPins`.
+- The app trusts the daemon's current pin — via `cliPins` for a pinned build, or via the
+  link-carried pin when no `cliPins` are configured.
 - The app has at least one registered tool.
 - The app scheme matches the scheme `cordierite link` will use to compose the deep link.
 - `cordierite ls` (or `cordierite_connect` + `cordierite_wait_for_session` over MCP)


### PR DESCRIPTION
The package READMEs now open with a five-minute path — install, configure nothing, register a tool, link, invoke — and the long-form hardening prose moved into `docs/`. This is a move, not a rewrite: every fact has a new home, and where two copies disagreed the code decided.

## Word counts (`wc -w`, before → after)

| File | Before | After |
| --- | --- | --- |
| `packages/react-native/README.md` | 4219 | **1189** |
| `packages/cordierite/README.md` | 1942 | **1608** |
| `README.md` | 829 | 844 |
| `docs/SECURITY.md` | 3081 | 3842 |
| `docs/CI.md` | 1656 | 2083 |
| `docs/BUILD-VARIANTS.md` | — | 1864 (new) |
| `docs/ARCHITECTURE.md` | 4032 | 4110 |
| `skills/cordierite/SKILL.md` | 1070 | 1108 |
| `skills/cordierite/references/setup.md` | 499 | 619 |

`packages/react-native/README.md` is under the 1 200-word target with headroom. Paragraphs in the moved prose are capped at roughly 80 words, one idea each, with tables for the option matrices.

## Where each section moved

**`packages/react-native/README.md` → `docs/SECURITY.md`** (merged into the existing "Trust modes", not duplicated beside it):

- the Expo config-plugin options, now an option matrix table (`cliPins`, `trust`, `allowPrivateLanOnly`, `deepLinkScheme`)
- "Bare React Native — native keys": both the iOS `Info.plist` and Android meta-data tables
- `allowPrivateLanOnly` semantics, plus the note that JS can only narrow what native allows
- `trust: "pin"` requires non-empty `cliPins`, refused at config time and again natively
- `getCordieriteBuildConfig()` → "Reading the effective configuration at runtime"
- the native-module-absent degradation → "What a build without the native module does"
- "Gating a tool by build variant" — the `enabled` recipe, why `__DEV__` is the wrong predicate, and the `tools/list`-differs-per-artifact consequence. SECURITY.md already referenced this section by name; that reference is now internal.

**`packages/react-native/README.md` → `docs/BUILD-VARIANTS.md`** (new):

- the inclusion contract: iOS `:configurations`, the Android `PackageList.java` constraint and source-set swap, and that neither platform has a build-type check in its code path
- the `CORDIERITE_ENABLED` × variant matrix, accepted values, the "must be set when autolinking resolves" rule, and the keyed-by-name caveat
- "Compiling Cordierite out of production builds", "Excluding it permanently, without the environment variable" (including `expo.autolinking` being read from `package.json` only, `apple` overriding `ios`, and the iOS codegen coupling), and "JS — swap the module at bundle time"

**`packages/react-native/README.md` → `docs/ARCHITECTURE.md` §11** — only the client-behavior facts §11 did not already state: runtime URLs parsing the payload and calling `connect` when idle (so no `Linking` handler is needed), `1011 send_failed` / `1001 daemon_shutdown` as retryable transport closes, the extra `1008` reasons, and `cordieriteClient.restoreSession()`.

**`packages/cordierite/README.md` → `docs/CI.md`** — the `doctor` internals: what it inspects per platform, the full exit-code table (including `64`, which only existed in the README), the invert-for-testing-builds note, and the Android detection writeup (marker-only verdict, the three signals in reliability order, the R8 verification and what is still unmeasured).

`docs/SECURITY.md`'s two "Production guidance" bullets that restated the inclusion and compile-out mechanisms are condensed to their security-relevant framing plus links, so each mechanism has exactly one home.

## Discrepancies found (code checked; the code won)

1. **`packages/cordierite/README.md`: "a release build with the module enabled never accepts it, embedded pins only."** False. `resolveTrustedPins` (`CordieriteConnectionManager.kt`, and its iOS twin) consults no build-type signal at all: with no embedded pins the resolution is `LinkPin` in *any* variant. Corrected to "a build with no embedded pins trusts it for that one session", matching `docs/SECURITY.md`.
2. **Same file: key setup described as skippable "for a debug build".** Skippable for any build with no `cliPins` configured — the zero-config default. Corrected.
3. **Both of the above pointed at `docs/SECURITY.md`'s "Dev trust mode" section, which does not exist** (the section is "Trust modes"). Fixed.
4. **RN README's entry table claimed importing never crashes but "only calling a native-requiring function like `connect()` without native support does, with an actionable error."** This contradicted the same file's hardening bullet and `default-client.ts`/`noop.ts`: `noopIfNativeUnavailable` warns once and delegates to `/noop`, so nothing throws and `connect()` rejects with `CordieriteDisabledError`. The true statement is kept.
5. **`skills/.../setup.md` listed `cliPins` as required for the Expo plugin and keygen as a mandatory step.** `app.plugin.js` requires `cliPins` only when `trust: "pin"` is set or implied, and the daemon generates its own key. Corrected to present pinning as opt-in, with the `cliPins` → `trust: "pin"` consequence spelled out.
6. **`README.md` and `packages/react-native/README.md` PRs-welcome badges pointed at `./CONTRIBUTING.md`, which does not exist in this repo** (`packages/shared/README.md` had the same dead target as an absolute URL). All three now point at the repository's pull requests.
7. **`CORDIERITE_ENABLED`'s "any other value is a config error, raised at prebuild" was Expo-only.** `react-native.config.js:38-51` swallows the parse error and falls back to linking into *every* build, while `android/build.gradle:55` treats anything but `1`/`true` as off and compiles the `release` stub — so the platforms disagree and a bare-RN pipeline gets no error at all. Documented, with `cordierite doctor` named as the check that actually holds.
8. **Not fixed — `packages/react-native/src/Cordierite.types.ts:57-63`** still documents `linkPin` as trusted only "when built in debug mode with no build-time `cliPins`", and says "release builds without pins keep the existing hard error". That contradicts `resolveTrustedPins` and every document here. Stale JSDoc with no behavioural effect; flagged rather than changed, since a `.types.ts` edit is outside this PR's scope.

Smaller corrections while moving: the Metro snippet called `getDefaultConfig(__dirname)` twice and left `config` unused (now `withCordierite(config)`); `CORDIERITE_ENABLED=0` was described as stripping the JS unconditionally when it does so only once `withCordierite` is wired into `metro.config.js`; and `{ include: <your own predicate> }` was wrong, since `include` is a `boolean` (`metro.d.ts:14`) and a function would always be truthy.

## Link check

`scripts/check-md-links.mjs`, wired as the root `check:links` script and run in `lint.yaml` after `pnpm lint`. Dependency-free and offline: it validates inline links, reference definitions and usages, heading anchors (GitHub slug rules, including duplicate-heading suffixes) and empty `[text]()` destinations across every `.md` file, masking fenced blocks and inline code spans so snippets can't produce phantom links. Absolute URLs are skipped, except this repository's own `blob/main` and `tree/main` URLs (with or without `www.`), which are rewritten to local paths so the package READMEs' npm-safe absolute links stay verified; a rewritten URL carrying only a fragment resolves against the root README rather than the linking file.

```
check:links — 27 Markdown files, no broken relative links or anchors.
```

It was validated against fixtures covering each of those cases, and it found all three dead `CONTRIBUTING.md` links listed above.

## Review findings and resolutions

Two adversarial review rounds against `origin/main...HEAD`. Nothing was dismissed.

### Round 1

1. **Five-minute path broke at `cordierite link --qr`** — `mintLink` (`link.ts:73-78`) errors without a scheme. *Fixed:* both READMEs now show `--scheme myapp` and say the scheme comes from `--scheme` (matching `expo.scheme`) or `~/.cordierite/config.json`, consistent with the skill.
2. **`skills/.../setup.md` claimed `CORDIERITE_ENABLED=0` swaps the JS entries for `/noop`** — it does so only via `withCordierite`. *Fixed:* the skill splits this into two steps and names the Metro helper; the precondition is now stated at the top of `docs/BUILD-VARIANTS.md` and in its compile-out section, not only in the Metro section, and in `docs/SECURITY.md`'s compile-out bullet.
3. **Getting-started no longer predicted a default Release build carrying no Cordierite.** *Fixed:* one line in the RN getting-started, linking to `docs/BUILD-VARIANTS.md`.
4. **RN README used `../../docs/…` links that 404 on npmjs.com** (no `repository.directory`). *Fixed:* absolute URLs, matching `packages/cordierite/README.md`. The link checker was extended to resolve those URLs locally so anchor coverage did not regress.
5. **RN README was 1201 words against a sub-1200 target.** *Fixed.*
6. **`check:links` not wired into CI.** *Fixed:* a step in `lint.yaml` after `pnpm lint`; existing action SHA pins untouched.
7. **Source comments pointing at removed README sections** (`src/noop.ts`, `metro.js`, `metro.d.ts`). *Fixed:* they name `docs/BUILD-VARIANTS.md`'s "Compiling Cordierite out of production builds". Comment-only edits in an otherwise docs-only PR. `CHANGELOG.md` and `docs/tasks/` history untouched.
8. **Nits.** All fixed: `docs/SECURITY.md`'s compile-out link text now matches its target; the ~106-word bullet split into three paragraphs; `docs/BUILD-VARIANTS.md` no longer restates the per-platform inclusion mechanism twice.

### Round 2

1. **`packages/react-native/README.md:127` lost the word "unified"** from "one unified channel" in an earlier word trim. *Fixed*, and the budget was recovered elsewhere.
2. **`docs/BUILD-VARIANTS.md`: "Any other value is a config error, raised at prebuild" is Expo-only.** *Fixed* — see discrepancy 7 above: the two platforms disagree on a bad value, bare-RN pipelines get no error, and `cordierite doctor` is named as the real check.
3. **A local `npm install cordierite` leaves a bare `cordierite link` off PATH.** *Fixed:* both package READMEs use `npm install -g cordierite`, consistent with the root README.
4. **`packages/react-native/metro.js:86`'s "(see the README)" pointed nowhere.** *Fixed:* it names `docs/BUILD-VARIANTS.md`'s "JS — swap the module at bundle time" section.
5. **`src/useCordieriteTool.ts:23-25` and `src/index.ts:147` pointed at "Define tools in app startup code" for the `__DEV__` argument**, whose content moved. *Fixed:* both name `docs/SECURITY.md`'s "Gating a tool by build variant". (These two were deliberately left in round 1 because the heading still existed; the *content* they cite does not live there any more, so they are now updated too.)
6. **Remaining relative links in the package READMEs 404 on npm** — `../cordierite/README.md`, and `packages/cordierite/README.md`'s `src/index.ts`, sibling-package and monorepo links (`src/index.ts` is not even in the published files). *Fixed:* every one is an absolute URL; no relative link remains in any package README.
7. **`{ include: <your own predicate> }` was wrong** — `include` is a boolean. *Fixed:* "pass `{ include: yourCondition }` with a boolean you compute yourself — `include` is a boolean, not a callback."
8. **Link checker coverage.** *Fixed:* it now rewrites `tree/main` and `www.` forms of this repo's self-links, flags empty `[text]()` destinations, and resolves a fragment-only rewritten URL against the repo root instead of the linking file. Still dependency-free; verified against fixtures for each case.
9. **`docs/CI.md`'s summary of what `doctor` inspects** listed the Android signals as equals. *Fixed:* it names `CordieriteNativeMarker` as the deciding signal and says the dex package and manifest keys are reported but cannot flip the verdict, matching the detection section below it.
10. **Word-count headroom.** *Fixed:* 1189 words.

## Coverage audit

Every sentence of both original READMEs was matched against the post-change corpus by token overlap, and each low-scoring hit reviewed by hand. One genuine gap surfaced and was fixed: the handler `AbortSignal` can also be observed via `signal.aborted` or an `"abort"` listener, not only by forwarding it. Everything else was paraphrase or a sentence-splitter artefact.

## Validation

`pnpm check:links` passes. `pnpm build` succeeds. `@cordierite/react-native` — the only package whose source this PR touches, and only in comments — passes its full suite (212 tests). The `cordierite` package reports 14 failures in four files (`daemon.test.ts`, `rpc-client.test.ts`, `daemon-cli.integration.test.ts`, `daemon-restart.e2e.test.ts`), all daemon tests failing at `httpsServer.listen()` in a sandbox that cannot bind the listener; no file under `packages/cordierite/src` is touched by this PR.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkzpDHexc8EuFfsFf8yQyh