### PR TITLE
feat(react-native): accept paired and raw JSON Schema tool schemas; dev error when no exporter (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@ package versions for a release.
   a Standard Schema (as before); a `{ schema, jsonSchema }` pair, where `jsonSchema` is a JSON
   Schema object or an `{ input, output }` converter — the supported path for zod 3
   (`zod-to-json-schema`) and valibot (`@valibot/to-json-schema`); or a raw JSON Schema object,
-  detected by the absence of `~standard`, published verbatim and passed to the handler
-  unvalidated. Handler argument/result inference is unchanged for zod 4, follows the pair's
+  detected by the absence of `~standard` and required to carry at least one JSON Schema
+  keyword (`type`, `properties`, `$ref`, `anyOf`, `allOf`, `oneOf`, `enum`, `const`),
+  published verbatim and passed to the handler unvalidated. A Standard Schema may be an
+  object or a callable, so arktype's `Type` is accepted. Anything that is none of the three
+  — including an object mentioning `schema`/`jsonSchema` that is not a valid pair — throws a
+  `TypeError` at registration instead of being published as the tool's shape. Handler argument/result inference is unchanged for zod 4, follows the pair's
   `schema` for pairs, and is `Record<string, unknown>` for a bare raw schema or `T` when
   tagged with the new type-level `jsonSchema<T>()` helper. No runtime dependency was added:
   Cordierite still bundles no JSON Schema validator, which is why a raw schema is not enforced.
@@ -29,10 +33,13 @@ package versions for a release.
   `__DEV__`.** `registerTool`/`useCordieriteTool` used to accept a bare zod 3 or plain valibot
   schema, emit a dev warning, and register the tool with no schema at all — a silent failure,
   since the tool looked registered but no agent could work out what to pass it. That case now
-  throws a `TypeError` naming the two supported forms above. **Release builds are unaffected
-  in kind**: the tool still registers without a schema, now with one `console.warn` per tool
-  name (previously dev-only), so an app already shipping such a tool is not broken by
-  upgrading. Fix by pairing the schema with a JSON Schema, or passing raw JSON Schema.
+  throws a `TypeError` naming the two supported forms above. The same applies to every other
+  way a slot can end up shapeless, which previously all returned quietly: an exporter or a
+  paired converter that throws, or that returns something other than a JSON Schema object.
+  **Release builds are unaffected in kind**: the tool still registers without a schema, now
+  with one `console.warn` per tool name (previously dev-only), so an app already shipping
+  such a tool is not broken by upgrading. Fix by pairing the schema with a JSON Schema, or
+  passing raw JSON Schema.
 - **Type change:** `CordieriteRuntimeSchema` is now a union of the three accepted forms rather
   than an alias for `StandardSchemaV1`, and `CordieriteRegisteredTool.inputSchema`/
   `.outputSchema` hold the normalized `CordieriteNormalizedToolSchema` rather than the raw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@ package versions for a release.
   a Standard Schema (as before); a `{ schema, jsonSchema }` pair, where `jsonSchema` is a JSON
   Schema object or an `{ input, output }` converter — the supported path for zod 3
   (`zod-to-json-schema`) and valibot (`@valibot/to-json-schema`); or a raw JSON Schema object,
-  detected by the absence of `~standard` and required to carry at least one JSON Schema
-  keyword (`type`, `properties`, `$ref`, `anyOf`, `allOf`, `oneOf`, `enum`, `const`),
-  published verbatim and passed to the handler unvalidated. A Standard Schema may be an
-  object or a callable, so arktype's `Type` is accepted. Anything that is none of the three
-  — including an object mentioning `schema`/`jsonSchema` that is not a valid pair — throws a
-  `TypeError` at registration instead of being published as the tool's shape. Handler argument/result inference is unchanged for zod 4, follows the pair's
+  detected by the absence of `~standard` and required to be a plain object whose `type`, if
+  present, is a JSON Schema type name, published verbatim and passed to the handler
+  unvalidated. A Standard Schema may be an object or a callable, so arktype's `Type` is
+  accepted. Anything that is none of the three — a class instance, an object mentioning
+  `schema`/`jsonSchema` that is not a valid pair — throws a `TypeError` at registration
+  instead of being published as the tool's shape. Handler argument/result inference is unchanged for zod 4, follows the pair's
   `schema` for pairs, and is `Record<string, unknown>` for a bare raw schema or `T` when
   tagged with the new type-level `jsonSchema<T>()` helper. No runtime dependency was added:
   Cordierite still bundles no JSON Schema validator, which is why a raw schema is not enforced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ This file is maintained by hand. There is no automated changelog tooling (see
 `docs/CI.md#release-policy` for why) — update this file as part of the commit that bumps the
 package versions for a release.
 
+## Unreleased
+
+- **New: `inputSchema`/`outputSchema` accept a `{ schema, jsonSchema }` pair and raw JSON
+  Schema objects.** Previously a tool schema had to be a Standard Schema *and* implement the
+  non-standard `~standard.jsonSchema` exporter to give agents a real shape; zod 3 and plain
+  valibot implement the first but not the second, so those tools registered with no
+  `input_schema` and reached the agent as `{ type: "object", additionalProperties: true }`.
+  Standard Schema remains the only runtime-validation contract, but the two slots now accept:
+  a Standard Schema (as before); a `{ schema, jsonSchema }` pair, where `jsonSchema` is a JSON
+  Schema object or an `{ input, output }` converter — the supported path for zod 3
+  (`zod-to-json-schema`) and valibot (`@valibot/to-json-schema`); or a raw JSON Schema object,
+  detected by the absence of `~standard`, published verbatim and passed to the handler
+  unvalidated. Handler argument/result inference is unchanged for zod 4, follows the pair's
+  `schema` for pairs, and is `Record<string, unknown>` for a bare raw schema or `T` when
+  tagged with the new type-level `jsonSchema<T>()` helper. No runtime dependency was added:
+  Cordierite still bundles no JSON Schema validator, which is why a raw schema is not enforced.
+  The wire `ToolDescriptor` is unchanged, so this is app-side only.
+- **Breaking (development only): a Standard Schema that exports no JSON Schema now throws in
+  `__DEV__`.** `registerTool`/`useCordieriteTool` used to accept a bare zod 3 or plain valibot
+  schema, emit a dev warning, and register the tool with no schema at all — a silent failure,
+  since the tool looked registered but no agent could work out what to pass it. That case now
+  throws a `TypeError` naming the two supported forms above. **Release builds are unaffected
+  in kind**: the tool still registers without a schema, now with one `console.warn` per tool
+  name (previously dev-only), so an app already shipping such a tool is not broken by
+  upgrading. Fix by pairing the schema with a JSON Schema, or passing raw JSON Schema.
+- **Type change:** `CordieriteRuntimeSchema` is now a union of the three accepted forms rather
+  than an alias for `StandardSchemaV1`, and `CordieriteRegisteredTool.inputSchema`/
+  `.outputSchema` hold the normalized `CordieriteNormalizedToolSchema` rather than the raw
+  user value. Both matter only to code that inspected those internal types directly.
+  `requireStandardSchema`/`requireOptionalStandardSchema`/`validateStandardSchema` (never part
+  of the documented surface) are replaced by `normalizeToolSchema`/
+  `normalizeOptionalToolSchema`/`validateToolSchema`.
+
 ## 0.7.0 (2026-08-19)
 
 - **Fix: a terminal daemon rejection (1008) now ends the session instead of retrying until

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -403,21 +403,31 @@ Client behavior:
 - Schema handling: Standard Schema stays the only runtime-validation contract, but
   `inputSchema`/`outputSchema` accept three forms, classified once at registration by
   `normalizeToolSchema` (`schema.ts`) into `standard` / `paired` / `raw`:
-  - a **Standard Schema** — validated with `~standard.validate`, published from
+  - a **Standard Schema** — anything carrying `~standard.validate`, object or callable
+    (arktype's `Type` is a function) — validated with `~standard.validate`, published from
     `~standard.jsonSchema` (the Standard JSON Schema companion spec; zod 4 and arktype
-    implement it, zod 3 and plain valibot do not). With no exporter this **throws in
-    `__DEV__`**, naming the two forms below; outside dev it warns once per tool name and
-    registers with no `input_schema`/`output_schema`, as it always did, so a shipped app
-    is not bricked by an upgrade.
+    implement it, zod 3 and plain valibot do not).
   - a **`{ schema, jsonSchema }` pair** — validated with `schema["~standard"].validate`,
     published from the supplied JSON Schema object or `{ input, output }` converter. This
     is the supported path for zod 3 (`zod-to-json-schema`) and valibot
     (`@valibot/to-json-schema`).
-  - a **raw JSON Schema object**, detected purely by the absence of `~standard` —
+  - a **raw JSON Schema object** — no `~standard`, and carrying at least one JSON Schema
+    keyword (`type`, `properties`, `$ref`, `anyOf`, `allOf`, `oneOf`, `enum`, `const`) —
     published verbatim and handed to the handler **unvalidated**. No JSON Schema validator
-    is bundled: `@cordierite/react-native` keeps zero runtime dependencies (§13). The
-    optional `jsonSchema<T>()` helper is a pure type-level cast that gives such a handler
-    real argument/result types.
+    is bundled: `@cordierite/react-native` keeps zero third-party runtime dependencies
+    (§13). The optional `jsonSchema<T>()` helper is a pure type-level cast that gives such
+    a handler real argument/result types.
+
+  Everything else throws a `TypeError` at registration rather than being published as the
+  tool's shape: non-objects and arrays, a `~standard` that is not a Standard Schema, and —
+  because `raw` would otherwise be a catch-all — any object mentioning `schema`/`jsonSchema`
+  that is not a valid pair (a malformed pair, not JSON Schema; neither is a JSON Schema
+  keyword) or carrying no JSON Schema keyword at all.
+
+  Every way a slot can end up with no shape — a missing exporter, an exporter that throws or
+  returns a non-object, a paired converter that does either — takes the same route: throw in
+  `__DEV__`, warn once per tool name and register shapeless otherwise, so a shipped app is
+  not bricked by an upgrade. Nothing is swallowed silently.
 
   Exported JSON Schema is not normalized or checked against a target dialect, and vendors
   differ in what they emit (`default` handling, `additionalProperties`, draft version), so
@@ -502,7 +512,9 @@ packages/
     src/rpc/       RPC client library (connect-or-spawn), shared by cli/ and mcp/
     src/cli/       command definitions + renderers (keep DI/testability patterns)
     src/mcp/       stdio MCP server
-  react-native/    @cordierite/react-native (entries: ., /auto, /noop)
+  react-native/    @cordierite/react-native (entries: ., /auto, /noop). Depends only on
+                   @cordierite/shared — no third-party runtime deps, which is why no
+                   JSON Schema validator ships with it (§11's raw schema form).
 playground/        reference app (Expo dev build)
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -411,18 +411,30 @@ Client behavior:
     published from the supplied JSON Schema object or `{ input, output }` converter. This
     is the supported path for zod 3 (`zod-to-json-schema`) and valibot
     (`@valibot/to-json-schema`).
-  - a **raw JSON Schema object** — no `~standard`, and carrying at least one JSON Schema
-    keyword (`type`, `properties`, `$ref`, `anyOf`, `allOf`, `oneOf`, `enum`, `const`) —
-    published verbatim and handed to the handler **unvalidated**. No JSON Schema validator
-    is bundled: `@cordierite/react-native` keeps zero third-party runtime dependencies
-    (§13). The optional `jsonSchema<T>()` helper is a pure type-level cast that gives such
-    a handler real argument/result types.
+  - a **raw JSON Schema object** — no `~standard`, a *plain* object (prototype
+    `Object.prototype` or `null`), and an own `type`, if present, that is a JSON Schema type
+    name or an array of them — published verbatim and handed to the handler **unvalidated**.
+    `{}` qualifies: it is valid accept-anything JSON Schema. No JSON Schema validator is
+    bundled: `@cordierite/react-native` keeps zero third-party runtime dependencies (§13).
+    The optional `jsonSchema<T>()` helper is a pure type-level cast that gives such a handler
+    real argument/result types.
+
+  The raw test is structural rather than keyword-based on purpose. A keyword probe using `in`
+  walks the prototype chain, and validator instances from libraries predating Standard Schema
+  (yup, joi, superstruct, valibot 0.x) carry a prototype `type` — they would be taken as raw
+  JSON Schema and published as the tool's shape, having previously been rejected outright.
+  Many also hold circular references, so `JSON.stringify` on `tool_registry_snapshot` would
+  throw and lose the whole snapshot, not just that tool.
 
   Everything else throws a `TypeError` at registration rather than being published as the
-  tool's shape: non-objects and arrays, a `~standard` that is not a Standard Schema, and —
-  because `raw` would otherwise be a catch-all — any object mentioning `schema`/`jsonSchema`
-  that is not a valid pair (a malformed pair, not JSON Schema; neither is a JSON Schema
-  keyword) or carrying no JSON Schema keyword at all.
+  tool's shape: non-objects and arrays, a `~standard` that is not a Standard Schema, any
+  object mentioning `schema`/`jsonSchema` that is not a valid pair, and anything failing the
+  plain-object rule. The `jsonSchema` half of a pair and every converter result are held to
+  that same rule, so the forms cannot diverge in what they will publish.
+
+  Separately from all of this, an **input schema should be object-typed at its root** to be
+  usable over MCP — a root `enum`/`const`/`$ref`/`anyOf` is legal JSON Schema but leaves the
+  agent with no named arguments (issue #34). This is documented, not enforced.
 
   Every way a slot can end up with no shape — a missing exporter, an exporter that throws or
   returns a non-object, a paired converter that does either — takes the same route: throw in

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -400,8 +400,30 @@ Client behavior:
   warning) otherwise.
 - Unified listener: `addCordieriteListener(kind, cb)` with kinds `stateChange`,
   `error` (covers bootstrap parse/connect and socket errors), `sessionChange`.
-- Schema handling: Standard Schema JSON exporter as in v1; when a schema lacks the
-  exporter, log a dev warning that agents will see a shapeless tool.
+- Schema handling: Standard Schema stays the only runtime-validation contract, but
+  `inputSchema`/`outputSchema` accept three forms, classified once at registration by
+  `normalizeToolSchema` (`schema.ts`) into `standard` / `paired` / `raw`:
+  - a **Standard Schema** — validated with `~standard.validate`, published from
+    `~standard.jsonSchema` (the Standard JSON Schema companion spec; zod 4 and arktype
+    implement it, zod 3 and plain valibot do not). With no exporter this **throws in
+    `__DEV__`**, naming the two forms below; outside dev it warns once per tool name and
+    registers with no `input_schema`/`output_schema`, as it always did, so a shipped app
+    is not bricked by an upgrade.
+  - a **`{ schema, jsonSchema }` pair** — validated with `schema["~standard"].validate`,
+    published from the supplied JSON Schema object or `{ input, output }` converter. This
+    is the supported path for zod 3 (`zod-to-json-schema`) and valibot
+    (`@valibot/to-json-schema`).
+  - a **raw JSON Schema object**, detected purely by the absence of `~standard` —
+    published verbatim and handed to the handler **unvalidated**. No JSON Schema validator
+    is bundled: `@cordierite/react-native` keeps zero runtime dependencies (§13). The
+    optional `jsonSchema<T>()` helper is a pure type-level cast that gives such a handler
+    real argument/result types.
+
+  Exported JSON Schema is not normalized or checked against a target dialect, and vendors
+  differ in what they emit (`default` handling, `additionalProperties`, draft version), so
+  two libraries describing the same shape may not produce byte-identical schemas. The wire
+  `ToolDescriptor` (§7) is unchanged by any of this — it already carries draft 2020-12
+  JSON Schema, so the whole contract is app-side.
 - App-side handler timeout: if a handler exceeds the call timeout hint, abort its
   `AbortSignal`, reply `tool_timeout`, and ignore the late result.
 - Cancellation: `tool.handler(args, context)`'s `context.signal` (`AbortSignal`) aborts on

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -240,9 +240,11 @@ exporter (zod v4's built-in one, for example), the JSON Schema half of a
 `{ schema, jsonSchema }` pair, or a raw JSON Schema object passed straight through — see
 `docs/ARCHITECTURE.md` §11. A Standard Schema whose library has no exporter still registers
 the tool, without `input_schema`/`output_schema`, so agents see a shapeless (`{}`) schema;
-the app-side SDK throws on that in development rather than letting it ship silently.
-`annotations` map 1:1 to MCP tool
-annotations and drive the daemon's policy engine (`docs/ARCHITECTURE.md` §12):
+the app-side SDK throws on that in development rather than letting it ship silently. The
+daemon never inspects a schema's internals — only that it is a JSON object.
+
+`annotations` map 1:1 to MCP tool annotations and drive the daemon's policy engine
+(`docs/ARCHITECTURE.md` §12):
 `destructiveHint: true` routes a call through `policy.destructive` instead of
 `policy.default`.
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -235,9 +235,13 @@ can ask "what happened?" after the fact instead of only listening live.
   "annotations": { "readOnlyHint": true, "destructiveHint": false, "idempotentHint": true } }
 ```
 
-Schemas come from the Standard Schema JSON Schema exporter (zod v4's built-in exporter,
-for example); a schema library without one still registers the tool, with a JS-side dev
-warning that agents will see a shapeless (`{}`) schema. `annotations` map 1:1 to MCP tool
+Schemas come from whatever the app registered the tool with: a Standard Schema JSON Schema
+exporter (zod v4's built-in one, for example), the JSON Schema half of a
+`{ schema, jsonSchema }` pair, or a raw JSON Schema object passed straight through — see
+`docs/ARCHITECTURE.md` §11. A Standard Schema whose library has no exporter still registers
+the tool, without `input_schema`/`output_schema`, so agents see a shapeless (`{}`) schema;
+the app-side SDK throws on that in development rather than letting it ship silently.
+`annotations` map 1:1 to MCP tool
 annotations and drive the daemon's policy engine (`docs/ARCHITECTURE.md` §12):
 `destructiveHint: true` routes a call through `policy.destructive` instead of
 `policy.default`.

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -141,9 +141,72 @@ The resume lease is native **process-memory only** and is committed before JS re
 
 ### 5. Define tools in app startup code
 
-Call `registerTool({ ... })` with Standard Schema compatible `inputSchema` and `outputSchema` values plus a `handler` so the host can invoke your tools after the session is active. `zod` v4 works well here (its built-in JSON Schema exporter means agents see a real tool shape — zod 3 and plain valibot schemas still register, just with a dev warning and an empty schema).
+Call `registerTool({ ... })` with `inputSchema`/`outputSchema` plus a `handler` so the host can invoke your tools after the session is active.
 
-`useCordieriteTool` wraps `registerTool` in a `useEffect` so registration follows the component's lifecycle, including remounts and Fast Refresh:
+#### Accepted schema forms
+
+An agent can only use a tool it can see the shape of, so every form below except the last one publishes a real JSON Schema:
+
+| `inputSchema` / `outputSchema` | Validated app-side with | Published to agents | `handler` argument type |
+| --- | --- | --- | --- |
+| Standard Schema **with** a JSON Schema exporter — zod 4, arktype | `~standard.validate` | its `~standard.jsonSchema` export | the schema's own type |
+| `{ schema, jsonSchema }` pair — zod 3, valibot, anything else | `schema["~standard"].validate` | the `jsonSchema` you supply (an object, or an `{ input, output }` converter) | the schema's own type |
+| A raw JSON Schema object (no `~standard` property) | **nothing** — args reach the handler as sent | the object, verbatim | `Record<string, unknown>`, or `T` via `jsonSchema<T>()` |
+| Standard Schema **without** an exporter — bare zod 3, plain valibot | `~standard.validate` | **nothing** — throws in dev (see below) | the schema's own type |
+
+Cordierite has no runtime dependencies and does not bundle a JSON Schema validator, so a raw JSON Schema describes the tool for the agent but never enforces anything. Use a pair when you want both a real shape *and* real validation.
+
+Different libraries emit different JSON Schema for the same shape (draft version, `additionalProperties`, how `default` is handled). Whatever you supply is forwarded as-is; Cordierite does not normalize it.
+
+**Zod 3** — pair the schema with `zod-to-json-schema`:
+
+```ts
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+const sumInput = z.object({ a: z.number(), b: z.number() });
+
+registerTool({
+  name: "sum",
+  description: "Add two numeric values",
+  inputSchema: { schema: sumInput, jsonSchema: zodToJsonSchema(sumInput) },
+  handler: async ({ a, b }) => undefined, // `a` and `b` are still typed `number`
+});
+```
+
+**Valibot** — the same shape, with `@valibot/to-json-schema`:
+
+```ts
+import * as v from "valibot";
+import { toJsonSchema } from "@valibot/to-json-schema";
+
+const sumInput = v.object({ a: v.number(), b: v.number() });
+const inputSchema = { schema: sumInput, jsonSchema: toJsonSchema(sumInput) };
+```
+
+**No validation library at all** — hand over JSON Schema directly. `jsonSchema<T>()` is an optional, purely type-level helper that tells the handler what to expect; it validates nothing:
+
+```ts
+import { jsonSchema, registerTool } from "@cordierite/react-native";
+
+registerTool({
+  name: "weather",
+  description: "Current weather for a city",
+  inputSchema: jsonSchema<{ city: string }>({
+    type: "object",
+    properties: { city: { type: "string" } },
+    required: ["city"],
+    additionalProperties: false,
+  }),
+  handler: async ({ city }) => fetchWeather(city),
+});
+```
+
+**A Standard Schema with no exporter throws in development.** Passing a bare zod 3 or plain valibot schema used to register the tool with no shape at all, which agents saw as "takes any object" — the tool looked fine and was unusable. In `__DEV__` that now throws at `registerTool` with a message pointing at the two forms above. Release builds keep the old behaviour (one console warning per tool name, tool registered without a schema) so an app already shipping such a tool is not broken by upgrading.
+
+#### Registering from a component
+
+`useCordieriteTool` wraps `registerTool` in a `useEffect` so registration follows the component's lifecycle, including remounts and Fast Refresh. It takes exactly the same schema forms; the example below uses zod 4, whose built-in exporter needs no pairing:
 
 ```ts
 import "@cordierite/react-native/auto";

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -156,7 +156,9 @@ An agent can only use a tool it can see the shape of, so every form below except
 
 A Standard Schema does not have to be a plain object: arktype's `Type` is callable, and is detected the same way (anything carrying `~standard.validate`).
 
-Cordierite has no runtime dependencies and does not bundle a JSON Schema validator, so a raw JSON Schema describes the tool for the agent but never enforces anything. Use a pair when you want both a real shape *and* real validation.
+Whatever form you use, an **input schema must be object-typed at its root** to be callable over MCP — a root `enum`, `const`, `$ref` or `anyOf` is legal JSON Schema but leaves the agent with no named arguments to pass (see [#34](https://github.com/callstackincubator/cordierite/issues/34)).
+
+Cordierite has no third-party runtime dependencies and does not bundle a JSON Schema validator, so a raw JSON Schema describes the tool for the agent but never enforces anything. Use a pair when you want both a real shape *and* real validation.
 
 The wire field is documented as draft 2020-12, but Cordierite forwards whatever you supply as-is — it does not normalize, re-target, or check the dialect, and different libraries emit different JSON Schema for the same shape (draft version, `additionalProperties`, how `default` is handled). Pick the target closest to 2020-12 that your converter offers.
 
@@ -211,7 +213,11 @@ registerTool({
 
 If your JSON Schema value is typed as an *interface* (`JSONSchema7` from `@types/json-schema`, for instance) TypeScript will not accept it directly: interfaces do not get the implicit index signature that `Record<string, unknown>` requires. Pass it through `jsonSchema<T>()`, or cast it.
 
-**What is rejected.** A raw schema must actually look like JSON Schema: it needs at least one of `type`, `properties`, `$ref`, `anyOf`, `allOf`, `oneOf`, `enum`, `const`. An object mentioning `schema` or `jsonSchema` that is not a valid pair is rejected too — `{ schema: someJsonSchema, jsonSchema }` and a lone `{ jsonSchema }` are malformed pairs, and publishing them verbatim would make the wrapper itself the tool's advertised shape. Both throw a `TypeError` at registration naming what to fix.
+**What is rejected.** A raw schema must be a *plain* object — an object literal or `Object.create(null)`, not a class instance — and its `type`, if it has one, must be a real JSON Schema type name (or an array of them). `{}` is fine: it is the canonical accept-anything schema. This rules out passing a validator from a library with no Standard Schema support (yup, joi, superstruct, valibot 0.x): those instances carry a `type` on their *prototype*, so a looser check would publish one as the tool's shape, and their internal circular references would then break serialization of the entire tool registry rather than just that tool.
+
+An object mentioning `schema` or `jsonSchema` that is not a valid pair is rejected too — `{ schema: someJsonSchema, jsonSchema }` and a lone `{ jsonSchema }` are malformed pairs, and publishing them verbatim would make the wrapper itself the tool's advertised shape. The `jsonSchema` half of a pair, and anything a converter returns, must satisfy the same plain-object rule.
+
+All of these throw a `TypeError` at registration naming what to fix.
 
 **A Standard Schema with no exporter throws in development.** Passing a bare zod 3 or plain valibot schema used to register the tool with no shape at all, which agents saw as "takes any object" — the tool looked fine and was unusable. In `__DEV__` that now throws at `registerTool` with a message pointing at the two forms above — including when the call comes from `useCordieriteTool`, where the throw surfaces from the component's effect. Release builds keep the old behaviour (one console warning per tool name, tool registered without a schema) so an app already shipping such a tool is not broken by upgrading.
 

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -202,7 +202,7 @@ registerTool({
 });
 ```
 
-**A Standard Schema with no exporter throws in development.** Passing a bare zod 3 or plain valibot schema used to register the tool with no shape at all, which agents saw as "takes any object" — the tool looked fine and was unusable. In `__DEV__` that now throws at `registerTool` with a message pointing at the two forms above. Release builds keep the old behaviour (one console warning per tool name, tool registered without a schema) so an app already shipping such a tool is not broken by upgrading.
+**A Standard Schema with no exporter throws in development.** Passing a bare zod 3 or plain valibot schema used to register the tool with no shape at all, which agents saw as "takes any object" — the tool looked fine and was unusable. In `__DEV__` that now throws at `registerTool` with a message pointing at the two forms above — including when the call comes from `useCordieriteTool`, where the throw surfaces from the component's effect. Release builds keep the old behaviour (one console warning per tool name, tool registered without a schema) so an app already shipping such a tool is not broken by upgrading.
 
 #### Registering from a component
 

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -154,9 +154,11 @@ An agent can only use a tool it can see the shape of, so every form below except
 | A raw JSON Schema object (no `~standard` property) | **nothing** — args reach the handler as sent | the object, verbatim | `Record<string, unknown>`, or `T` via `jsonSchema<T>()` |
 | Standard Schema **without** an exporter — bare zod 3, plain valibot | `~standard.validate` | **nothing** — throws in dev (see below) | the schema's own type |
 
+A Standard Schema does not have to be a plain object: arktype's `Type` is callable, and is detected the same way (anything carrying `~standard.validate`).
+
 Cordierite has no runtime dependencies and does not bundle a JSON Schema validator, so a raw JSON Schema describes the tool for the agent but never enforces anything. Use a pair when you want both a real shape *and* real validation.
 
-Different libraries emit different JSON Schema for the same shape (draft version, `additionalProperties`, how `default` is handled). Whatever you supply is forwarded as-is; Cordierite does not normalize it.
+The wire field is documented as draft 2020-12, but Cordierite forwards whatever you supply as-is — it does not normalize, re-target, or check the dialect, and different libraries emit different JSON Schema for the same shape (draft version, `additionalProperties`, how `default` is handled). Pick the target closest to 2020-12 that your converter offers.
 
 **Zod 3** — pair the schema with `zod-to-json-schema`:
 
@@ -169,7 +171,12 @@ const sumInput = z.object({ a: z.number(), b: z.number() });
 registerTool({
   name: "sum",
   description: "Add two numeric values",
-  inputSchema: { schema: sumInput, jsonSchema: zodToJsonSchema(sumInput) },
+  // `zod-to-json-schema` has no 2020-12 target; 2019-09 is the closest it offers, and its
+  // default (`jsonSchema7`) stamps a draft-07 `$schema`. Either is understood in practice.
+  inputSchema: {
+    schema: sumInput,
+    jsonSchema: zodToJsonSchema(sumInput, { target: "jsonSchema2019-09" }),
+  },
   handler: async ({ a, b }) => undefined, // `a` and `b` are still typed `number`
 });
 ```
@@ -201,6 +208,10 @@ registerTool({
   handler: async ({ city }) => fetchWeather(city),
 });
 ```
+
+If your JSON Schema value is typed as an *interface* (`JSONSchema7` from `@types/json-schema`, for instance) TypeScript will not accept it directly: interfaces do not get the implicit index signature that `Record<string, unknown>` requires. Pass it through `jsonSchema<T>()`, or cast it.
+
+**What is rejected.** A raw schema must actually look like JSON Schema: it needs at least one of `type`, `properties`, `$ref`, `anyOf`, `allOf`, `oneOf`, `enum`, `const`. An object mentioning `schema` or `jsonSchema` that is not a valid pair is rejected too — `{ schema: someJsonSchema, jsonSchema }` and a lone `{ jsonSchema }` are malformed pairs, and publishing them verbatim would make the wrapper itself the tool's advertised shape. Both throw a `TypeError` at registration naming what to fix.
 
 **A Standard Schema with no exporter throws in development.** Passing a bare zod 3 or plain valibot schema used to register the tool with no shape at all, which agents saw as "takes any object" — the tool looked fine and was unusable. In `__DEV__` that now throws at `registerTool` with a message pointing at the two forms above — including when the call comes from `useCordieriteTool`, where the throw surfaces from the component's effect. Release builds keep the old behaviour (one console warning per tool name, tool registered without a schema) so an app already shipping such a tool is not broken by upgrading.
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -70,14 +70,17 @@
     "@cordierite/shared": "workspace:*"
   },
   "devDependencies": {
-    "@types/react": "~19.1.1",
     "@types/node": "^22.10.0",
+    "@types/react": "~19.1.1",
     "eslint": "^8.57.0",
     "eslint-config-universe": "^15.0.3",
     "expo": "^54.0.0",
     "react": "19.1.0",
     "react-native": "0.81.5",
-    "typescript": "~5.9.2"
+    "typescript": "~5.9.2",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.25.2",
+    "zod4": "npm:zod@^4.4.3"
   },
   "peerDependencies": {
     "expo": ">=54.0.0",

--- a/packages/react-native/src/Cordierite.types.ts
+++ b/packages/react-native/src/Cordierite.types.ts
@@ -255,18 +255,26 @@ export type CordieriteToolHandler<TArgs = unknown, TResult = unknown> = (
  * is no wrapper to import. It is forwarded to the daemon verbatim and **never validated app-side**:
  * a handler with a raw input schema receives `tool_call.args` exactly as the caller sent them.
  *
- * The type parameter is phantom (never present at runtime). It is set only by the `jsonSchema<T>()`
- * helper below, which is how a raw schema still gets real handler argument/result types; a bare
- * object literal infers `Record<string, unknown>` instead. There is one phantom slot, carrying the
- * type the *handler* sees for whichever of the two slots the schema is used in.
+ * The type parameters are phantom (never present at runtime). They are set only by the
+ * `jsonSchema<T>()` helper below, which is how a raw schema still gets real handler argument/result
+ * types; a bare object literal infers `Record<string, unknown>` instead. They mirror Standard
+ * Schema's own two: `Input` is the pre-validation type an `outputSchema` handler may *return*,
+ * `Output` the post-validation type an `inputSchema` handler *receives* — so the raw member of
+ * {@link CordieriteRuntimeSchema} tracks both sides of an annotation instead of collapsing them.
  *
  * A JSON Schema value typed as an interface (`JSONSchema7` from `@types/json-schema`, say) is not
  * assignable to `Record<string, unknown>` — TypeScript gives implicit index signatures to type
  * aliases, not interfaces. Wrap it in `jsonSchema<T>()` or cast it.
  */
-export type CordieriteJsonSchemaObject<T = unknown> = Record<string, unknown> & {
+export type CordieriteJsonSchemaObject<
+  Input = unknown,
+  Output = Input,
+> = Record<string, unknown> & {
   /** Phantom marker; `jsonSchema<T>()` only casts, it never writes this property. */
-  readonly "~cordieriteJsonSchemaType"?: T;
+  readonly "~cordieriteJsonSchemaTypes"?: {
+    readonly input: Input;
+    readonly output: Output;
+  };
 };
 
 /**
@@ -274,7 +282,8 @@ export type CordieriteJsonSchemaObject<T = unknown> = Record<string, unknown> & 
  * `~standard.jsonSchema`. Accepted as the `jsonSchema` half of a {@link CordieritePairedSchema} so
  * one converter (e.g. a `zod-to-json-schema` wrapper) can serve both slots.
  */
-export type CordieriteJsonSchemaConverter = StandardSchemaV1JsonSchema.Converter;
+export type CordieriteJsonSchemaConverter =
+  StandardSchemaV1JsonSchema.Converter;
 
 /**
  * A Standard Schema paired with the JSON Schema to publish for it — the supported form for
@@ -296,14 +305,15 @@ export type CordieritePairedSchema<Input = unknown, Output = Input> = {
  * without a `~standard.jsonSchema` exporter), a `{ schema, jsonSchema }` pair, or a raw JSON Schema
  * object.
  *
- * All three members carry the annotation's types, so an explicitly annotated
- * `CordieriteRuntimeSchema<Args>` still gives the handler exactly `Args` — the raw member is
- * parameterized precisely so it cannot widen that back to `Record<string, unknown>`.
+ * All three members carry *both* of the annotation's types, so an annotated
+ * `CordieriteRuntimeSchema<In, Out>` gives a handler exactly `Out` for its arguments and exactly
+ * `In` for its result. The raw member is parameterized precisely so it cannot widen either back to
+ * `Record<string, unknown>`, nor collapse the two into `In | Out`.
  */
 export type CordieriteRuntimeSchema<Input = unknown, Output = Input> =
   | StandardSchemaV1<Input, Output>
   | CordieritePairedSchema<Input, Output>
-  | CordieriteJsonSchemaObject<Output>;
+  | CordieriteJsonSchemaObject<Input, Output>;
 
 /**
  * Tags a raw JSON Schema object with the argument/result type its handler should see. Purely a
@@ -319,8 +329,9 @@ export type CordieriteRuntimeSchema<Input = unknown, Output = Input> =
  * ```
  */
 export const jsonSchema = <T = Record<string, unknown>>(
-  schema: Record<string, unknown>
-): CordieriteJsonSchemaObject<T> => schema as CordieriteJsonSchemaObject<T>;
+  schema: Record<string, unknown>,
+): CordieriteJsonSchemaObject<T, T> =>
+  schema as CordieriteJsonSchemaObject<T, T>;
 
 /**
  * Runtime shape an `inputSchema`/`outputSchema` takes once `normalizeToolSchema` (`schema.ts`) has
@@ -351,10 +362,10 @@ export type InferToolArgs<TSchema> = TSchema extends StandardSchemaV1
   ? StandardSchemaV1.InferOutput<TSchema>
   : TSchema extends { readonly schema: infer S extends StandardSchemaV1 }
     ? StandardSchemaV1.InferOutput<S>
-    : TSchema extends CordieriteJsonSchemaObject<infer T>
-      ? unknown extends T
+    : TSchema extends CordieriteJsonSchemaObject<unknown, infer Output>
+      ? unknown extends Output
         ? Record<string, unknown>
-        : T
+        : Output
       : undefined;
 
 /**
@@ -365,10 +376,10 @@ export type InferToolResult<TSchema> = TSchema extends StandardSchemaV1
   ? StandardSchemaV1.InferInput<TSchema>
   : TSchema extends { readonly schema: infer S extends StandardSchemaV1 }
     ? StandardSchemaV1.InferInput<S>
-    : TSchema extends CordieriteJsonSchemaObject<infer T>
-      ? unknown extends T
+    : TSchema extends CordieriteJsonSchemaObject<infer Input, unknown>
+      ? unknown extends Input
         ? Record<string, unknown>
-        : T
+        : Input
       : void;
 
 export type CordieriteToolDefinition<

--- a/packages/react-native/src/Cordierite.types.ts
+++ b/packages/react-native/src/Cordierite.types.ts
@@ -332,12 +332,10 @@ export type CordieriteNormalizedToolSchema =
  * schema's *output* (post-validation) type; a raw JSON Schema infers whatever `jsonSchema<T>()`
  * declared, or `Record<string, unknown>` for a bare object; no schema at all infers `undefined`.
  */
-export type InferToolArgs<TSchema> = TSchema extends {
-  readonly schema: infer S extends StandardSchemaV1;
-}
-  ? StandardSchemaV1.InferOutput<S>
-  : TSchema extends StandardSchemaV1
-    ? StandardSchemaV1.InferOutput<TSchema>
+export type InferToolArgs<TSchema> = TSchema extends StandardSchemaV1
+  ? StandardSchemaV1.InferOutput<TSchema>
+  : TSchema extends { readonly schema: infer S extends StandardSchemaV1 }
+    ? StandardSchemaV1.InferOutput<S>
     : TSchema extends CordieriteJsonSchemaObject<infer T>
       ? unknown extends T
         ? Record<string, unknown>
@@ -348,12 +346,10 @@ export type InferToolArgs<TSchema> = TSchema extends {
  * Handler result type for an `outputSchema` — the mirror of {@link InferToolArgs}, using the
  * schema's *input* (pre-validation) type so a handler may return whatever the schema accepts.
  */
-export type InferToolResult<TSchema> = TSchema extends {
-  readonly schema: infer S extends StandardSchemaV1;
-}
-  ? StandardSchemaV1.InferInput<S>
-  : TSchema extends StandardSchemaV1
-    ? StandardSchemaV1.InferInput<TSchema>
+export type InferToolResult<TSchema> = TSchema extends StandardSchemaV1
+  ? StandardSchemaV1.InferInput<TSchema>
+  : TSchema extends { readonly schema: infer S extends StandardSchemaV1 }
+    ? StandardSchemaV1.InferInput<S>
     : TSchema extends CordieriteJsonSchemaObject<infer T>
       ? unknown extends T
         ? Record<string, unknown>

--- a/packages/react-native/src/Cordierite.types.ts
+++ b/packages/react-native/src/Cordierite.types.ts
@@ -3,6 +3,7 @@ import type {
   SessionBoundMessage,
   SessionId,
   StandardSchemaV1,
+  StandardSchemaV1JsonSchema,
   ToolAnnotations,
   ToolCallMessage,
   ToolDescriptor,
@@ -247,18 +248,117 @@ export type CordieriteToolHandler<TArgs = unknown, TResult = unknown> = (
   context: CordieriteToolExecutionContext
 ) => TResult | Promise<TResult>;
 
-export type CordieriteRuntimeSchema<
-  Input = unknown,
-  Output = Input
-> = StandardSchemaV1<Input, Output>;
+/**
+ * A raw JSON Schema object handed straight to `inputSchema`/`outputSchema` (ARCHITECTURE.md §11).
+ *
+ * Recognised at runtime purely by the *absence* of `~standard`, so any plain object works — there
+ * is no wrapper to import. It is forwarded to the daemon verbatim and **never validated app-side**:
+ * a handler with a raw input schema receives `tool_call.args` exactly as the caller sent them.
+ *
+ * The type parameter is phantom (never present at runtime). It is set only by the `jsonSchema<T>()`
+ * helper below, which is how a raw schema still gets real handler argument/result types; a bare
+ * object literal infers `Record<string, unknown>` instead.
+ */
+export type CordieriteJsonSchemaObject<T = unknown> = Record<string, unknown> & {
+  /** Phantom marker; `jsonSchema<T>()` only casts, it never writes this property. */
+  readonly "~cordieriteJsonSchemaType"?: T;
+};
 
-export type InferToolArgs<TSchema> = TSchema extends CordieriteRuntimeSchema
-  ? StandardSchemaV1.InferOutput<TSchema>
-  : undefined;
+/**
+ * `{ input, output }` JSON Schema exporter — the same shape Standard JSON Schema puts on
+ * `~standard.jsonSchema`. Accepted as the `jsonSchema` half of a {@link CordieritePairedSchema} so
+ * one converter (e.g. a `zod-to-json-schema` wrapper) can serve both slots.
+ */
+export type CordieriteJsonSchemaConverter = StandardSchemaV1JsonSchema.Converter;
 
-export type InferToolResult<TSchema> = TSchema extends CordieriteRuntimeSchema
-  ? StandardSchemaV1.InferInput<TSchema>
-  : void;
+/**
+ * A Standard Schema paired with the JSON Schema to publish for it — the supported form for
+ * libraries that validate but cannot export JSON Schema themselves (zod 3, plain valibot, arktype
+ * without an adapter).
+ *
+ * `schema` still drives runtime validation (`~standard.validate`), so handler argument and result
+ * types are inferred exactly as they are for zod 4. `jsonSchema` is either a ready JSON Schema
+ * object or an `{ input, output }` converter; only the half matching the slot this pair is used in
+ * is ever called.
+ */
+export type CordieritePairedSchema<Input = unknown, Output = Input> = {
+  readonly schema: StandardSchemaV1<Input, Output>;
+  readonly jsonSchema: Record<string, unknown> | CordieriteJsonSchemaConverter;
+};
+
+/**
+ * Everything `inputSchema`/`outputSchema` accept (ARCHITECTURE.md §11): a Standard Schema (with or
+ * without a `~standard.jsonSchema` exporter), a `{ schema, jsonSchema }` pair, or a raw JSON Schema
+ * object.
+ */
+export type CordieriteRuntimeSchema<Input = unknown, Output = Input> =
+  | StandardSchemaV1<Input, Output>
+  | CordieritePairedSchema<Input, Output>
+  | CordieriteJsonSchemaObject;
+
+/**
+ * Tags a raw JSON Schema object with the argument/result type its handler should see. Purely a
+ * type-level cast — the object is returned unchanged, nothing is validated, and no runtime check
+ * ever confirms that `T` matches the schema.
+ *
+ * ```ts
+ * inputSchema: jsonSchema<{ city: string }>({
+ *   type: "object",
+ *   properties: { city: { type: "string" } },
+ *   required: ["city"],
+ * })
+ * ```
+ */
+export const jsonSchema = <T = Record<string, unknown>>(
+  schema: Record<string, unknown>
+): CordieriteJsonSchemaObject<T> => schema as CordieriteJsonSchemaObject<T>;
+
+/**
+ * Runtime shape an `inputSchema`/`outputSchema` takes once `normalizeToolSchema` (`schema.ts`) has
+ * classified it. Stored on {@link CordieriteRegisteredTool} so export and validation never re-sniff
+ * the user's value.
+ */
+export type CordieriteNormalizedToolSchema =
+  | { kind: "standard"; schema: StandardSchemaV1 }
+  | {
+      kind: "paired";
+      schema: StandardSchemaV1;
+      jsonSchema: Record<string, unknown> | CordieriteJsonSchemaConverter;
+    }
+  | { kind: "raw"; jsonSchema: Record<string, unknown> };
+
+/**
+ * Handler argument type for an `inputSchema`. Paired and plain Standard Schemas both infer the
+ * schema's *output* (post-validation) type; a raw JSON Schema infers whatever `jsonSchema<T>()`
+ * declared, or `Record<string, unknown>` for a bare object; no schema at all infers `undefined`.
+ */
+export type InferToolArgs<TSchema> = TSchema extends {
+  readonly schema: infer S extends StandardSchemaV1;
+}
+  ? StandardSchemaV1.InferOutput<S>
+  : TSchema extends StandardSchemaV1
+    ? StandardSchemaV1.InferOutput<TSchema>
+    : TSchema extends CordieriteJsonSchemaObject<infer T>
+      ? unknown extends T
+        ? Record<string, unknown>
+        : T
+      : undefined;
+
+/**
+ * Handler result type for an `outputSchema` — the mirror of {@link InferToolArgs}, using the
+ * schema's *input* (pre-validation) type so a handler may return whatever the schema accepts.
+ */
+export type InferToolResult<TSchema> = TSchema extends {
+  readonly schema: infer S extends StandardSchemaV1;
+}
+  ? StandardSchemaV1.InferInput<S>
+  : TSchema extends StandardSchemaV1
+    ? StandardSchemaV1.InferInput<TSchema>
+    : TSchema extends CordieriteJsonSchemaObject<infer T>
+      ? unknown extends T
+        ? Record<string, unknown>
+        : T
+      : void;
 
 export type CordieriteToolDefinition<
   TInputSchema extends CordieriteRuntimeSchema | undefined = undefined,
@@ -291,8 +391,9 @@ export type CordieriteRegisteredTool = {
   /** Registration identity: `remove()` disposers compare this, not the tool name (stale-disposer fix). */
   id: symbol;
   descriptor: ToolDescriptor;
-  inputSchema?: CordieriteRuntimeSchema;
-  outputSchema?: CordieriteRuntimeSchema;
+  /** Normalized at registration time (`schema.ts`'s `normalizeToolSchema`), never the raw user value. */
+  inputSchema?: CordieriteNormalizedToolSchema;
+  outputSchema?: CordieriteNormalizedToolSchema;
   handler: CordieriteToolHandler;
   timeoutMs: number;
 };

--- a/packages/react-native/src/Cordierite.types.ts
+++ b/packages/react-native/src/Cordierite.types.ts
@@ -257,7 +257,12 @@ export type CordieriteToolHandler<TArgs = unknown, TResult = unknown> = (
  *
  * The type parameter is phantom (never present at runtime). It is set only by the `jsonSchema<T>()`
  * helper below, which is how a raw schema still gets real handler argument/result types; a bare
- * object literal infers `Record<string, unknown>` instead.
+ * object literal infers `Record<string, unknown>` instead. There is one phantom slot, carrying the
+ * type the *handler* sees for whichever of the two slots the schema is used in.
+ *
+ * A JSON Schema value typed as an interface (`JSONSchema7` from `@types/json-schema`, say) is not
+ * assignable to `Record<string, unknown>` — TypeScript gives implicit index signatures to type
+ * aliases, not interfaces. Wrap it in `jsonSchema<T>()` or cast it.
  */
 export type CordieriteJsonSchemaObject<T = unknown> = Record<string, unknown> & {
   /** Phantom marker; `jsonSchema<T>()` only casts, it never writes this property. */
@@ -290,11 +295,15 @@ export type CordieritePairedSchema<Input = unknown, Output = Input> = {
  * Everything `inputSchema`/`outputSchema` accept (ARCHITECTURE.md §11): a Standard Schema (with or
  * without a `~standard.jsonSchema` exporter), a `{ schema, jsonSchema }` pair, or a raw JSON Schema
  * object.
+ *
+ * All three members carry the annotation's types, so an explicitly annotated
+ * `CordieriteRuntimeSchema<Args>` still gives the handler exactly `Args` — the raw member is
+ * parameterized precisely so it cannot widen that back to `Record<string, unknown>`.
  */
 export type CordieriteRuntimeSchema<Input = unknown, Output = Input> =
   | StandardSchemaV1<Input, Output>
   | CordieritePairedSchema<Input, Output>
-  | CordieriteJsonSchemaObject;
+  | CordieriteJsonSchemaObject<Output>;
 
 /**
  * Tags a raw JSON Schema object with the argument/result type its handler should see. Purely a
@@ -330,7 +339,13 @@ export type CordieriteNormalizedToolSchema =
 /**
  * Handler argument type for an `inputSchema`. Paired and plain Standard Schemas both infer the
  * schema's *output* (post-validation) type; a raw JSON Schema infers whatever `jsonSchema<T>()`
- * declared, or `Record<string, unknown>` for a bare object; no schema at all infers `undefined`.
+ * declared, or `Record<string, unknown>` for a bare object.
+ *
+ * `InferToolArgs<undefined>` is `undefined`. Note that a registration that simply *omits*
+ * `inputSchema` gives its handler `unknown`, not `undefined`: with no property to infer from,
+ * `registerTool`'s type parameter falls back to its constraint
+ * (`CordieriteRuntimeSchema | undefined`), and this type distributes over that union. That has
+ * always been the behaviour and is unchanged here.
  */
 export type InferToolArgs<TSchema> = TSchema extends StandardSchemaV1
   ? StandardSchemaV1.InferOutput<TSchema>

--- a/packages/react-native/src/__tests__/client.test.ts
+++ b/packages/react-native/src/__tests__/client.test.ts
@@ -6,6 +6,7 @@ import type {
 import { describe, expect, test } from "vitest";
 import { z as z3 } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
+import { z as z4 } from "zod4";
 
 import type {
   CordieriteConnectionState,
@@ -336,6 +337,47 @@ describe("createCordieriteClient: claim handshake", () => {
       type: "object",
       properties: { a: { type: "number" } },
       required: ["a"],
+    });
+  });
+
+  test("a real zod 4 schema publishes a real input_schema through its own exporter (issue #27)", async () => {
+    // Not a hand-rolled `~standard.jsonSchema` double: this exercises zod 4's built-in exporter
+    // end to end, so a change in how zod exports (or in how we call it) fails here.
+    const nativeModule = createMockModule();
+    const client = createCordieriteClient(nativeModule);
+
+    client.registerTool({
+      name: "zod4-sum",
+      description: "zod 4 tool",
+      inputSchema: z4.object({ a: z4.number(), b: z4.string() }),
+      outputSchema: z4.object({ total: z4.number() }),
+      handler: ({ a }) => ({ total: a }),
+    });
+
+    const connectPromise = client.connect(validBootstrap());
+    fireMessage(nativeModule, buildAck());
+    await connectPromise;
+    await flushMicrotasks();
+
+    const snapshot = nativeModule.sentMessages
+      .map((json) => JSON.parse(json) as Record<string, unknown>)
+      .find((message) => message.type === "tool_registry_snapshot");
+    const tool = (
+      snapshot?.tools as {
+        name: string;
+        input_schema?: Record<string, unknown>;
+        output_schema?: Record<string, unknown>;
+      }[]
+    ).find((entry) => entry.name === "zod4-sum");
+
+    expect(tool?.input_schema).toMatchObject({
+      type: "object",
+      properties: { a: { type: "number" }, b: { type: "string" } },
+      required: ["a", "b"],
+    });
+    expect(tool?.output_schema).toMatchObject({
+      type: "object",
+      properties: { total: { type: "number" } },
     });
   });
 

--- a/packages/react-native/src/__tests__/client.test.ts
+++ b/packages/react-native/src/__tests__/client.test.ts
@@ -4,6 +4,8 @@ import type {
   StandardSchemaV1JsonSchema,
 } from "@cordierite/shared";
 import { describe, expect, test } from "vitest";
+import { z as z3 } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 import type {
   CordieriteConnectionState,
@@ -280,6 +282,77 @@ describe("createCordieriteClient: claim handshake", () => {
         ],
       })
     );
+  });
+
+  test("a raw JSON Schema and a zod 3 pair both reach tool_registry_snapshot with a real shape (issue #27)", async () => {
+    const nativeModule = createMockModule();
+    const client = createCordieriteClient(nativeModule);
+
+    const rawInput = {
+      type: "object",
+      properties: { city: { type: "string" } },
+      required: ["city"],
+      additionalProperties: false,
+    };
+
+    client.registerTool({
+      name: "weather",
+      description: "Raw JSON Schema tool",
+      inputSchema: rawInput,
+      handler: () => undefined,
+    });
+
+    const zod3Input = z3.object({ a: z3.number() });
+    client.registerTool({
+      name: "sum",
+      description: "zod 3 paired tool",
+      inputSchema: {
+        schema: zod3Input,
+        jsonSchema: zodToJsonSchema(zod3Input, {
+          target: "jsonSchema2019-09",
+        }) as Record<string, unknown>,
+      },
+      handler: () => undefined,
+    });
+
+    const connectPromise = client.connect(validBootstrap());
+    fireMessage(nativeModule, buildAck());
+    await connectPromise;
+    await flushMicrotasks();
+
+    const snapshot = nativeModule.sentMessages
+      .map((json) => JSON.parse(json) as Record<string, unknown>)
+      .find((message) => message.type === "tool_registry_snapshot");
+
+    expect(snapshot).toBeDefined();
+    const tools = snapshot?.tools as { name: string; input_schema?: unknown }[];
+
+    expect(tools.find((tool) => tool.name === "weather")?.input_schema).toEqual(
+      rawInput
+    );
+    expect(
+      tools.find((tool) => tool.name === "sum")?.input_schema
+    ).toMatchObject({
+      type: "object",
+      properties: { a: { type: "number" } },
+      required: ["a"],
+    });
+  });
+
+  test("registering a bare zod 3 schema throws in dev, naming the supported forms (issue #27)", async () => {
+    const nativeModule = createMockModule();
+    const client = createCordieriteClient(nativeModule);
+
+    expect(() =>
+      client.registerTool({
+        name: "shapeless",
+        description: "zod 3 without an exporter",
+        inputSchema: z3.object({ a: z3.number() }),
+        handler: () => undefined,
+      })
+    ).toThrow(/schema, jsonSchema/);
+
+    expect(client.getRegisteredTools()).toEqual([]);
   });
 
   test("connect surfaces native connect() rejection on the unified error channel and rethrows", async () => {

--- a/packages/react-native/src/__tests__/client.test.ts
+++ b/packages/react-native/src/__tests__/client.test.ts
@@ -329,10 +329,10 @@ describe("createCordieriteClient: claim handshake", () => {
     const tools = snapshot?.tools as { name: string; input_schema?: unknown }[];
 
     expect(tools.find((tool) => tool.name === "weather")?.input_schema).toEqual(
-      rawInput
+      rawInput,
     );
     expect(
-      tools.find((tool) => tool.name === "sum")?.input_schema
+      tools.find((tool) => tool.name === "sum")?.input_schema,
     ).toMatchObject({
       type: "object",
       properties: { a: { type: "number" } },
@@ -391,7 +391,7 @@ describe("createCordieriteClient: claim handshake", () => {
         description: "zod 3 without an exporter",
         inputSchema: z3.object({ a: z3.number() }),
         handler: () => undefined,
-      })
+      }),
     ).toThrow(/schema, jsonSchema/);
 
     expect(client.getRegisteredTools()).toEqual([]);

--- a/packages/react-native/src/__tests__/noop-parity.test.ts
+++ b/packages/react-native/src/__tests__/noop-parity.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, vi, test } from "vitest";
+import { z as z3 } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 import { CordieriteDisabledError } from "../Cordierite.types";
 import type { CordierePublicApi } from "../public-api";
 
 (globalThis as { __DEV__?: boolean }).__DEV__ = true;
+
+/** Compile-time assertion that `value` is exactly `T` (invariant, so a widened arg type fails). */
+const expectType = <T>(value: T): T => value;
 
 // The root (`.`) entry pulls in `react-native` (for `AppState`/`Linking`), whose own source cannot
 // be parsed under a Node test runner (Flow-typed; see `deep-link-install.test.ts`); `./noop` never
@@ -35,6 +40,7 @@ describe("noop parity: type-level (see also public-api.ts's doc comment)", () =>
     const names: (keyof CordierePublicApi)[] = [
       "registerTool",
       "useCordieriteTool",
+      "jsonSchema",
       "postEvent",
       "getRegisteredTools",
       "addCordieriteListener",
@@ -47,6 +53,64 @@ describe("noop parity: type-level (see also public-api.ts's doc comment)", () =>
       expect(typeof realSatisfiesPublicApi[name]).toBe("function");
       expect(typeof noopSatisfiesPublicApi[name]).toBe("function");
     }
+  });
+
+  test("every accepted schema form compiles identically against both entries (issue #27)", async () => {
+    const realModule = await import("../index");
+    const noopModule = await import("../noop");
+
+    const rawSchema = {
+      type: "object",
+      properties: { city: { type: "string" } },
+      required: ["city"],
+    };
+    const zod3Input = z3.object({ a: z3.number() });
+    const pairedSchema = {
+      schema: zod3Input,
+      jsonSchema: zodToJsonSchema(zod3Input) as Record<string, unknown>,
+    };
+
+    // As with the assignments above, the real enforcement is `tsc`: each of these registrations
+    // must type-check against BOTH entries, and each `handler` must receive the inferred argument
+    // type — a bare raw schema gives `Record<string, unknown>`, `jsonSchema<T>()` gives `T`, and a
+    // pair gives the Standard Schema's own output type.
+    const registrars: CordierePublicApi["registerTool"][] = [
+      realModule.registerTool,
+      noopModule.registerTool,
+    ];
+
+    for (const registerTool of registrars) {
+      registerTool({
+        name: "raw-bare",
+        description: "d",
+        inputSchema: rawSchema,
+        handler: (args) => {
+          expectType<Record<string, unknown>>(args);
+        },
+      }).remove();
+
+      registerTool({
+        name: "raw-typed",
+        description: "d",
+        inputSchema: noopModule.jsonSchema<{ city: string }>(rawSchema),
+        handler: (args) => {
+          expectType<{ city: string }>(args);
+        },
+      }).remove();
+
+      registerTool({
+        name: "paired",
+        description: "d",
+        inputSchema: pairedSchema,
+        handler: (args) => {
+          expectType<{ a: number }>(args);
+        },
+      }).remove();
+    }
+
+    // `jsonSchema` is the same identity helper on both entries.
+    expect(realModule.jsonSchema(rawSchema)).toBe(rawSchema);
+    expect(noopModule.jsonSchema(rawSchema)).toBe(rawSchema);
   });
 
   test("useCordieriteTool takes the same (definition, deps, options) arity on both entries", async () => {

--- a/packages/react-native/src/__tests__/schema-inference.test.ts
+++ b/packages/react-native/src/__tests__/schema-inference.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Type-level regression guard for issue #27: widening what `inputSchema`/`outputSchema` accept
+ * must not weaken handler argument/result inference for the forms that already worked (zod 4),
+ * and must give the new forms real types too.
+ *
+ * The enforcement here is `tsc` (`pnpm typecheck` / `pnpm build`), not Vitest — `exactType` is
+ * invariant, so a handler argument that is even slightly wider or narrower than the expected type
+ * fails to compile. The single runtime assertion exists only so the file is a real test.
+ */
+import { describe, expect, test, vi } from "vitest";
+import { z as z3 } from "zod";
+import { z as z4 } from "zod4";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+import { jsonSchema } from "../Cordierite.types";
+import type { CordierePublicApi } from "../public-api";
+
+(globalThis as { __DEV__?: boolean }).__DEV__ = true;
+
+vi.mock("react-native", () => ({
+  AppState: {
+    currentState: "active",
+    addEventListener: () => ({ remove() {} }),
+  },
+  Linking: {
+    getInitialURL: () => Promise.resolve(null),
+    addEventListener: () => ({ remove() {} }),
+  },
+}));
+
+type Equals<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false;
+
+/** Compiles only when `A` is *exactly* `Expected` — not merely assignable in either direction. */
+const exactType =
+  <Expected>() =>
+  <A>(_value: A & (Equals<A, Expected> extends true ? unknown : never)): void => {};
+
+describe("handler inference across every accepted schema form (issue #27)", () => {
+  test("compiles against the shared public API type", async () => {
+    const { registerTool } = (await import("../noop")) as Pick<
+      CordierePublicApi,
+      "registerTool"
+    >;
+
+    // zod 4: unchanged behaviour — the schema's own output type, via `~standard`.
+    registerTool({
+      name: "zod4",
+      description: "d",
+      inputSchema: z4.object({ a: z4.number(), b: z4.string() }),
+      outputSchema: z4.object({ total: z4.number() }),
+      handler: (args) => {
+        exactType<{ a: number; b: string }>()(args);
+        return { total: args.a };
+      },
+    }).remove();
+
+    // zod 3 paired with an explicit JSON Schema: same inference as zod 4.
+    const zod3Input = z3.object({ a: z3.number() });
+    const zod3Output = z3.object({ total: z3.number() });
+    registerTool({
+      name: "zod3-paired",
+      description: "d",
+      inputSchema: {
+        schema: zod3Input,
+        jsonSchema: zodToJsonSchema(zod3Input) as Record<string, unknown>,
+      },
+      outputSchema: {
+        schema: zod3Output,
+        jsonSchema: zodToJsonSchema(zod3Output) as Record<string, unknown>,
+      },
+      handler: (args) => {
+        exactType<{ a: number }>()(args);
+        return { total: args.a };
+      },
+    }).remove();
+
+    // A bare raw JSON Schema: no type information to recover, so `Record<string, unknown>`.
+    registerTool({
+      name: "raw-bare",
+      description: "d",
+      inputSchema: { type: "object", properties: { city: { type: "string" } } },
+      handler: (args) => {
+        exactType<Record<string, unknown>>()(args);
+      },
+    }).remove();
+
+    // `jsonSchema<T>()` carries the caller's declared type into the handler.
+    registerTool({
+      name: "raw-typed",
+      description: "d",
+      inputSchema: jsonSchema<{ city: string }>({ type: "object" }),
+      outputSchema: jsonSchema<{ temp: number }>({ type: "object" }),
+      handler: (args) => {
+        exactType<{ city: string }>()(args);
+        return { temp: args.city.length };
+      },
+    }).remove();
+
+    expect(true).toBe(true);
+  });
+});

--- a/packages/react-native/src/__tests__/schema-inference.test.ts
+++ b/packages/react-native/src/__tests__/schema-inference.test.ts
@@ -12,7 +12,11 @@ import { z as z3 } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { z as z4 } from "zod4";
 
-import type { CordieriteRuntimeSchema } from "../Cordierite.types";
+import type {
+  CordieriteRuntimeSchema,
+  InferToolArgs,
+  InferToolResult,
+} from "../Cordierite.types";
 import { jsonSchema } from "../Cordierite.types";
 import type { CordierePublicApi } from "../public-api";
 
@@ -139,6 +143,71 @@ describe("handler inference across every accepted schema form (issue #27)", () =
         exactType<{ a: number }>()(args);
       },
     }).remove();
+
+    expect(true).toBe(true);
+  });
+
+  test("a two-parameter CordieriteRuntimeSchema<In, Out> keeps the sides apart", async () => {
+    const { registerTool } = await import("../noop");
+
+    // With distinct input and output types the two sides must not collapse into `In | Out`: an
+    // `inputSchema` handler receives the *output* (post-validation) type, an `outputSchema` handler
+    // returns the *input* (pre-validation) one. A raw member carrying a single phantom slot would
+    // widen both to the union.
+    const coercing: CordieriteRuntimeSchema<string, number> = {
+      "~standard": {
+        version: 1,
+        vendor: "test",
+        validate: (value: unknown) => ({ value: Number(value) }),
+      },
+    } as CordieriteRuntimeSchema<string, number>;
+
+    registerTool({
+      name: "two-param-input",
+      description: "d",
+      inputSchema: coercing,
+      handler: (args) => {
+        exactType<number>()(args);
+      },
+    }).remove();
+
+    registerTool({
+      name: "two-param-output",
+      description: "d",
+      outputSchema: coercing,
+      handler: () => {
+        return "42";
+      },
+    }).remove();
+
+    // `registerTool` above only proves the handler's return is *assignable*; these assert the two
+    // sides are exactly `number` and `string`, so a collapse to `string | number` fails to compile.
+    exactType<number>()(null as unknown as InferToolArgs<typeof coercing>);
+    exactType<string>()(null as unknown as InferToolResult<typeof coercing>);
+
+    // Same annotation, satisfied by a raw JSON Schema rather than a Standard Schema.
+    const coercingRaw = {} as CordieriteRuntimeSchema<string, number>;
+
+    registerTool({
+      name: "two-param-raw-input",
+      description: "d",
+      inputSchema: coercingRaw,
+      handler: (args) => {
+        exactType<number>()(args);
+      },
+    }).remove();
+
+    registerTool({
+      name: "two-param-raw-output",
+      description: "d",
+      outputSchema: coercingRaw,
+      handler: () => {
+        return "42";
+      },
+    }).remove();
+
+    exactType<number>()(null as unknown as InferToolArgs<typeof coercingRaw>);
+    exactType<string>()(null as unknown as InferToolResult<typeof coercingRaw>);
 
     expect(true).toBe(true);
   });

--- a/packages/react-native/src/__tests__/schema-inference.test.ts
+++ b/packages/react-native/src/__tests__/schema-inference.test.ts
@@ -9,9 +9,10 @@
  */
 import { describe, expect, test, vi } from "vitest";
 import { z as z3 } from "zod";
-import { z as z4 } from "zod4";
 import { zodToJsonSchema } from "zod-to-json-schema";
+import { z as z4 } from "zod4";
 
+import type { CordieriteRuntimeSchema } from "../Cordierite.types";
 import { jsonSchema } from "../Cordierite.types";
 import type { CordierePublicApi } from "../public-api";
 
@@ -36,7 +37,9 @@ type Equals<A, B> =
 /** Compiles only when `A` is *exactly* `Expected` — not merely assignable in either direction. */
 const exactType =
   <Expected>() =>
-  <A>(_value: A & (Equals<A, Expected> extends true ? unknown : never)): void => {};
+  <A>(
+    _value: A & (Equals<A, Expected> extends true ? unknown : never),
+  ): void => {};
 
 describe("handler inference across every accepted schema form (issue #27)", () => {
   test("compiles against the shared public API type", async () => {
@@ -96,6 +99,44 @@ describe("handler inference across every accepted schema form (issue #27)", () =
       handler: (args) => {
         exactType<{ city: string }>()(args);
         return { temp: args.city.length };
+      },
+    }).remove();
+
+    expect(true).toBe(true);
+  });
+
+  test("an explicitly annotated CordieriteRuntimeSchema<T> stays exactly T", async () => {
+    const { registerTool } = await import("../noop");
+
+    // Annotating the schema (rather than letting it be inferred from the value) must not widen the
+    // handler argument: every member of the union — Standard Schema, pair, and raw — carries the
+    // annotation's own type, so the raw member cannot leak `Record<string, unknown>` back in.
+    const annotated: CordieriteRuntimeSchema<{ a: number }> = z4.object({
+      a: z4.number(),
+    });
+
+    registerTool({
+      name: "annotated",
+      description: "d",
+      inputSchema: annotated,
+      outputSchema: annotated,
+      handler: (args) => {
+        exactType<{ a: number }>()(args);
+        return { a: args.a };
+      },
+    }).remove();
+
+    // The same annotation satisfied by a raw JSON Schema rather than a Standard Schema.
+    const annotatedRaw: CordieriteRuntimeSchema<{ a: number }> = jsonSchema<{
+      a: number;
+    }>({ type: "object", properties: { a: { type: "number" } } });
+
+    registerTool({
+      name: "annotated-raw",
+      description: "d",
+      inputSchema: annotatedRaw,
+      handler: (args) => {
+        exactType<{ a: number }>()(args);
       },
     }).remove();
 

--- a/packages/react-native/src/__tests__/schema.test.ts
+++ b/packages/react-native/src/__tests__/schema.test.ts
@@ -1,15 +1,44 @@
 import type { StandardSchemaV1 } from "@cordierite/shared";
 import { describe, expect, test } from "vitest";
+import { z as z3 } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
-import { exportToolSchema, toToolDescriptor } from "../schema";
+import { jsonSchema } from "../Cordierite.types";
+import {
+  exportToolSchema,
+  normalizeOptionalToolSchema,
+  normalizeToolSchema,
+  toToolDescriptor,
+  validateToolSchema,
+} from "../schema";
 
 (globalThis as { __DEV__?: boolean }).__DEV__ = true;
+
+const setDev = (value: boolean): void => {
+  (globalThis as { __DEV__?: boolean }).__DEV__ = value;
+};
+
+const withDev = <T>(value: boolean, run: () => T): T => {
+  const previous = (globalThis as { __DEV__?: boolean }).__DEV__;
+  setDev(value);
+  try {
+    return run();
+  } finally {
+    (globalThis as { __DEV__?: boolean }).__DEV__ = previous;
+  }
+};
 
 const success = <T>(value: T): StandardSchemaV1.SuccessResult<T> => ({
   value,
 });
 
-/** A Standard Schema without a JSON Schema exporter — the zod 3 / valibot shape. */
+/**
+ * A real zod 3 schema: it implements `~standard` but has no `~standard.jsonSchema` exporter, which
+ * is exactly the shape issue #27 is about. Asserted below rather than assumed.
+ */
+const zod3Schema = z3.object({ a: z3.number() });
+
+/** A hand-rolled Standard Schema without an exporter (stands in for plain valibot / arktype). */
 const shapelessSchema: StandardSchemaV1 = {
   "~standard": {
     version: 1,
@@ -25,12 +54,12 @@ const withJsonSchemaExporter = (): StandardSchemaV1 => ({
     validate: (value: unknown) => success(value),
     jsonSchema: {
       input: () => ({ type: "object" }),
-      output: () => ({ type: "object" }),
+      output: () => ({ type: "object", title: "out" }),
     },
   } as unknown as StandardSchemaV1["~standard"],
 });
 
-const withDevWarnCaptured = (run: () => void): string[][] => {
+const withWarningsCaptured = (run: () => void): string[][] => {
   const warnings: string[][] = [];
   const original = console.warn;
   console.warn = (...args: unknown[]) => {
@@ -44,69 +73,378 @@ const withDevWarnCaptured = (run: () => void): string[][] => {
   return warnings;
 };
 
-describe("exportToolSchema: missing JSON Schema exporter", () => {
-  test("returns undefined and warns once when a tool name is given", () => {
-    const warnings = withDevWarnCaptured(() => {
-      const result = exportToolSchema(shapelessSchema, "input", "my-tool");
-      expect(result).toBeUndefined();
-    });
+const rawJsonSchema = {
+  type: "object",
+  properties: { city: { type: "string" } },
+  required: ["city"],
+  additionalProperties: false,
+};
 
-    expect(
-      warnings.some((args) =>
-        args.some((arg) => arg.includes("my-tool") && arg.includes("shapeless"))
-      )
-    ).toBe(true);
+describe("zod 3 baseline (the case issue #27 is about)", () => {
+  test("zod 3 exposes ~standard.validate but no ~standard.jsonSchema exporter", () => {
+    const standard = (zod3Schema as unknown as Record<string, unknown>)[
+      "~standard"
+    ] as Record<string, unknown>;
+
+    expect(typeof standard.validate).toBe("function");
+    expect(standard.jsonSchema).toBeUndefined();
+  });
+});
+
+describe("normalizeToolSchema: detection matrix", () => {
+  test("a Standard Schema is detected as kind 'standard'", () => {
+    expect(normalizeToolSchema(zod3Schema, "l")).toEqual({
+      kind: "standard",
+      schema: zod3Schema,
+    });
   });
 
-  test("does not warn a second time for the same tool name", () => {
-    const warnings = withDevWarnCaptured(() => {
-      exportToolSchema(shapelessSchema, "input", "dup-tool");
-      exportToolSchema(shapelessSchema, "output", "dup-tool");
-    });
+  test("a { schema, jsonSchema } object pair is detected as kind 'paired'", () => {
+    const pair = { schema: zod3Schema, jsonSchema: rawJsonSchema };
 
-    const matching = warnings.filter((args) =>
-      args.some((arg) => arg.includes("dup-tool"))
+    expect(normalizeToolSchema(pair, "l")).toEqual({
+      kind: "paired",
+      schema: zod3Schema,
+      jsonSchema: rawJsonSchema,
+    });
+  });
+
+  test("a { schema, jsonSchema } converter pair keeps the converter", () => {
+    const converter = {
+      input: () => ({ type: "object" }),
+      output: () => ({ type: "object" }),
+    };
+    const normalized = normalizeToolSchema(
+      { schema: zod3Schema, jsonSchema: converter },
+      "l"
     );
-    expect(matching).toHaveLength(1);
+
+    expect(normalized).toEqual({
+      kind: "paired",
+      schema: zod3Schema,
+      jsonSchema: converter,
+    });
   });
 
-  test("does not warn when no schema is provided at all", () => {
-    const warnings = withDevWarnCaptured(() => {
-      const result = exportToolSchema(undefined, "input", "no-schema-tool");
-      expect(result).toBeUndefined();
+  test("a plain object with no ~standard is detected as kind 'raw'", () => {
+    expect(normalizeToolSchema(rawJsonSchema, "l")).toEqual({
+      kind: "raw",
+      jsonSchema: rawJsonSchema,
+    });
+  });
+
+  test("a JSON Schema whose own keywords include `schema` is still raw", () => {
+    const schemaKeyword = { type: "object", schema: { type: "string" } };
+
+    expect(normalizeToolSchema(schemaKeyword, "l")).toEqual({
+      kind: "raw",
+      jsonSchema: schemaKeyword,
+    });
+  });
+
+  test("throws when ~standard is present but not a Standard Schema", () => {
+    expect(() => normalizeToolSchema({ "~standard": {} }, "MySchema")).toThrow(
+      /must expose "~standard.validate"/
+    );
+  });
+
+  test("throws for a pair missing its jsonSchema half", () => {
+    expect(() => normalizeToolSchema({ schema: zod3Schema }, "MySchema")).toThrow(
+      /"jsonSchema" is missing or not an object/
+    );
+  });
+
+  test("throws for non-objects and arrays", () => {
+    expect(() => normalizeToolSchema("nope", "MySchema")).toThrow(TypeError);
+    expect(() => normalizeToolSchema(null, "MySchema")).toThrow(TypeError);
+    expect(() => normalizeToolSchema([{ type: "object" }], "MySchema")).toThrow(
+      TypeError
+    );
+  });
+
+  test("normalizeOptionalToolSchema passes undefined through", () => {
+    expect(normalizeOptionalToolSchema(undefined, "l")).toBeUndefined();
+  });
+});
+
+describe("exportToolSchema: Standard Schema with an exporter", () => {
+  test("exports the mode-specific JSON Schema and never warns", () => {
+    const warnings = withWarningsCaptured(() => {
+      const normalized = normalizeToolSchema(withJsonSchemaExporter(), "l");
+
+      expect(exportToolSchema(normalized, "input", "shaped-tool")).toEqual({
+        type: "object",
+      });
+      expect(exportToolSchema(normalized, "output", "shaped-tool")).toEqual({
+        type: "object",
+        title: "out",
+      });
     });
 
     expect(warnings).toEqual([]);
   });
 
-  test("does not warn when the schema does export JSON Schema", () => {
-    const warnings = withDevWarnCaptured(() => {
-      const result = exportToolSchema(
-        withJsonSchemaExporter(),
-        "input",
-        "shaped-tool"
-      );
-      expect(result).toEqual({ type: "object" });
+  test("returns undefined when the exporter itself throws", () => {
+    const throwing = {
+      "~standard": {
+        version: 1,
+        vendor: "test",
+        validate: (value: unknown) => success(value),
+        jsonSchema: {
+          input: () => {
+            throw new Error("nope");
+          },
+          output: () => ({ type: "object" }),
+        },
+      },
+    };
+
+    expect(
+      exportToolSchema(normalizeToolSchema(throwing, "l"), "input", "t")
+    ).toBeUndefined();
+  });
+});
+
+describe("exportToolSchema: Standard Schema without an exporter", () => {
+  test("throws in dev, naming the tool and pointing at the two supported forms", () => {
+    const normalized = normalizeToolSchema(zod3Schema, "l");
+
+    expect(() =>
+      withDev(true, () => exportToolSchema(normalized, "input", "zod3-tool"))
+    ).toThrow(/zod3-tool/);
+    expect(() =>
+      withDev(true, () => exportToolSchema(normalized, "input", "zod3-tool"))
+    ).toThrow(/schema, jsonSchema/);
+  });
+
+  test("throws in dev even when no tool name is available", () => {
+    expect(() =>
+      withDev(true, () =>
+        exportToolSchema(normalizeToolSchema(shapelessSchema, "l"), "input")
+      )
+    ).toThrow(TypeError);
+  });
+
+  test("outside dev it warns once per tool name and registers shapeless", () => {
+    const warnings = withWarningsCaptured(() => {
+      withDev(false, () => {
+        const normalized = normalizeToolSchema(shapelessSchema, "l");
+
+        expect(exportToolSchema(normalized, "input", "prod-tool")).toBeUndefined();
+        expect(
+          exportToolSchema(normalized, "output", "prod-tool")
+        ).toBeUndefined();
+      });
+    });
+
+    const matching = warnings.filter((args) =>
+      args.some((arg) => arg.includes("prod-tool") && arg.includes("shapeless"))
+    );
+    expect(matching).toHaveLength(1);
+  });
+
+  test("does not warn or throw when no schema is provided at all", () => {
+    const warnings = withWarningsCaptured(() => {
+      expect(exportToolSchema(undefined, "input", "no-schema-tool")).toBeUndefined();
     });
 
     expect(warnings).toEqual([]);
   });
 });
 
-describe("toToolDescriptor: shapeless tool still registers", () => {
-  test("registers with no input_schema/output_schema fields, not a throw", () => {
-    withDevWarnCaptured(() => {
-      const descriptor = toToolDescriptor({
-        name: "shapeless-registered",
-        description: "d",
-        inputSchema: shapelessSchema,
-        outputSchema: shapelessSchema,
-      });
+describe("exportToolSchema: paired schemas", () => {
+  test("a real zod 3 schema paired with zod-to-json-schema publishes a real shape", () => {
+    const normalized = normalizeToolSchema(
+      {
+        schema: zod3Schema,
+        jsonSchema: zodToJsonSchema(zod3Schema, {
+          target: "jsonSchema2019-09",
+        }) as Record<string, unknown>,
+      },
+      "l"
+    );
 
-      expect(descriptor).toEqual({
-        name: "shapeless-registered",
-        description: "d",
+    const exported = exportToolSchema(normalized, "input", "zod3-paired");
+
+    expect(exported).toMatchObject({
+      type: "object",
+      properties: { a: { type: "number" } },
+      required: ["a"],
+    });
+  });
+
+  test("a converter pair is called with the draft 2020-12 target, per mode", () => {
+    const targets: string[] = [];
+    const normalized = normalizeToolSchema(
+      {
+        schema: zod3Schema,
+        jsonSchema: {
+          input: (options: { target: string }) => {
+            targets.push(options.target);
+            return { type: "object", title: "in" };
+          },
+          output: (options: { target: string }) => {
+            targets.push(options.target);
+            return { type: "object", title: "out" };
+          },
+        },
+      },
+      "l"
+    );
+
+    expect(exportToolSchema(normalized, "input", "t")).toEqual({
+      type: "object",
+      title: "in",
+    });
+    expect(exportToolSchema(normalized, "output", "t")).toEqual({
+      type: "object",
+      title: "out",
+    });
+    expect(targets).toEqual(["draft-2020-12", "draft-2020-12"]);
+  });
+
+  test("a paired schema never warns or throws in dev", () => {
+    const warnings = withWarningsCaptured(() => {
+      withDev(true, () => {
+        expect(
+          exportToolSchema(
+            normalizeToolSchema(
+              { schema: zod3Schema, jsonSchema: rawJsonSchema },
+              "l"
+            ),
+            "input",
+            "paired-tool"
+          )
+        ).toEqual(rawJsonSchema);
       });
+    });
+
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe("exportToolSchema: raw JSON Schema", () => {
+  test("is published verbatim for both modes, with no warning in dev", () => {
+    const warnings = withWarningsCaptured(() => {
+      withDev(true, () => {
+        const normalized = normalizeToolSchema(rawJsonSchema, "l");
+
+        expect(exportToolSchema(normalized, "input", "raw-tool")).toEqual(
+          rawJsonSchema
+        );
+        expect(exportToolSchema(normalized, "output", "raw-tool")).toEqual(
+          rawJsonSchema
+        );
+      });
+    });
+
+    expect(warnings).toEqual([]);
+  });
+});
+
+describe("validateToolSchema", () => {
+  test("a zod 3 schema validates through ~standard.validate", async () => {
+    const normalized = normalizeToolSchema(zod3Schema, "l");
+
+    await expect(validateToolSchema(normalized, { a: 1 })).resolves.toEqual({
+      ok: true,
+      value: { a: 1 },
+    });
+
+    const failure = await validateToolSchema(normalized, { a: "no" });
+    expect(failure.ok).toBe(false);
+    if (!failure.ok) {
+      expect(failure.issues[0]?.path).toEqual(["a"]);
+    }
+  });
+
+  test("a paired schema validates through its `schema` half", async () => {
+    const normalized = normalizeToolSchema(
+      { schema: zod3Schema, jsonSchema: rawJsonSchema },
+      "l"
+    );
+
+    const failure = await validateToolSchema(normalized, { a: "no" });
+    expect(failure.ok).toBe(false);
+  });
+
+  test("a raw JSON Schema passes every value through unvalidated", async () => {
+    const normalized = normalizeToolSchema(rawJsonSchema, "l");
+
+    // Deliberately does not match `rawJsonSchema`: there is no app-side JSON Schema validator.
+    await expect(
+      validateToolSchema(normalized, { totally: "unrelated" })
+    ).resolves.toEqual({ ok: true, value: { totally: "unrelated" } });
+    await expect(validateToolSchema(normalized, 42)).resolves.toEqual({
+      ok: true,
+      value: 42,
+    });
+  });
+});
+
+describe("toToolDescriptor", () => {
+  test("publishes input_schema/output_schema from a raw JSON Schema", () => {
+    expect(
+      toToolDescriptor({
+        name: "raw-registered",
+        description: "d",
+        inputSchema: normalizeToolSchema(rawJsonSchema, "l"),
+        outputSchema: normalizeToolSchema({ type: "string" }, "l"),
+      })
+    ).toEqual({
+      name: "raw-registered",
+      description: "d",
+      input_schema: rawJsonSchema,
+      output_schema: { type: "string" },
+    });
+  });
+
+  test("publishes input_schema from a zod 3 + zod-to-json-schema pair", () => {
+    const descriptor = toToolDescriptor({
+      name: "zod3-registered",
+      description: "d",
+      inputSchema: normalizeToolSchema(
+        {
+          schema: zod3Schema,
+          jsonSchema: zodToJsonSchema(zod3Schema, {
+            target: "jsonSchema2019-09",
+          }) as Record<string, unknown>,
+        },
+        "l"
+      ),
+    });
+
+    expect(descriptor.input_schema).toMatchObject({
+      type: "object",
+      properties: { a: { type: "number" } },
+    });
+    expect(descriptor.output_schema).toBeUndefined();
+  });
+
+  test("outside dev a shapeless tool still registers with no schema fields", () => {
+    withWarningsCaptured(() => {
+      withDev(false, () => {
+        expect(
+          toToolDescriptor({
+            name: "shapeless-registered",
+            description: "d",
+            inputSchema: normalizeToolSchema(shapelessSchema, "l"),
+            outputSchema: normalizeToolSchema(shapelessSchema, "l"),
+          })
+        ).toEqual({ name: "shapeless-registered", description: "d" });
+      });
+    });
+  });
+});
+
+describe("jsonSchema<T>() helper", () => {
+  test("returns the very same object (identity at runtime)", () => {
+    const tagged = jsonSchema<{ city: string }>(rawJsonSchema);
+
+    expect(tagged).toBe(rawJsonSchema);
+    expect(normalizeToolSchema(tagged, "l")).toEqual({
+      kind: "raw",
+      jsonSchema: rawJsonSchema,
     });
   });
 });

--- a/packages/react-native/src/__tests__/schema.test.ts
+++ b/packages/react-native/src/__tests__/schema.test.ts
@@ -47,6 +47,26 @@ const shapelessSchema: StandardSchemaV1 = {
   },
 };
 
+/**
+ * A *callable* Standard Schema. arktype's `Type` is a function object carrying `~standard`, so
+ * `typeof` reports `"function"` — detection must not require a plain object.
+ */
+const callableStandardSchema = (): StandardSchemaV1 => {
+  const schema = (value: unknown) => value;
+  Object.assign(schema, {
+    "~standard": {
+      version: 1,
+      vendor: "arktype-like",
+      validate: (value: unknown) => success(value),
+      jsonSchema: {
+        input: () => ({ type: "object", title: "callable-in" }),
+        output: () => ({ type: "object", title: "callable-out" }),
+      },
+    },
+  });
+  return schema as unknown as StandardSchemaV1;
+};
+
 const withJsonSchemaExporter = (): StandardSchemaV1 => ({
   "~standard": {
     version: 1,
@@ -116,13 +136,23 @@ describe("normalizeToolSchema: detection matrix", () => {
     };
     const normalized = normalizeToolSchema(
       { schema: zod3Schema, jsonSchema: converter },
-      "l"
+      "l",
     );
 
     expect(normalized).toEqual({
       kind: "paired",
       schema: zod3Schema,
       jsonSchema: converter,
+    });
+  });
+
+  test("a callable Standard Schema (the arktype shape) is detected as kind 'standard'", () => {
+    const schema = callableStandardSchema();
+
+    expect(typeof schema).toBe("function");
+    expect(normalizeToolSchema(schema, "l")).toEqual({
+      kind: "standard",
+      schema,
     });
   });
 
@@ -133,32 +163,64 @@ describe("normalizeToolSchema: detection matrix", () => {
     });
   });
 
-  test("a JSON Schema whose own keywords include `schema` is still raw", () => {
-    const schemaKeyword = { type: "object", schema: { type: "string" } };
-
-    expect(normalizeToolSchema(schemaKeyword, "l")).toEqual({
-      kind: "raw",
-      jsonSchema: schemaKeyword,
-    });
-  });
-
   test("throws when ~standard is present but not a Standard Schema", () => {
     expect(() => normalizeToolSchema({ "~standard": {} }, "MySchema")).toThrow(
-      /must expose "~standard.validate"/
+      /must expose "~standard.validate"/,
     );
   });
 
   test("throws for a pair missing its jsonSchema half", () => {
-    expect(() => normalizeToolSchema({ schema: zod3Schema }, "MySchema")).toThrow(
-      /"jsonSchema" is missing or not an object/
+    expect(() =>
+      normalizeToolSchema({ schema: zod3Schema }, "MySchema"),
+    ).toThrow(/"jsonSchema" is missing or not an object/);
+  });
+
+  test("throws for a pair whose `schema` half is a JSON Schema, not a Standard Schema", () => {
+    // The easy mistake: putting JSON Schema in both halves. Silently publishing this object
+    // verbatim would make `{ schema: ..., jsonSchema: ... }` the tool's advertised shape.
+    expect(() =>
+      normalizeToolSchema(
+        { schema: { type: "object" }, jsonSchema: rawJsonSchema },
+        "MySchema",
+      ),
+    ).toThrow(/"schema" is missing or is not a Standard Schema/);
+  });
+
+  test("throws for a lone `jsonSchema` wrapper with no `schema` half", () => {
+    expect(() =>
+      normalizeToolSchema({ jsonSchema: rawJsonSchema }, "MySchema"),
+    ).toThrow(/"schema" is missing or is not a Standard Schema/);
+  });
+
+  test("throws for an object carrying no JSON Schema keyword at all", () => {
+    expect(() => normalizeToolSchema({}, "MySchema")).toThrow(
+      /does not look like JSON Schema/,
     );
+    expect(() => normalizeToolSchema({ city: "Warsaw" }, "MySchema")).toThrow(
+      /does not look like JSON Schema/,
+    );
+  });
+
+  test("accepts every recognised JSON Schema keyword on its own", () => {
+    for (const keyword of [
+      "type",
+      "properties",
+      "$ref",
+      "anyOf",
+      "allOf",
+      "oneOf",
+      "enum",
+      "const",
+    ]) {
+      expect(normalizeToolSchema({ [keyword]: "x" }, "l").kind).toBe("raw");
+    }
   });
 
   test("throws for non-objects and arrays", () => {
     expect(() => normalizeToolSchema("nope", "MySchema")).toThrow(TypeError);
     expect(() => normalizeToolSchema(null, "MySchema")).toThrow(TypeError);
     expect(() => normalizeToolSchema([{ type: "object" }], "MySchema")).toThrow(
-      TypeError
+      TypeError,
     );
   });
 
@@ -184,7 +246,20 @@ describe("exportToolSchema: Standard Schema with an exporter", () => {
     expect(warnings).toEqual([]);
   });
 
-  test("returns undefined when the exporter itself throws", () => {
+  test("a callable Standard Schema exports through its ~standard.jsonSchema", () => {
+    const normalized = normalizeToolSchema(callableStandardSchema(), "l");
+
+    expect(exportToolSchema(normalized, "input", "callable-tool")).toEqual({
+      type: "object",
+      title: "callable-in",
+    });
+    expect(exportToolSchema(normalized, "output", "callable-tool")).toEqual({
+      type: "object",
+      title: "callable-out",
+    });
+  });
+
+  test("an exporter that throws is reported, not silently swallowed", () => {
     const throwing = {
       "~standard": {
         version: 1,
@@ -192,16 +267,56 @@ describe("exportToolSchema: Standard Schema with an exporter", () => {
         validate: (value: unknown) => success(value),
         jsonSchema: {
           input: () => {
-            throw new Error("nope");
+            throw new Error("exporter blew up");
           },
           output: () => ({ type: "object" }),
         },
       },
     };
+    const normalized = normalizeToolSchema(throwing, "l");
 
+    expect(() =>
+      withDev(true, () =>
+        exportToolSchema(normalized, "input", "throwing-tool"),
+      ),
+    ).toThrow(/exporter blew up/);
+
+    const warnings = withWarningsCaptured(() => {
+      withDev(false, () => {
+        expect(
+          exportToolSchema(normalized, "input", "throwing-prod-tool"),
+        ).toBeUndefined();
+      });
+    });
     expect(
-      exportToolSchema(normalizeToolSchema(throwing, "l"), "input", "t")
-    ).toBeUndefined();
+      warnings.some((args) =>
+        args.some((arg) => arg.includes("exporter blew up")),
+      ),
+    ).toBe(true);
+  });
+
+  test("an exporter that returns a non-object is reported too", () => {
+    const notAnObject = {
+      "~standard": {
+        version: 1,
+        vendor: "test",
+        validate: (value: unknown) => success(value),
+        jsonSchema: {
+          input: () => "not a schema",
+          output: () => ({ type: "object" }),
+        },
+      },
+    };
+
+    expect(() =>
+      withDev(true, () =>
+        exportToolSchema(
+          normalizeToolSchema(notAnObject, "l"),
+          "input",
+          "string-tool",
+        ),
+      ),
+    ).toThrow(/returned string instead of a JSON Schema object/);
   });
 });
 
@@ -210,18 +325,18 @@ describe("exportToolSchema: Standard Schema without an exporter", () => {
     const normalized = normalizeToolSchema(zod3Schema, "l");
 
     expect(() =>
-      withDev(true, () => exportToolSchema(normalized, "input", "zod3-tool"))
+      withDev(true, () => exportToolSchema(normalized, "input", "zod3-tool")),
     ).toThrow(/zod3-tool/);
     expect(() =>
-      withDev(true, () => exportToolSchema(normalized, "input", "zod3-tool"))
+      withDev(true, () => exportToolSchema(normalized, "input", "zod3-tool")),
     ).toThrow(/schema, jsonSchema/);
   });
 
   test("throws in dev even when no tool name is available", () => {
     expect(() =>
       withDev(true, () =>
-        exportToolSchema(normalizeToolSchema(shapelessSchema, "l"), "input")
-      )
+        exportToolSchema(normalizeToolSchema(shapelessSchema, "l"), "input"),
+      ),
     ).toThrow(TypeError);
   });
 
@@ -230,22 +345,28 @@ describe("exportToolSchema: Standard Schema without an exporter", () => {
       withDev(false, () => {
         const normalized = normalizeToolSchema(shapelessSchema, "l");
 
-        expect(exportToolSchema(normalized, "input", "prod-tool")).toBeUndefined();
         expect(
-          exportToolSchema(normalized, "output", "prod-tool")
+          exportToolSchema(normalized, "input", "prod-tool"),
+        ).toBeUndefined();
+        expect(
+          exportToolSchema(normalized, "output", "prod-tool"),
         ).toBeUndefined();
       });
     });
 
     const matching = warnings.filter((args) =>
-      args.some((arg) => arg.includes("prod-tool") && arg.includes("shapeless"))
+      args.some(
+        (arg) => arg.includes("prod-tool") && arg.includes("shapeless"),
+      ),
     );
     expect(matching).toHaveLength(1);
   });
 
   test("does not warn or throw when no schema is provided at all", () => {
     const warnings = withWarningsCaptured(() => {
-      expect(exportToolSchema(undefined, "input", "no-schema-tool")).toBeUndefined();
+      expect(
+        exportToolSchema(undefined, "input", "no-schema-tool"),
+      ).toBeUndefined();
     });
 
     expect(warnings).toEqual([]);
@@ -261,7 +382,7 @@ describe("exportToolSchema: paired schemas", () => {
           target: "jsonSchema2019-09",
         }) as Record<string, unknown>,
       },
-      "l"
+      "l",
     );
 
     const exported = exportToolSchema(normalized, "input", "zod3-paired");
@@ -289,7 +410,7 @@ describe("exportToolSchema: paired schemas", () => {
           },
         },
       },
-      "l"
+      "l",
     );
 
     expect(exportToolSchema(normalized, "input", "t")).toEqual({
@@ -303,6 +424,59 @@ describe("exportToolSchema: paired schemas", () => {
     expect(targets).toEqual(["draft-2020-12", "draft-2020-12"]);
   });
 
+  test("a paired converter that throws is reported, not silently swallowed", () => {
+    // The pair form exists precisely to avoid a shapeless tool, so failing quietly here would put
+    // the original bug back for exactly the users who took the documented way out of it.
+    const normalized = normalizeToolSchema(
+      {
+        schema: zod3Schema,
+        jsonSchema: {
+          input: () => {
+            throw new Error("converter blew up");
+          },
+          output: () => ({ type: "object" }),
+        },
+      },
+      "l",
+    );
+
+    expect(() =>
+      withDev(true, () => exportToolSchema(normalized, "input", "bad-pair")),
+    ).toThrow(/converter blew up/);
+
+    const warnings = withWarningsCaptured(() => {
+      withDev(false, () => {
+        expect(
+          exportToolSchema(normalized, "input", "bad-pair-prod"),
+        ).toBeUndefined();
+      });
+    });
+    expect(
+      warnings.some((args) =>
+        args.some(
+          (arg) => arg.includes("bad-pair-prod") && arg.includes("shapeless"),
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  test("a paired converter returning a non-object is reported too", () => {
+    const normalized = normalizeToolSchema(
+      {
+        schema: zod3Schema,
+        jsonSchema: {
+          input: () => [1, 2, 3],
+          output: () => ({ type: "object" }),
+        },
+      },
+      "l",
+    );
+
+    expect(() =>
+      withDev(true, () => exportToolSchema(normalized, "input", "array-pair")),
+    ).toThrow(/returned an array instead of a JSON Schema object/);
+  });
+
   test("a paired schema never warns or throws in dev", () => {
     const warnings = withWarningsCaptured(() => {
       withDev(true, () => {
@@ -310,11 +484,11 @@ describe("exportToolSchema: paired schemas", () => {
           exportToolSchema(
             normalizeToolSchema(
               { schema: zod3Schema, jsonSchema: rawJsonSchema },
-              "l"
+              "l",
             ),
             "input",
-            "paired-tool"
-          )
+            "paired-tool",
+          ),
         ).toEqual(rawJsonSchema);
       });
     });
@@ -330,10 +504,10 @@ describe("exportToolSchema: raw JSON Schema", () => {
         const normalized = normalizeToolSchema(rawJsonSchema, "l");
 
         expect(exportToolSchema(normalized, "input", "raw-tool")).toEqual(
-          rawJsonSchema
+          rawJsonSchema,
         );
         expect(exportToolSchema(normalized, "output", "raw-tool")).toEqual(
-          rawJsonSchema
+          rawJsonSchema,
         );
       });
     });
@@ -361,7 +535,7 @@ describe("validateToolSchema", () => {
   test("a paired schema validates through its `schema` half", async () => {
     const normalized = normalizeToolSchema(
       { schema: zod3Schema, jsonSchema: rawJsonSchema },
-      "l"
+      "l",
     );
 
     const failure = await validateToolSchema(normalized, { a: "no" });
@@ -373,7 +547,7 @@ describe("validateToolSchema", () => {
 
     // Deliberately does not match `rawJsonSchema`: there is no app-side JSON Schema validator.
     await expect(
-      validateToolSchema(normalized, { totally: "unrelated" })
+      validateToolSchema(normalized, { totally: "unrelated" }),
     ).resolves.toEqual({ ok: true, value: { totally: "unrelated" } });
     await expect(validateToolSchema(normalized, 42)).resolves.toEqual({
       ok: true,
@@ -390,7 +564,7 @@ describe("toToolDescriptor", () => {
         description: "d",
         inputSchema: normalizeToolSchema(rawJsonSchema, "l"),
         outputSchema: normalizeToolSchema({ type: "string" }, "l"),
-      })
+      }),
     ).toEqual({
       name: "raw-registered",
       description: "d",
@@ -410,7 +584,7 @@ describe("toToolDescriptor", () => {
             target: "jsonSchema2019-09",
           }) as Record<string, unknown>,
         },
-        "l"
+        "l",
       ),
     });
 
@@ -430,7 +604,7 @@ describe("toToolDescriptor", () => {
             description: "d",
             inputSchema: normalizeToolSchema(shapelessSchema, "l"),
             outputSchema: normalizeToolSchema(shapelessSchema, "l"),
-          })
+          }),
         ).toEqual({ name: "shapeless-registered", description: "d" });
       });
     });

--- a/packages/react-native/src/__tests__/schema.test.ts
+++ b/packages/react-native/src/__tests__/schema.test.ts
@@ -172,7 +172,30 @@ describe("normalizeToolSchema: detection matrix", () => {
   test("throws for a pair missing its jsonSchema half", () => {
     expect(() =>
       normalizeToolSchema({ schema: zod3Schema }, "MySchema"),
-    ).toThrow(/"jsonSchema" is missing or not an object/);
+    ).toThrow(/"jsonSchema" half is not a plain JSON Schema object/);
+  });
+
+  test("throws for a pair whose jsonSchema half is a class instance", () => {
+    // Held to exactly the same standard as a hand-written raw schema, so the two forms cannot
+    // diverge in what they will publish.
+    class FakeSchema {
+      get type() {
+        return "object";
+      }
+    }
+
+    expect(() =>
+      normalizeToolSchema(
+        { schema: zod3Schema, jsonSchema: new FakeSchema() },
+        "MySchema",
+      ),
+    ).toThrow(/"jsonSchema" half is not a plain JSON Schema object/);
+  });
+
+  test("accepts an empty object as the jsonSchema half of a pair", () => {
+    expect(
+      normalizeToolSchema({ schema: zod3Schema, jsonSchema: {} }, "l"),
+    ).toEqual({ kind: "paired", schema: zod3Schema, jsonSchema: {} });
   });
 
   test("throws for a pair whose `schema` half is a JSON Schema, not a Standard Schema", () => {
@@ -192,28 +215,90 @@ describe("normalizeToolSchema: detection matrix", () => {
     ).toThrow(/"schema" is missing or is not a Standard Schema/);
   });
 
-  test("throws for an object carrying no JSON Schema keyword at all", () => {
-    expect(() => normalizeToolSchema({}, "MySchema")).toThrow(
-      /does not look like JSON Schema/,
-    );
-    expect(() => normalizeToolSchema({ city: "Warsaw" }, "MySchema")).toThrow(
-      /does not look like JSON Schema/,
+  test("throws for a validator instance carrying a prototype `type` (yup/joi/superstruct shape)", () => {
+    // The regression this rule exists for. A keyword probe using `in` walks the prototype chain,
+    // so such an instance would be classified raw and published as the tool's shape — and, holding
+    // a circular reference, would then break `JSON.stringify` on the whole registry snapshot, not
+    // just this tool.
+    class LegacyValidator {
+      self: LegacyValidator;
+
+      constructor() {
+        this.self = this;
+      }
+
+      get type() {
+        return "object";
+      }
+    }
+    const instance = new LegacyValidator();
+
+    expect("type" in instance).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(instance, "type")).toBe(false);
+    expect(() => JSON.stringify(instance)).toThrow();
+    expect(() => normalizeToolSchema(instance, "MySchema")).toThrow(
+      /is not a plain JSON Schema object/,
     );
   });
 
-  test("accepts every recognised JSON Schema keyword on its own", () => {
-    for (const keyword of [
-      "type",
-      "properties",
-      "$ref",
-      "anyOf",
-      "allOf",
-      "oneOf",
-      "enum",
-      "const",
+  test("throws for an object whose own `type` is not a JSON Schema type name", () => {
+    expect(() => normalizeToolSchema({ type: "banana" }, "MySchema")).toThrow(
+      /is not a plain JSON Schema object/,
+    );
+    expect(() => normalizeToolSchema({ type: 7 }, "MySchema")).toThrow(
+      /is not a plain JSON Schema object/,
+    );
+    expect(() => normalizeToolSchema({ type: [] }, "MySchema")).toThrow(
+      /is not a plain JSON Schema object/,
+    );
+  });
+
+  test("accepts an empty object — the canonical accept-anything JSON Schema", () => {
+    expect(normalizeToolSchema({}, "l")).toEqual({
+      kind: "raw",
+      jsonSchema: {},
+    });
+  });
+
+  test("accepts a null-prototype object", () => {
+    const schema = Object.assign(Object.create(null), { type: "object" });
+    expect(normalizeToolSchema(schema, "l").kind).toBe("raw");
+  });
+
+  test("accepts schemas built from keywords other than `type`", () => {
+    for (const schema of [
+      { $defs: { a: { type: "string" } } },
+      { required: ["a"] },
+      { items: { type: "string" } },
+      { not: {} },
+      { $ref: "#/$defs/a" },
+      { anyOf: [{ type: "string" }] },
+      { enum: ["a", "b"] },
+      { const: 1 },
+      { description: "anything goes" },
     ]) {
-      expect(normalizeToolSchema({ [keyword]: "x" }, "l").kind).toBe("raw");
+      expect(normalizeToolSchema(schema, "l").kind).toBe("raw");
     }
+  });
+
+  test("accepts every JSON Schema type name, and an array of them", () => {
+    for (const type of [
+      "null",
+      "boolean",
+      "object",
+      "array",
+      "number",
+      "string",
+      "integer",
+    ]) {
+      expect(normalizeToolSchema({ type }, "l").kind).toBe("raw");
+    }
+    expect(normalizeToolSchema({ type: ["string", "null"] }, "l").kind).toBe(
+      "raw",
+    );
+    expect(() =>
+      normalizeToolSchema({ type: ["string", "banana"] }, "MySchema"),
+    ).toThrow(/is not a plain JSON Schema object/);
   });
 
   test("throws for non-objects and arrays", () => {
@@ -340,7 +425,12 @@ describe("exportToolSchema: Standard Schema without an exporter", () => {
     ).toThrow(TypeError);
   });
 
-  test("outside dev it warns once per tool name and registers shapeless", () => {
+  test("outside dev it warns once per tool *and slot*, and registers shapeless", () => {
+    const matching = (warnings: string[][], needle: string) =>
+      warnings.filter((args) =>
+        args.some((arg) => arg.includes(needle) && arg.includes("shapeless")),
+      );
+
     const warnings = withWarningsCaptured(() => {
       withDev(false, () => {
         const normalized = normalizeToolSchema(shapelessSchema, "l");
@@ -354,12 +444,24 @@ describe("exportToolSchema: Standard Schema without an exporter", () => {
       });
     });
 
-    const matching = warnings.filter((args) =>
-      args.some(
-        (arg) => arg.includes("prod-tool") && arg.includes("shapeless"),
+    // Input and output are two separate things to fix, so both are reported; keying the dedupe on
+    // the tool name alone would hide the second.
+    expect(matching(warnings, "prod-tool")).toHaveLength(2);
+    expect(
+      matching(warnings, "prod-tool").filter((args) =>
+        args.some((arg) => arg.includes("inputSchema")),
       ),
-    );
-    expect(matching).toHaveLength(1);
+    ).toHaveLength(1);
+
+    // Re-registering the same tool does not warn again for a slot already reported.
+    const repeated = withWarningsCaptured(() => {
+      withDev(false, () => {
+        const normalized = normalizeToolSchema(shapelessSchema, "l");
+        exportToolSchema(normalized, "input", "prod-tool");
+        exportToolSchema(normalized, "output", "prod-tool");
+      });
+    });
+    expect(matching(repeated, "prod-tool")).toHaveLength(0);
   });
 
   test("does not warn or throw when no schema is provided at all", () => {
@@ -475,6 +577,43 @@ describe("exportToolSchema: paired schemas", () => {
     expect(() =>
       withDev(true, () => exportToolSchema(normalized, "input", "array-pair")),
     ).toThrow(/returned an array instead of a JSON Schema object/);
+  });
+
+  test("a paired converter returning a non-plain object is reported too", () => {
+    // Converter *results* are held to the same plain-object rule as a hand-written raw schema.
+    class FakeSchema {
+      get type() {
+        return "object";
+      }
+    }
+    const normalized = normalizeToolSchema(
+      {
+        schema: zod3Schema,
+        jsonSchema: {
+          input: () => new FakeSchema(),
+          output: () => ({ type: "object" }),
+        },
+      },
+      "l",
+    );
+
+    expect(() =>
+      withDev(true, () =>
+        exportToolSchema(normalized, "input", "instance-pair"),
+      ),
+    ).toThrow(/returned an object that is not plain JSON Schema/);
+  });
+
+  test("a converter returning an empty object is accepted", () => {
+    const normalized = normalizeToolSchema(
+      {
+        schema: zod3Schema,
+        jsonSchema: { input: () => ({}), output: () => ({}) },
+      },
+      "l",
+    );
+
+    expect(exportToolSchema(normalized, "input", "empty-pair")).toEqual({});
   });
 
   test("a paired schema never warns or throws in dev", () => {

--- a/packages/react-native/src/__tests__/tool-invocation.test.ts
+++ b/packages/react-native/src/__tests__/tool-invocation.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test, vi } from "vitest";
+import { z as z3 } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 import type { CordieriteRegisteredTool } from "../Cordierite.types";
 import type { ClientTimerHandle, ClientTimers } from "../client/timers";
 import { createToolMessageHandler } from "../client/tool-invocation";
+import { normalizeToolSchema, toToolDescriptor } from "../schema";
 
 /** Real timers, but exposed through the `ClientTimers` DI seam the module under test expects. */
 const realTimers: ClientTimers = {
@@ -237,6 +240,145 @@ describe("createToolMessageHandler: cancellation", () => {
         session_id: SESSION_ID,
         id: "call-3",
         error: { type: "tool_timeout", message: expect.any(String) },
+      },
+    ]);
+  });
+});
+
+describe("createToolMessageHandler: paired and raw tool schemas (issue #27)", () => {
+  test("a zod 3 + zod-to-json-schema pair validates args and results end to end", async () => {
+    const { registry, sent, handleMessage } = createHarness();
+
+    const input = z3.object({ a: z3.number(), b: z3.number() });
+    const output = z3.object({ total: z3.number() });
+    const inputPair = normalizeToolSchema(
+      { schema: input, jsonSchema: zodToJsonSchema(input) },
+      "l",
+    );
+    const outputPair = normalizeToolSchema(
+      { schema: output, jsonSchema: zodToJsonSchema(output) },
+      "l",
+    );
+
+    registry.set("sum", {
+      id: Symbol("sum"),
+      descriptor: toToolDescriptor({
+        name: "sum",
+        description: "Add two numbers.",
+        inputSchema: inputPair,
+        outputSchema: outputPair,
+      }),
+      inputSchema: inputPair,
+      outputSchema: outputPair,
+      handler: (args) => {
+        const { a, b } = args as { a: number; b: number };
+        return { total: a + b };
+      },
+      timeoutMs: 1000,
+    });
+
+    // The descriptor the daemon would receive carries a real shape, not an empty object.
+    expect(registry.get("sum")?.descriptor.input_schema).toMatchObject({
+      type: "object",
+      properties: { a: { type: "number" }, b: { type: "number" } },
+    });
+
+    await handleMessage(toolCallMessage("call-p1", "sum", { a: 2, b: 3 }));
+
+    expect(sent).toEqual([
+      {
+        type: "tool_result",
+        session_id: SESSION_ID,
+        id: "call-p1",
+        result: { total: 5 },
+      },
+    ]);
+  });
+
+  test("a paired schema still rejects bad input with tool_input_validation_error", async () => {
+    const { registry, sent, handleMessage } = createHarness();
+
+    const input = z3.object({ a: z3.number() });
+    registry.set("strict", {
+      id: Symbol("strict"),
+      descriptor: { name: "strict", description: "d" },
+      inputSchema: normalizeToolSchema(
+        { schema: input, jsonSchema: zodToJsonSchema(input) },
+        "l",
+      ),
+      handler: () => undefined,
+      timeoutMs: 1000,
+    });
+
+    await handleMessage(toolCallMessage("call-p2", "strict", { a: "nope" }));
+
+    expect(sent[0]).toMatchObject({
+      type: "tool_error",
+      id: "call-p2",
+      error: { type: "tool_input_validation_error" },
+    });
+  });
+
+  test("a raw JSON Schema tool passes args straight through, unvalidated", async () => {
+    const { registry, sent, handleMessage } = createHarness();
+
+    const seen: unknown[] = [];
+    registry.set("raw", {
+      id: Symbol("raw"),
+      descriptor: { name: "raw", description: "d" },
+      inputSchema: normalizeToolSchema(
+        {
+          type: "object",
+          properties: { city: { type: "string" } },
+          required: ["city"],
+        },
+        "l",
+      ),
+      outputSchema: normalizeToolSchema({ type: "object" }, "l"),
+      handler: (args) => {
+        seen.push(args);
+        return { ok: true };
+      },
+      timeoutMs: 1000,
+    });
+
+    // `city` is required by the schema and absent, and `extra` is not declared at all: with no
+    // app-side JSON Schema validator both reach the handler verbatim.
+    await handleMessage(toolCallMessage("call-r1", "raw", { extra: 1 }));
+
+    expect(seen).toEqual([{ extra: 1 }]);
+    expect(sent).toEqual([
+      {
+        type: "tool_result",
+        session_id: SESSION_ID,
+        id: "call-r1",
+        result: { ok: true },
+      },
+    ]);
+  });
+
+  test("a raw output schema does not reject a non-matching result", async () => {
+    const { registry, sent, handleMessage } = createHarness();
+
+    registry.set("raw-out", {
+      id: Symbol("raw-out"),
+      descriptor: { name: "raw-out", description: "d" },
+      outputSchema: normalizeToolSchema(
+        { type: "object", required: ["total"] },
+        "l",
+      ),
+      handler: () => "a string, not an object",
+      timeoutMs: 1000,
+    });
+
+    await handleMessage(toolCallMessage("call-r2", "raw-out"));
+
+    expect(sent).toEqual([
+      {
+        type: "tool_result",
+        session_id: SESSION_ID,
+        id: "call-r2",
+        result: "a string, not an object",
       },
     ]);
   });

--- a/packages/react-native/src/__tests__/use-cordierite-tool.test.ts
+++ b/packages/react-native/src/__tests__/use-cordierite-tool.test.ts
@@ -7,7 +7,7 @@ import type {
   CordieriteToolRegistration,
 } from "../Cordierite.types";
 import type { CordieriteSubscription } from "../public-api";
-import { exportToolSchema } from "../schema";
+import { exportToolSchemaForKey } from "../schema";
 
 (globalThis as { __DEV__?: boolean }).__DEV__ = true;
 
@@ -129,7 +129,7 @@ const toolDefinition = (
  * What the real (`.`) entry passes: the JSON Schema exporter that makes the derived registration
  * key possible. The inert (`./noop`) entry deliberately passes nothing -- covered separately below.
  */
-const realEntryOptions = { exportSchema: exportToolSchema };
+const realEntryOptions = { exportSchema: exportToolSchemaForKey };
 
 /** Enough of an execution context to invoke a registered handler that ignores it. */
 const fakeContext = {} as CordieriteToolExecutionContext;

--- a/packages/react-native/src/client/index.ts
+++ b/packages/react-native/src/client/index.ts
@@ -15,6 +15,7 @@ import type {
   CordieriteListenerKind,
   CordieriteModuleEvents,
   CordieriteOutboundMessage,
+  CordieriteRuntimeSchema,
   CordieriteToolRegistration,
   CordieriteUnifiedErrorEvent,
   CordieriteUnifiedListenerMap,
@@ -828,12 +829,8 @@ export const createCordieriteClient = (
     },
 
     registerTool<
-      TInputSchema extends
-        | import("@cordierite/shared").StandardSchemaV1
-        | undefined,
-      TOutputSchema extends
-        | import("@cordierite/shared").StandardSchemaV1
-        | undefined
+      TInputSchema extends CordieriteRuntimeSchema | undefined,
+      TOutputSchema extends CordieriteRuntimeSchema | undefined
     >(registration: CordieriteToolRegistration<TInputSchema, TOutputSchema>) {
       return registry.registerTool(registration);
     },

--- a/packages/react-native/src/client/registry.ts
+++ b/packages/react-native/src/client/registry.ts
@@ -2,12 +2,13 @@ import type { ToolDescriptor } from "@cordierite/shared";
 
 import type {
   CordieriteRegisteredTool,
+  CordieriteRuntimeSchema,
   CordieriteToolHandler,
   CordieriteToolRegistration,
 } from "../Cordierite.types";
 import { CORDIERITE_DEFAULT_TOOL_TIMEOUT_MS } from "../Cordierite.types";
 import { logger } from "../logger";
-import { requireOptionalStandardSchema, toToolDescriptor } from "../schema";
+import { normalizeOptionalToolSchema, toToolDescriptor } from "../schema";
 
 export type RegistryDelta =
   | {
@@ -22,12 +23,8 @@ export type RegistryDelta =
 export type ToolRegistry = {
   entries: Map<string, CordieriteRegisteredTool>;
   registerTool<
-    TInputSchema extends
-      | import("@cordierite/shared").StandardSchemaV1
-      | undefined,
-    TOutputSchema extends
-      | import("@cordierite/shared").StandardSchemaV1
-      | undefined
+    TInputSchema extends CordieriteRuntimeSchema | undefined,
+    TOutputSchema extends CordieriteRuntimeSchema | undefined
   >(
     registration: CordieriteToolRegistration<TInputSchema, TOutputSchema>
   ): { remove(): void };
@@ -51,11 +48,11 @@ export const createToolRegistry = (deps: ToolRegistryDeps): ToolRegistry => {
   const registerTool = (
     registration: CordieriteToolRegistration<any, any>
   ): { remove(): void } => {
-    const inputSchema = requireOptionalStandardSchema(
+    const inputSchema = normalizeOptionalToolSchema(
       registration.inputSchema,
       `Tool "${registration.name}" inputSchema`
     );
-    const outputSchema = requireOptionalStandardSchema(
+    const outputSchema = normalizeOptionalToolSchema(
       registration.outputSchema,
       `Tool "${registration.name}" outputSchema`
     );

--- a/packages/react-native/src/client/tool-invocation.ts
+++ b/packages/react-native/src/client/tool-invocation.ts
@@ -6,7 +6,7 @@ import type {
   CordieriteUnifiedErrorEvent,
 } from "../Cordierite.types";
 import { logger } from "../logger";
-import { validateStandardSchema } from "../schema";
+import { validateToolSchema } from "../schema";
 import type { ClientTimers } from "./timers";
 
 export const normalizeThrownError = (error: unknown) => {
@@ -141,7 +141,7 @@ export const createToolMessageHandler = (
 
     try {
       const parsedArgs = tool.inputSchema
-        ? await validateStandardSchema(tool.inputSchema, rawMessage.args)
+        ? await validateToolSchema(tool.inputSchema, rawMessage.args)
         : Object.keys(rawMessage.args).length === 0
           ? {
               ok: true as const,
@@ -228,7 +228,7 @@ export const createToolMessageHandler = (
       }
 
       const parsedResult = tool.outputSchema
-        ? await validateStandardSchema(tool.outputSchema, result)
+        ? await validateToolSchema(tool.outputSchema, result)
         : result === undefined
           ? {
               ok: true as const,

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -16,7 +16,7 @@ import {
 import { parseBootstrapPayload, parseBootstrapUrl } from "./bootstrap";
 import { cordieriteClient, noopIfNativeUnavailable } from "./default-client";
 import * as noop from "./noop";
-import { exportToolSchema } from "./schema";
+import { exportToolSchemaForKey } from "./schema";
 import { createUseCordieriteTool } from "./useCordieriteTool";
 
 export * from "./Cordierite.types";
@@ -149,9 +149,9 @@ export function getCordieriteBuildConfig(): CordieriteBuildConfig {
  * `true`) gates registration without breaking the rules of hooks — see the README's "Define tools
  * in app startup code" section.
  *
- * `exportToolSchema` is injected (rather than imported by the hook) so the inert `./noop` entry
+ * `exportToolSchemaForKey` is injected (rather than imported by the hook) so the inert `./noop` entry
  * below does not pull JSON Schema export into a bundle that registers nothing.
  */
 export const useCordieriteTool = createUseCordieriteTool(registerTool, {
-  exportSchema: exportToolSchema,
+  exportSchema: exportToolSchemaForKey,
 });

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -5,6 +5,7 @@ import type {
   CordieriteClientState,
   CordieriteConnectInput,
   CordieriteListenerKind,
+  CordieriteRuntimeSchema,
   CordieriteToolRegistration,
   CordieriteUnifiedListenerMap,
 } from "./Cordierite.types";
@@ -38,10 +39,8 @@ export type { UseCordieriteToolOptions } from "./useCordieriteTool";
  * same tool name.
  */
 export function registerTool<
-  TInputSchema extends
-    import("@cordierite/shared").StandardSchemaV1 | undefined,
-  TOutputSchema extends
-    import("@cordierite/shared").StandardSchemaV1 | undefined,
+  TInputSchema extends CordieriteRuntimeSchema | undefined,
+  TOutputSchema extends CordieriteRuntimeSchema | undefined,
 >(registration: CordieriteToolRegistration<TInputSchema, TOutputSchema>) {
   return noopIfNativeUnavailable(
     () => cordieriteClient.registerTool(registration),

--- a/packages/react-native/src/logger.ts
+++ b/packages/react-native/src/logger.ts
@@ -5,7 +5,13 @@ const PREFIX = "[Cordierite]";
 // Computed per call (not cached at module load): `__DEV__` is a bundler-injected global that some
 // test environments set only after this module has already been imported transitively, and a
 // cached constant would silently miss that.
-const isDev = (): boolean => typeof __DEV__ !== "undefined" && Boolean(__DEV__);
+/**
+ * Whether this bundle is a development build. An undefined `__DEV__` (a plain Node/Vitest process,
+ * a non-RN bundler) counts as *not* dev, so nothing dev-only ever fires outside a real dev bundle.
+ * Exported so `schema.ts`'s dev-only errors use the same definition of "dev" the logger does.
+ */
+export const isDev = (): boolean =>
+  typeof __DEV__ !== "undefined" && Boolean(__DEV__);
 
 const prefixed = (args: unknown[]): unknown[] => [PREFIX, ...args];
 

--- a/packages/react-native/src/noop.ts
+++ b/packages/react-native/src/noop.ts
@@ -15,6 +15,7 @@ import type {
   CordieriteClientState,
   CordieriteConnectInput,
   CordieriteListenerKind,
+  CordieriteRuntimeSchema,
   CordieriteToolRegistration,
   CordieriteUnifiedListenerMap,
 } from "./Cordierite.types";
@@ -30,10 +31,8 @@ const noopSubscription: CordieriteSubscription = { remove() {} };
 
 /** Accepts any registration and returns a disposer; the tool is never actually registered anywhere. */
 export function registerTool<
-  TInputSchema extends
-    import("@cordierite/shared").StandardSchemaV1 | undefined,
-  TOutputSchema extends
-    import("@cordierite/shared").StandardSchemaV1 | undefined,
+  TInputSchema extends CordieriteRuntimeSchema | undefined,
+  TOutputSchema extends CordieriteRuntimeSchema | undefined,
 >(
   _registration: CordieriteToolRegistration<TInputSchema, TOutputSchema>,
 ): CordieriteSubscription {

--- a/packages/react-native/src/public-api.ts
+++ b/packages/react-native/src/public-api.ts
@@ -5,6 +5,7 @@ import type {
   CordieriteBuildConfig,
   CordieriteClientState,
   CordieriteConnectInput,
+  CordieriteJsonSchemaObject,
   CordieriteListenerKind,
   CordieriteRuntimeSchema,
   CordieriteToolRegistration,
@@ -35,6 +36,11 @@ export type CordierePublicApi = {
     deps?: DependencyList,
     options?: UseCordieriteToolOptions,
   ): void;
+
+  /** Type-only helper for raw JSON Schema tool schemas; identity at runtime. */
+  jsonSchema<T = Record<string, unknown>>(
+    schema: Record<string, unknown>,
+  ): CordieriteJsonSchemaObject<T>;
 
   postEvent(name: string, payload?: unknown): Promise<void>;
 

--- a/packages/react-native/src/schema.ts
+++ b/packages/react-native/src/schema.ts
@@ -6,77 +6,168 @@ import type {
 } from "@cordierite/shared";
 
 import type {
-  CordieriteRuntimeSchema,
+  CordieriteJsonSchemaConverter,
+  CordieriteNormalizedToolSchema,
   CordieriteToolDefinition,
 } from "./Cordierite.types";
 import { logger } from "./logger";
 
+declare const __DEV__: boolean | undefined;
+
+const isDev = (): boolean => typeof __DEV__ !== "undefined" && Boolean(__DEV__);
+
 const JSON_SCHEMA_TARGET = "draft-2020-12";
 
-/** Dedupes the dev warning below across repeated registrations of the same tool name. */
+/** Dedupes the production warning below across repeated registrations of the same tool name. */
 const shapelessToolWarningsSeen = new Set<string>();
 
 /**
- * ARCHITECTURE.md §11: when a provided Standard Schema does not export JSON Schema (zod 3, valibot
- * without an adapter), the tool is still registered — just with an empty `input_schema`/
- * `output_schema` — so warn once per tool name that agents will see it as shapeless.
+ * Points at the two supported ways to give a schema a shape when its library has no
+ * `~standard.jsonSchema` exporter. Shared by the dev throw and the production warning so the two
+ * never drift apart.
+ */
+const MISSING_EXPORTER_REMEDY =
+  'Pass `{ schema, jsonSchema }` (e.g. `{ schema, jsonSchema: zodToJsonSchema(schema, { target: "jsonSchema2020-12" }) }` ' +
+  "for zod 3, `toJsonSchema(schema)` from `@valibot/to-json-schema` for valibot), pass a raw JSON " +
+  "Schema object instead of the schema, or use a library with a built-in exporter (zod 4, arktype).";
+
+const missingExporterMessage = (label: string): string =>
+  `${label} is a Standard Schema without a JSON Schema exporter ` +
+  '("~standard.jsonSchema" is missing — expected for zod 3 and plain valibot), so agents would see ' +
+  `the tool as shapeless. ${MISSING_EXPORTER_REMEDY}`;
+
+/**
+ * ARCHITECTURE.md §11: outside dev, a Standard Schema with no JSON Schema exporter still registers
+ * — just with no `input_schema`/`output_schema` — so an app that shipped one keeps working. Warn
+ * once per tool name that agents will see it as shapeless. In dev this case throws instead (see
+ * `exportToolSchema`).
  */
 const warnMissingSchemaExporter = (toolName: string): void => {
   if (shapelessToolWarningsSeen.has(toolName)) {
     return;
   }
   shapelessToolWarningsSeen.add(toolName);
-  logger.devWarn(
+  logger.warn(
     `Tool "${toolName}" has a Standard Schema that does not export JSON Schema ` +
       `("~standard.jsonSchema" is missing — this is expected for zod 3 and plain valibot). It will ` +
-      "be registered without a schema, so agents will see it as shapeless. Use zod v4 (built-in " +
-      'exporter) or a wrapper that implements "~standard.jsonSchema" to give agents a real shape.'
+      `be registered without a schema, so agents will see it as shapeless. ${MISSING_EXPORTER_REMEDY}`
   );
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-export const requireStandardSchema = (
-  value: unknown,
-  label: string
-): StandardSchemaV1 => {
+const asStandardSchema = (value: unknown): StandardSchemaV1 | undefined => {
   if (!isRecord(value)) {
-    throw new TypeError(
-      `${label} must be a Standard Schema compatible object.`
-    );
+    return undefined;
   }
 
   const standard = value["~standard"];
   if (!isRecord(standard) || typeof standard.validate !== "function") {
-    throw new TypeError(`${label} must expose "~standard.validate".`);
+    return undefined;
   }
 
   return value as unknown as StandardSchemaV1;
 };
 
-export const requireOptionalStandardSchema = (
+const isJsonSchemaConverter = (
+  value: unknown
+): value is CordieriteJsonSchemaConverter =>
+  isRecord(value) &&
+  typeof value.input === "function" &&
+  typeof value.output === "function";
+
+/**
+ * Classifies a user-supplied `inputSchema`/`outputSchema` into the three accepted forms
+ * (ARCHITECTURE.md §11) exactly once, at registration time:
+ *
+ * - `standard` — anything exposing `~standard.validate` (zod 3/4, valibot, arktype);
+ * - `paired` — `{ schema, jsonSchema }`, where `schema` is a Standard Schema and `jsonSchema` is a
+ *   JSON Schema object or an `{ input, output }` converter;
+ * - `raw` — any other plain object, taken as a JSON Schema and passed through unvalidated.
+ *
+ * Throws a `TypeError` for values that are neither (non-objects, arrays) and for the two shapes
+ * that are almost certainly a mistake: a `~standard` that is not a Standard Schema, and a
+ * `{ schema }` pair missing its `jsonSchema` half.
+ */
+export const normalizeToolSchema = (
   value: unknown,
   label: string
-): StandardSchemaV1 | undefined =>
-  value === undefined ? undefined : requireStandardSchema(value, label);
+): CordieriteNormalizedToolSchema => {
+  if (!isRecord(value)) {
+    throw new TypeError(
+      `${label} must be a Standard Schema object, a { schema, jsonSchema } pair, or a JSON Schema object.`
+    );
+  }
+
+  if ("~standard" in value) {
+    const schema = asStandardSchema(value);
+    if (!schema) {
+      throw new TypeError(`${label} must expose "~standard.validate".`);
+    }
+    return { kind: "standard", schema };
+  }
+
+  // Only a `schema` that really is a Standard Schema makes this a pair; a JSON Schema that merely
+  // happens to have a `schema` keyword still falls through to `raw` below.
+  const pairedSchema = asStandardSchema(value.schema);
+  if (pairedSchema) {
+    const { jsonSchema } = value;
+    if (!isRecord(jsonSchema)) {
+      throw new TypeError(
+        `${label} looks like a { schema, jsonSchema } pair but its "jsonSchema" is missing or not an object. ` +
+          "Supply a JSON Schema object or an { input, output } converter."
+      );
+    }
+    return {
+      kind: "paired",
+      schema: pairedSchema,
+      jsonSchema: isJsonSchemaConverter(jsonSchema)
+        ? jsonSchema
+        : (jsonSchema as Record<string, unknown>),
+    };
+  }
+
+  return { kind: "raw", jsonSchema: value };
+};
+
+export const normalizeOptionalToolSchema = (
+  value: unknown,
+  label: string
+): CordieriteNormalizedToolSchema | undefined =>
+  value === undefined ? undefined : normalizeToolSchema(value, label);
 
 const hasJsonSchemaExporter = (
   schema: StandardSchemaV1
 ): schema is StandardSchemaV1JsonSchema => {
   const standard = schema["~standard"] as unknown as Record<string, unknown>;
-  const jsonSchema = standard.jsonSchema;
 
-  return (
-    isRecord(jsonSchema) &&
-    typeof jsonSchema.input === "function" &&
-    typeof jsonSchema.output === "function"
-  );
+  return isJsonSchemaConverter(standard.jsonSchema);
 };
 
-/** `undefined` when there is no schema, or it does not export JSON Schema (§7: `input_schema?`/`output_schema?` are optional). */
+const exportFromConverter = (
+  converter: CordieriteJsonSchemaConverter,
+  mode: "input" | "output"
+): ToolSchemaDescriptor | undefined => {
+  try {
+    const exported = converter[mode]({ target: JSON_SCHEMA_TARGET });
+    return isRecord(exported) ? exported : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * JSON Schema to publish for one slot, or `undefined` when there is none (§7: `input_schema`/
+ * `output_schema` are optional).
+ *
+ * A `standard` schema with no exporter **throws in dev** (`__DEV__`) so the "registered fine but
+ * the agent can't use it" failure is loud where it can still be fixed; in production it warns once
+ * and registers shapeless, exactly as before, so an app already shipping such a tool is not bricked
+ * by an upgrade.
+ */
 export const exportToolSchema = (
-  schema: StandardSchemaV1 | undefined,
+  schema: CordieriteNormalizedToolSchema | undefined,
   mode: "input" | "output",
   toolName?: string
 ): ToolSchemaDescriptor | undefined => {
@@ -84,21 +175,36 @@ export const exportToolSchema = (
     return undefined;
   }
 
-  if (!hasJsonSchemaExporter(schema)) {
+  if (schema.kind === "raw") {
+    return schema.jsonSchema;
+  }
+
+  if (schema.kind === "paired") {
+    return isJsonSchemaConverter(schema.jsonSchema)
+      ? exportFromConverter(schema.jsonSchema, mode)
+      : schema.jsonSchema;
+  }
+
+  if (!hasJsonSchemaExporter(schema.schema)) {
+    const label =
+      toolName !== undefined
+        ? `Tool "${toolName}" ${mode}Schema`
+        : `The tool ${mode}Schema`;
+
+    if (isDev()) {
+      throw new TypeError(missingExporterMessage(label));
+    }
+
     if (toolName !== undefined) {
       warnMissingSchemaExporter(toolName);
     }
     return undefined;
   }
 
-  try {
-    const exported = schema["~standard"].jsonSchema[mode]({
-      target: JSON_SCHEMA_TARGET,
-    });
-    return isRecord(exported) ? exported : undefined;
-  } catch {
-    return undefined;
-  }
+  return exportFromConverter(
+    schema.schema["~standard"].jsonSchema as CordieriteJsonSchemaConverter,
+    mode
+  );
 };
 
 export type NormalizedStandardSchemaIssue = {
@@ -122,7 +228,7 @@ export const normalizeStandardSchemaIssues = (
   }));
 };
 
-export type StandardSchemaValidationResult =
+export type CordieriteToolSchemaValidationResult =
   | {
       ok: true;
       value: unknown;
@@ -132,11 +238,21 @@ export type StandardSchemaValidationResult =
       issues: NormalizedStandardSchemaIssue[];
     };
 
-export const validateStandardSchema = async (
-  schema: StandardSchemaV1,
+/**
+ * Runs the slot's runtime validation. `standard` and `paired` both validate through
+ * `~standard.validate`; a `raw` JSON Schema has no validator at all, so the value passes through
+ * untouched — deliberately, since bundling a JSON Schema validator would break this package's
+ * zero-runtime-dependency guarantee (ARCHITECTURE.md §13).
+ */
+export const validateToolSchema = async (
+  schema: CordieriteNormalizedToolSchema,
   value: unknown
-): Promise<StandardSchemaValidationResult> => {
-  const result = await schema["~standard"].validate(value);
+): Promise<CordieriteToolSchemaValidationResult> => {
+  if (schema.kind === "raw") {
+    return { ok: true, value };
+  }
+
+  const result = await schema.schema["~standard"].validate(value);
 
   if (result.issues) {
     return {
@@ -151,11 +267,17 @@ export const validateStandardSchema = async (
   };
 };
 
+/** A tool definition whose schemas have already been through `normalizeToolSchema`. */
+export type CordieriteNormalizedToolDefinition = Pick<
+  CordieriteToolDefinition,
+  "name" | "description" | "annotations"
+> & {
+  inputSchema?: CordieriteNormalizedToolSchema;
+  outputSchema?: CordieriteNormalizedToolSchema;
+};
+
 export const toToolDescriptor = (
-  definition: CordieriteToolDefinition<
-    CordieriteRuntimeSchema | undefined,
-    CordieriteRuntimeSchema | undefined
-  >
+  definition: CordieriteNormalizedToolDefinition
 ): ToolDescriptor => {
   const inputSchema = exportToolSchema(
     definition.inputSchema,

--- a/packages/react-native/src/schema.ts
+++ b/packages/react-native/src/schema.ts
@@ -8,6 +8,7 @@ import type {
 import type {
   CordieriteJsonSchemaConverter,
   CordieriteNormalizedToolSchema,
+  CordieriteRuntimeSchema,
   CordieriteToolDefinition,
 } from "./Cordierite.types";
 import { isDev, logger } from "./logger";
@@ -287,6 +288,38 @@ const exportFromConverter = (
       };
 };
 
+/** Export outcome for one normalized slot, with the reason when no JSON Schema can be produced. */
+const exportNormalizedSchema = (
+  schema: CordieriteNormalizedToolSchema,
+  mode: "input" | "output",
+): ConverterOutcome => {
+  if (schema.kind === "raw") {
+    return { ok: true, schema: schema.jsonSchema };
+  }
+
+  if (schema.kind === "paired") {
+    if (!isJsonSchemaConverter(schema.jsonSchema)) {
+      return { ok: true, schema: schema.jsonSchema };
+    }
+
+    return exportFromConverter(
+      schema.jsonSchema,
+      mode,
+      `"jsonSchema.${mode}" converter`,
+    );
+  }
+
+  if (!hasJsonSchemaExporter(schema.schema)) {
+    return { ok: false, reason: missingExporterReason };
+  }
+
+  return exportFromConverter(
+    schema.schema["~standard"].jsonSchema as CordieriteJsonSchemaConverter,
+    mode,
+    `"~standard.jsonSchema.${mode}" exporter`,
+  );
+};
+
 /**
  * JSON Schema to publish for one slot, or `undefined` when there is none (§7: `input_schema`/
  * `output_schema` are optional).
@@ -304,37 +337,32 @@ export const exportToolSchema = (
     return undefined;
   }
 
-  if (schema.kind === "raw") {
-    return schema.jsonSchema;
-  }
-
-  if (schema.kind === "paired") {
-    if (!isJsonSchemaConverter(schema.jsonSchema)) {
-      return schema.jsonSchema;
-    }
-
-    const outcome = exportFromConverter(
-      schema.jsonSchema,
-      mode,
-      `"jsonSchema.${mode}" converter`,
-    );
-    return outcome.ok
-      ? outcome.schema
-      : reportShapelessSchema(outcome.reason, mode, toolName);
-  }
-
-  if (!hasJsonSchemaExporter(schema.schema)) {
-    return reportShapelessSchema(missingExporterReason, mode, toolName);
-  }
-
-  const outcome = exportFromConverter(
-    schema.schema["~standard"].jsonSchema as CordieriteJsonSchemaConverter,
-    mode,
-    `"~standard.jsonSchema.${mode}" exporter`,
-  );
+  const outcome = exportNormalizedSchema(schema, mode);
   return outcome.ok
     ? outcome.schema
     : reportShapelessSchema(outcome.reason, mode, toolName);
+};
+
+/**
+ * Render-time exporter for `useCordieriteTool`'s derived registration key. Takes the raw
+ * `inputSchema`/`outputSchema` value as the caller passed it, and never throws or warns: an
+ * invalid value or a shapeless schema yields `undefined` here, and the registration path
+ * (`toToolDescriptor` via `registerTool`) is where it is reported. Keying is not the place to
+ * fail a render or to log.
+ */
+export const exportToolSchemaForKey = (
+  schema: CordieriteRuntimeSchema,
+  mode: "input" | "output",
+): ToolSchemaDescriptor | undefined => {
+  let normalized: CordieriteNormalizedToolSchema;
+  try {
+    normalized = normalizeToolSchema(schema, "schema");
+  } catch {
+    return undefined;
+  }
+
+  const outcome = exportNormalizedSchema(normalized, mode);
+  return outcome.ok ? outcome.schema : undefined;
 };
 
 export type NormalizedStandardSchemaIssue = {

--- a/packages/react-native/src/schema.ts
+++ b/packages/react-native/src/schema.ts
@@ -10,11 +10,7 @@ import type {
   CordieriteNormalizedToolSchema,
   CordieriteToolDefinition,
 } from "./Cordierite.types";
-import { logger } from "./logger";
-
-declare const __DEV__: boolean | undefined;
-
-const isDev = (): boolean => typeof __DEV__ !== "undefined" && Boolean(__DEV__);
+import { isDev, logger } from "./logger";
 
 const JSON_SCHEMA_TARGET = "draft-2020-12";
 

--- a/packages/react-native/src/schema.ts
+++ b/packages/react-native/src/schema.ts
@@ -18,43 +18,69 @@ const JSON_SCHEMA_TARGET = "draft-2020-12";
 const shapelessToolWarningsSeen = new Set<string>();
 
 /**
- * Points at the two supported ways to give a schema a shape when its library has no
- * `~standard.jsonSchema` exporter. Shared by the dev throw and the production warning so the two
- * never drift apart.
+ * Points at the supported ways to give a schema a shape. Shared by every dev throw and production
+ * warning below so the advice can never drift between them.
  */
-const MISSING_EXPORTER_REMEDY =
-  'Pass `{ schema, jsonSchema }` (e.g. `{ schema, jsonSchema: zodToJsonSchema(schema, { target: "jsonSchema2020-12" }) }` ' +
-  "for zod 3, `toJsonSchema(schema)` from `@valibot/to-json-schema` for valibot), pass a raw JSON " +
-  "Schema object instead of the schema, or use a library with a built-in exporter (zod 4, arktype).";
+const SHAPE_REMEDY =
+  "Pass `{ schema, jsonSchema }` (e.g. `{ schema, jsonSchema: zodToJsonSchema(schema) }` for zod 3, " +
+  "`{ schema, jsonSchema: toJsonSchema(schema) }` with `@valibot/to-json-schema` for valibot), pass " +
+  "a raw JSON Schema object instead of the schema, or use a library with a built-in " +
+  '"~standard.jsonSchema" exporter (zod 4, arktype).';
 
-const missingExporterMessage = (label: string): string =>
-  `${label} is a Standard Schema without a JSON Schema exporter ` +
-  '("~standard.jsonSchema" is missing — expected for zod 3 and plain valibot), so agents would see ' +
-  `the tool as shapeless. ${MISSING_EXPORTER_REMEDY}`;
+const missingExporterReason =
+  'it is a Standard Schema without a JSON Schema exporter ("~standard.jsonSchema" is missing — ' +
+  "expected for zod 3 and plain valibot)";
 
 /**
- * ARCHITECTURE.md §11: outside dev, a Standard Schema with no JSON Schema exporter still registers
- * — just with no `input_schema`/`output_schema` — so an app that shipped one keeps working. Warn
- * once per tool name that agents will see it as shapeless. In dev this case throws instead (see
- * `exportToolSchema`).
+ * The one place a tool ends up shapeless. ARCHITECTURE.md §11: in dev this throws, so the
+ * "registered fine but the agent cannot use it" failure is loud while it can still be fixed;
+ * outside dev the tool still registers with no `input_schema`/`output_schema` — warning once per
+ * tool name — so an app that already shipped one is not bricked by an upgrade.
  */
-const warnMissingSchemaExporter = (toolName: string): void => {
-  if (shapelessToolWarningsSeen.has(toolName)) {
-    return;
+const reportShapelessSchema = (
+  reason: string,
+  mode: "input" | "output",
+  toolName: string | undefined,
+): undefined => {
+  const label =
+    toolName !== undefined
+      ? `Tool "${toolName}" ${mode}Schema`
+      : `The tool ${mode}Schema`;
+
+  if (isDev()) {
+    throw new TypeError(
+      `${label} cannot publish a JSON Schema: ${reason}. Agents would see the tool as shapeless. ${SHAPE_REMEDY}`,
+    );
   }
-  shapelessToolWarningsSeen.add(toolName);
-  logger.warn(
-    `Tool "${toolName}" has a Standard Schema that does not export JSON Schema ` +
-      `("~standard.jsonSchema" is missing — this is expected for zod 3 and plain valibot). It will ` +
-      `be registered without a schema, so agents will see it as shapeless. ${MISSING_EXPORTER_REMEDY}`
-  );
+
+  const warningKey = toolName ?? "<unnamed>";
+  if (!shapelessToolWarningsSeen.has(warningKey)) {
+    shapelessToolWarningsSeen.add(warningKey);
+    logger.warn(
+      `${label} cannot publish a JSON Schema: ${reason}. It is registered without a schema, so ` +
+        `agents will see it as shapeless. ${SHAPE_REMEDY}`,
+    );
+  }
+
+  return undefined;
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+/**
+ * A Standard Schema need not be a plain object: arktype's `Type` is *callable*, so `typeof` reports
+ * `"function"` while `~standard` sits on it as a property. Anything indexable that carries a real
+ * `~standard.validate` counts.
+ */
+const isIndexable = (value: unknown): value is Record<string, unknown> =>
+  (typeof value === "object" || typeof value === "function") && value !== null;
+
+const hasStandardProperty = (value: unknown): boolean =>
+  isIndexable(value) && "~standard" in value;
+
 const asStandardSchema = (value: unknown): StandardSchemaV1 | undefined => {
-  if (!isRecord(value)) {
+  if (!isIndexable(value)) {
     return undefined;
   }
 
@@ -67,36 +93,48 @@ const asStandardSchema = (value: unknown): StandardSchemaV1 | undefined => {
 };
 
 const isJsonSchemaConverter = (
-  value: unknown
+  value: unknown,
 ): value is CordieriteJsonSchemaConverter =>
   isRecord(value) &&
   typeof value.input === "function" &&
   typeof value.output === "function";
 
 /**
+ * Keywords that make an object recognisable as JSON Schema. A raw schema must carry at least one:
+ * without it, "raw" is a catch-all that would happily publish a mistyped pair or an unrelated
+ * object as the tool's shape.
+ */
+const JSON_SCHEMA_KEYWORDS = [
+  "type",
+  "properties",
+  "$ref",
+  "anyOf",
+  "allOf",
+  "oneOf",
+  "enum",
+  "const",
+] as const;
+
+/**
  * Classifies a user-supplied `inputSchema`/`outputSchema` into the three accepted forms
  * (ARCHITECTURE.md §11) exactly once, at registration time:
  *
- * - `standard` — anything exposing `~standard.validate` (zod 3/4, valibot, arktype);
+ * - `standard` — anything (object *or* callable, e.g. arktype) exposing `~standard.validate`;
  * - `paired` — `{ schema, jsonSchema }`, where `schema` is a Standard Schema and `jsonSchema` is a
  *   JSON Schema object or an `{ input, output }` converter;
- * - `raw` — any other plain object, taken as a JSON Schema and passed through unvalidated.
+ * - `raw` — a plain object carrying at least one JSON Schema keyword, passed through unvalidated.
  *
- * Throws a `TypeError` for values that are neither (non-objects, arrays) and for the two shapes
- * that are almost certainly a mistake: a `~standard` that is not a Standard Schema, and a
- * `{ schema }` pair missing its `jsonSchema` half.
+ * Everything else throws a `TypeError`, rather than being published as the tool's shape: non-objects
+ * and arrays, a `~standard` that is not a Standard Schema, a `{ schema }` pair missing or
+ * mistyping its `jsonSchema` half, and any object that mentions `schema`/`jsonSchema` without
+ * being a valid pair (overwhelmingly a malformed pair, not JSON Schema — neither is a JSON Schema
+ * keyword).
  */
 export const normalizeToolSchema = (
   value: unknown,
-  label: string
+  label: string,
 ): CordieriteNormalizedToolSchema => {
-  if (!isRecord(value)) {
-    throw new TypeError(
-      `${label} must be a Standard Schema object, a { schema, jsonSchema } pair, or a JSON Schema object.`
-    );
-  }
-
-  if ("~standard" in value) {
+  if (hasStandardProperty(value)) {
     const schema = asStandardSchema(value);
     if (!schema) {
       throw new TypeError(`${label} must expose "~standard.validate".`);
@@ -104,17 +142,31 @@ export const normalizeToolSchema = (
     return { kind: "standard", schema };
   }
 
-  // Only a `schema` that really is a Standard Schema makes this a pair; a JSON Schema that merely
-  // happens to have a `schema` keyword still falls through to `raw` below.
-  const pairedSchema = asStandardSchema(value.schema);
-  if (pairedSchema) {
+  if (!isRecord(value)) {
+    throw new TypeError(
+      `${label} must be a Standard Schema, a { schema, jsonSchema } pair, or a JSON Schema object.`,
+    );
+  }
+
+  const looksLikePair = "schema" in value || "jsonSchema" in value;
+  if (looksLikePair) {
+    const pairedSchema = asStandardSchema(value.schema);
+    if (!pairedSchema) {
+      throw new TypeError(
+        `${label} looks like a { schema, jsonSchema } pair but its "schema" is missing or is not a ` +
+          'Standard Schema (no "~standard.validate"). Supply the validation schema there, and the ' +
+          'JSON Schema to publish under "jsonSchema".',
+      );
+    }
+
     const { jsonSchema } = value;
     if (!isRecord(jsonSchema)) {
       throw new TypeError(
         `${label} looks like a { schema, jsonSchema } pair but its "jsonSchema" is missing or not an object. ` +
-          "Supply a JSON Schema object or an { input, output } converter."
+          "Supply a JSON Schema object or an { input, output } converter.",
       );
     }
+
     return {
       kind: "paired",
       schema: pairedSchema,
@@ -124,48 +176,75 @@ export const normalizeToolSchema = (
     };
   }
 
+  const keyword = JSON_SCHEMA_KEYWORDS.find((candidate) => candidate in value);
+  if (keyword === undefined) {
+    throw new TypeError(
+      `${label} is not a Standard Schema and does not look like JSON Schema: it has none of ` +
+        `${JSON_SCHEMA_KEYWORDS.join(", ")}. ${SHAPE_REMEDY}`,
+    );
+  }
+
   return { kind: "raw", jsonSchema: value };
 };
 
 export const normalizeOptionalToolSchema = (
   value: unknown,
-  label: string
+  label: string,
 ): CordieriteNormalizedToolSchema | undefined =>
   value === undefined ? undefined : normalizeToolSchema(value, label);
 
 const hasJsonSchemaExporter = (
-  schema: StandardSchemaV1
+  schema: StandardSchemaV1,
 ): schema is StandardSchemaV1JsonSchema => {
   const standard = schema["~standard"] as unknown as Record<string, unknown>;
 
   return isJsonSchemaConverter(standard.jsonSchema);
 };
 
+type ConverterOutcome =
+  { ok: true; schema: ToolSchemaDescriptor } | { ok: false; reason: string };
+
+/**
+ * Runs one half of a JSON Schema converter. A converter that throws or returns a non-object is a
+ * failure to be *reported*, never swallowed: silently returning `undefined` here would put back
+ * exactly the shapeless-tool failure this contract exists to remove — and for pair users, who
+ * chose the pair form precisely to avoid it.
+ */
 const exportFromConverter = (
   converter: CordieriteJsonSchemaConverter,
-  mode: "input" | "output"
-): ToolSchemaDescriptor | undefined => {
+  mode: "input" | "output",
+  source: string,
+): ConverterOutcome => {
+  let exported: unknown;
   try {
-    const exported = converter[mode]({ target: JSON_SCHEMA_TARGET });
-    return isRecord(exported) ? exported : undefined;
-  } catch {
-    return undefined;
+    exported = converter[mode]({ target: JSON_SCHEMA_TARGET });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { ok: false, reason: `its ${source} threw (${detail})` };
   }
+
+  return isRecord(exported)
+    ? { ok: true, schema: exported }
+    : {
+        ok: false,
+        reason: `its ${source} returned ${
+          Array.isArray(exported) ? "an array" : typeof exported
+        } instead of a JSON Schema object`,
+      };
 };
 
 /**
  * JSON Schema to publish for one slot, or `undefined` when there is none (§7: `input_schema`/
  * `output_schema` are optional).
  *
- * A `standard` schema with no exporter **throws in dev** (`__DEV__`) so the "registered fine but
- * the agent can't use it" failure is loud where it can still be fixed; in production it warns once
- * and registers shapeless, exactly as before, so an app already shipping such a tool is not bricked
- * by an upgrade.
+ * Every way a slot can fail to produce a shape — a Standard Schema with no exporter, an exporter
+ * that throws, a paired converter that throws — goes through `reportShapelessSchema`, which throws
+ * in `__DEV__` and warns once per tool name otherwise.
  */
 export const exportToolSchema = (
   schema: CordieriteNormalizedToolSchema | undefined,
   mode: "input" | "output",
-  toolName?: string
+  toolName?: string,
 ): ToolSchemaDescriptor | undefined => {
   if (!schema) {
     return undefined;
@@ -176,31 +255,32 @@ export const exportToolSchema = (
   }
 
   if (schema.kind === "paired") {
-    return isJsonSchemaConverter(schema.jsonSchema)
-      ? exportFromConverter(schema.jsonSchema, mode)
-      : schema.jsonSchema;
+    if (!isJsonSchemaConverter(schema.jsonSchema)) {
+      return schema.jsonSchema;
+    }
+
+    const outcome = exportFromConverter(
+      schema.jsonSchema,
+      mode,
+      `"jsonSchema.${mode}" converter`,
+    );
+    return outcome.ok
+      ? outcome.schema
+      : reportShapelessSchema(outcome.reason, mode, toolName);
   }
 
   if (!hasJsonSchemaExporter(schema.schema)) {
-    const label =
-      toolName !== undefined
-        ? `Tool "${toolName}" ${mode}Schema`
-        : `The tool ${mode}Schema`;
-
-    if (isDev()) {
-      throw new TypeError(missingExporterMessage(label));
-    }
-
-    if (toolName !== undefined) {
-      warnMissingSchemaExporter(toolName);
-    }
-    return undefined;
+    return reportShapelessSchema(missingExporterReason, mode, toolName);
   }
 
-  return exportFromConverter(
+  const outcome = exportFromConverter(
     schema.schema["~standard"].jsonSchema as CordieriteJsonSchemaConverter,
-    mode
+    mode,
+    `"~standard.jsonSchema.${mode}" exporter`,
   );
+  return outcome.ok
+    ? outcome.schema
+    : reportShapelessSchema(outcome.reason, mode, toolName);
 };
 
 export type NormalizedStandardSchemaIssue = {
@@ -209,14 +289,14 @@ export type NormalizedStandardSchemaIssue = {
 };
 
 const normalizePathSegment = (
-  segment: PropertyKey | StandardSchemaV1.PathSegment
+  segment: PropertyKey | StandardSchemaV1.PathSegment,
 ): PropertyKey =>
   typeof segment === "object" && segment !== null && "key" in segment
     ? segment.key
     : segment;
 
 export const normalizeStandardSchemaIssues = (
-  issues: readonly StandardSchemaV1.Issue[]
+  issues: readonly StandardSchemaV1.Issue[],
 ): NormalizedStandardSchemaIssue[] => {
   return issues.map((issue) => ({
     message: issue.message,
@@ -242,7 +322,7 @@ export type CordieriteToolSchemaValidationResult =
  */
 export const validateToolSchema = async (
   schema: CordieriteNormalizedToolSchema,
-  value: unknown
+  value: unknown,
 ): Promise<CordieriteToolSchemaValidationResult> => {
   if (schema.kind === "raw") {
     return { ok: true, value };
@@ -273,17 +353,17 @@ export type CordieriteNormalizedToolDefinition = Pick<
 };
 
 export const toToolDescriptor = (
-  definition: CordieriteNormalizedToolDefinition
+  definition: CordieriteNormalizedToolDefinition,
 ): ToolDescriptor => {
   const inputSchema = exportToolSchema(
     definition.inputSchema,
     "input",
-    definition.name
+    definition.name,
   );
   const outputSchema = exportToolSchema(
     definition.outputSchema,
     "output",
-    definition.name
+    definition.name,
   );
 
   return {

--- a/packages/react-native/src/schema.ts
+++ b/packages/react-native/src/schema.ts
@@ -53,7 +53,9 @@ const reportShapelessSchema = (
     );
   }
 
-  const warningKey = toolName ?? "<unnamed>";
+  // Keyed by slot as well as tool: a tool whose input and output schemas both fail has two
+  // distinct problems to fix, and reporting only the first would hide the second.
+  const warningKey = `${toolName ?? "<unnamed>"}:${mode}`;
   if (!shapelessToolWarningsSeen.has(warningKey)) {
     shapelessToolWarningsSeen.add(warningKey);
     logger.warn(
@@ -79,6 +81,9 @@ const isIndexable = (value: unknown): value is Record<string, unknown> =>
 const hasStandardProperty = (value: unknown): boolean =>
   isIndexable(value) && "~standard" in value;
 
+const hasOwn = (value: object, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
 const asStandardSchema = (value: unknown): StandardSchemaV1 | undefined => {
   if (!isIndexable(value)) {
     return undefined;
@@ -99,21 +104,57 @@ const isJsonSchemaConverter = (
   typeof value.input === "function" &&
   typeof value.output === "function";
 
+/** The seven type names draft 2020-12 defines. `type` may also be an array of them. */
+const JSON_SCHEMA_TYPE_NAMES = [
+  "null",
+  "boolean",
+  "object",
+  "array",
+  "number",
+  "string",
+  "integer",
+];
+
+const isValidJsonSchemaType = (type: unknown): boolean =>
+  Array.isArray(type)
+    ? type.length > 0 &&
+      type.every(
+        (entry) =>
+          typeof entry === "string" && JSON_SCHEMA_TYPE_NAMES.includes(entry),
+      )
+    : typeof type === "string" && JSON_SCHEMA_TYPE_NAMES.includes(type);
+
 /**
- * Keywords that make an object recognisable as JSON Schema. A raw schema must carry at least one:
- * without it, "raw" is a catch-all that would happily publish a mistyped pair or an unrelated
- * object as the tool's shape.
+ * Whether `value` can be published verbatim as JSON Schema.
+ *
+ * Structural, not keyword-based, and deliberately so. A keyword probe using `in` walks the
+ * prototype chain, and validator instances from libraries that predate Standard Schema (yup, joi,
+ * superstruct, valibot 0.x) carry a prototype `type` — they would be classified as raw JSON Schema
+ * and published as the tool's shape, where before they were rejected outright. Many also hold
+ * circular references, so `JSON.stringify` on the registry snapshot would throw and take the whole
+ * snapshot down with it, not just that one tool.
+ *
+ * So: a plain object (`{}` or `Object.create(null)` — no class, no prototype methods) whose own
+ * `type`, if it has one, is a real JSON Schema type name. `{}` is valid JSON Schema (it accepts
+ * anything), and is accepted.
  */
-const JSON_SCHEMA_KEYWORDS = [
-  "type",
-  "properties",
-  "$ref",
-  "anyOf",
-  "allOf",
-  "oneOf",
-  "enum",
-  "const",
-] as const;
+const isPlainJsonSchemaObject = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value) as unknown;
+  if (prototype !== Object.prototype && prototype !== null) {
+    return false;
+  }
+
+  return !hasOwn(value, "type") || isValidJsonSchemaType(value.type);
+};
+
+const NOT_JSON_SCHEMA_ADVICE =
+  'Pass a plain JSON Schema object such as `{ "type": "object", "properties": { … } }`, a ' +
+  "Standard Schema, or a { schema, jsonSchema } pair. A validator instance from a library without " +
+  "Standard Schema support (yup, joi, superstruct) is none of those.";
 
 /**
  * Classifies a user-supplied `inputSchema`/`outputSchema` into the three accepted forms
@@ -122,13 +163,11 @@ const JSON_SCHEMA_KEYWORDS = [
  * - `standard` — anything (object *or* callable, e.g. arktype) exposing `~standard.validate`;
  * - `paired` — `{ schema, jsonSchema }`, where `schema` is a Standard Schema and `jsonSchema` is a
  *   JSON Schema object or an `{ input, output }` converter;
- * - `raw` — a plain object carrying at least one JSON Schema keyword, passed through unvalidated.
+ * - `raw` — a plain JSON Schema object (see `isPlainJsonSchemaObject`), passed through unvalidated.
  *
- * Everything else throws a `TypeError`, rather than being published as the tool's shape: non-objects
- * and arrays, a `~standard` that is not a Standard Schema, a `{ schema }` pair missing or
- * mistyping its `jsonSchema` half, and any object that mentions `schema`/`jsonSchema` without
- * being a valid pair (overwhelmingly a malformed pair, not JSON Schema — neither is a JSON Schema
- * keyword).
+ * Everything else throws a `TypeError` rather than being published as the tool's shape: non-objects
+ * and arrays, a `~standard` that is not a Standard Schema, a malformed `{ schema, jsonSchema }`
+ * pair, and any class instance or object whose `type` is not a JSON Schema type.
  */
 export const normalizeToolSchema = (
   value: unknown,
@@ -148,7 +187,8 @@ export const normalizeToolSchema = (
     );
   }
 
-  const looksLikePair = "schema" in value || "jsonSchema" in value;
+  // Own properties only, for the same prototype-chain reason `isPlainJsonSchemaObject` explains.
+  const looksLikePair = hasOwn(value, "schema") || hasOwn(value, "jsonSchema");
   if (looksLikePair) {
     const pairedSchema = asStandardSchema(value.schema);
     if (!pairedSchema) {
@@ -160,27 +200,27 @@ export const normalizeToolSchema = (
     }
 
     const { jsonSchema } = value;
-    if (!isRecord(jsonSchema)) {
+    if (isJsonSchemaConverter(jsonSchema)) {
+      return { kind: "paired", schema: pairedSchema, jsonSchema };
+    }
+
+    if (!isPlainJsonSchemaObject(jsonSchema)) {
       throw new TypeError(
-        `${label} looks like a { schema, jsonSchema } pair but its "jsonSchema" is missing or not an object. ` +
-          "Supply a JSON Schema object or an { input, output } converter.",
+        `${label} looks like a { schema, jsonSchema } pair but its "jsonSchema" half is not a plain ` +
+          `JSON Schema object or an { input, output } converter. ${NOT_JSON_SCHEMA_ADVICE}`,
       );
     }
 
     return {
       kind: "paired",
       schema: pairedSchema,
-      jsonSchema: isJsonSchemaConverter(jsonSchema)
-        ? jsonSchema
-        : (jsonSchema as Record<string, unknown>),
+      jsonSchema: jsonSchema as Record<string, unknown>,
     };
   }
 
-  const keyword = JSON_SCHEMA_KEYWORDS.find((candidate) => candidate in value);
-  if (keyword === undefined) {
+  if (!isPlainJsonSchemaObject(value)) {
     throw new TypeError(
-      `${label} is not a Standard Schema and does not look like JSON Schema: it has none of ` +
-        `${JSON_SCHEMA_KEYWORDS.join(", ")}. ${SHAPE_REMEDY}`,
+      `${label} is not a Standard Schema and is not a plain JSON Schema object. ${NOT_JSON_SCHEMA_ADVICE}`,
     );
   }
 
@@ -204,11 +244,25 @@ const hasJsonSchemaExporter = (
 type ConverterOutcome =
   { ok: true; schema: ToolSchemaDescriptor } | { ok: false; reason: string };
 
+const describe = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return "an array";
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (isRecord(value)) {
+    return "an object that is not plain JSON Schema";
+  }
+  return typeof value;
+};
+
 /**
- * Runs one half of a JSON Schema converter. A converter that throws or returns a non-object is a
- * failure to be *reported*, never swallowed: silently returning `undefined` here would put back
- * exactly the shapeless-tool failure this contract exists to remove — and for pair users, who
- * chose the pair form precisely to avoid it.
+ * Runs one half of a JSON Schema converter. A converter that throws, or hands back anything that is
+ * not a plain JSON Schema object, is a failure to be *reported*, never swallowed: silently
+ * returning `undefined` here would put back exactly the shapeless-tool failure this contract exists
+ * to remove — and for pair users, who chose the pair form precisely to avoid it. The result is held
+ * to the same standard as a hand-written raw schema, so the two forms cannot diverge.
  */
 const exportFromConverter = (
   converter: CordieriteJsonSchemaConverter,
@@ -223,13 +277,13 @@ const exportFromConverter = (
     return { ok: false, reason: `its ${source} threw (${detail})` };
   }
 
-  return isRecord(exported)
-    ? { ok: true, schema: exported }
+  return isPlainJsonSchemaObject(exported)
+    ? { ok: true, schema: exported as ToolSchemaDescriptor }
     : {
         ok: false,
-        reason: `its ${source} returned ${
-          Array.isArray(exported) ? "an array" : typeof exported
-        } instead of a JSON Schema object`,
+        reason: `its ${source} returned ${describe(
+          exported,
+        )} instead of a JSON Schema object`,
       };
 };
 

--- a/packages/react-native/src/useCordieriteTool.ts
+++ b/packages/react-native/src/useCordieriteTool.ts
@@ -31,7 +31,7 @@ export type UseCordieriteToolOptions = {
   enabled?: boolean;
 };
 
-/** Shape of `schema.ts`'s `exportToolSchema`, injected rather than imported (see below). */
+/** Shape of `schema.ts`'s `exportToolSchemaForKey`, injected rather than imported (see below). */
 type ToolSchemaExporter = (
   schema: CordieriteRuntimeSchema,
   mode: "input" | "output",
@@ -84,9 +84,10 @@ const schemaKey = (
   if (schema === undefined) {
     key = undefined;
   } else {
-    // `exportToolSchema` returns `undefined` for a schema that does not export JSON Schema (zod 3,
-    // plain valibot). The tool name is deliberately not passed: this runs during render, and the
-    // "shapeless tool" dev warning belongs to the registration path, not to key derivation.
+    // `exportToolSchemaForKey` returns `undefined` for a schema that does not export JSON Schema
+    // (zod 3, plain valibot) or that is not a valid schema at all. It never throws or warns: this
+    // runs during render, and reporting a shapeless or invalid schema belongs to the registration
+    // path, not to key derivation.
     const exported = exportSchema(schema, mode);
     if (exported === undefined) {
       // No shape to compare by value, and "exports nothing" must not collide with "no schema at

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,15 @@ importers:
       typescript:
         specifier: ~5.9.2
         version: 5.9.3
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@3.25.76)
+      zod4:
+        specifier: npm:zod@^4.4.3
+        version: zod@4.4.3
 
   packages/shared:
     devDependencies:
@@ -1798,10 +1807,12 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -5057,6 +5068,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -10874,6 +10888,10 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
@@ -10881,5 +10899,7 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1807,12 +1807,10 @@ packages:
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
-    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}

--- a/skills/cordierite/SKILL.md
+++ b/skills/cordierite/SKILL.md
@@ -129,7 +129,7 @@ registerTool({
 | --- | --- | --- |
 | Standard Schema with a JSON Schema exporter (**Zod v4**, arktype) | yes | its exporter's output |
 | `{ schema, jsonSchema }` pair — for Zod 3 (`zod-to-json-schema`), valibot (`@valibot/to-json-schema`) | yes | the supplied JSON Schema |
-| A raw JSON Schema object (no `~standard`) | **no** — args pass through | the object, verbatim |
+| A raw JSON Schema object (no `~standard`, at least one JSON Schema keyword) | **no** — args pass through | the object, verbatim |
 
 A bare Zod 3 / plain valibot schema (Standard Schema, no exporter) **throws in `__DEV__`**:
 it would otherwise register a shapeless tool that `tools/list` reports as taking any

--- a/skills/cordierite/SKILL.md
+++ b/skills/cordierite/SKILL.md
@@ -135,6 +135,10 @@ A bare Zod 3 / plain valibot schema (Standard Schema, no exporter) **throws in `
 it would otherwise register a shapeless tool that `tools/list` reports as taking any
 object. Pair it, or pass raw JSON Schema.
 
+An input schema must be **object-typed at its root** to be callable over MCP: a root
+`enum`, `const`, `$ref` or `anyOf` is legal JSON Schema but gives the agent no named
+arguments to pass (issue #34).
+
 ## Notes
 
 - Use **`--json`** for structured CLI output in agent flows; runtime failures in

--- a/skills/cordierite/SKILL.md
+++ b/skills/cordierite/SKILL.md
@@ -105,9 +105,7 @@ the `wss://` port or the daemon's key is being rotated.
 ## Declaring tools
 
 The app must register tools before `cordierite tools` / `cordierite invoke` (or MCP
-`tools/call`) can do anything useful. Define schemas with **Zod v4** (its built-in JSON
-Schema exporter means agents see a real tool shape) and register with `registerTool` or
-`useCordieriteTool`:
+`tools/call`) can do anything useful. Register with `registerTool` or `useCordieriteTool`:
 
 ```ts
 import { registerTool } from "@cordierite/react-native";
@@ -124,6 +122,18 @@ registerTool({
   handler: async (args) => ({ echoed: args.value }),
 });
 ```
+
+`inputSchema`/`outputSchema` accept three forms:
+
+| Form | Validated app-side | Shape agents see |
+| --- | --- | --- |
+| Standard Schema with a JSON Schema exporter (**Zod v4**, arktype) | yes | its exporter's output |
+| `{ schema, jsonSchema }` pair — for Zod 3 (`zod-to-json-schema`), valibot (`@valibot/to-json-schema`) | yes | the supplied JSON Schema |
+| A raw JSON Schema object (no `~standard`) | **no** — args pass through | the object, verbatim |
+
+A bare Zod 3 / plain valibot schema (Standard Schema, no exporter) **throws in `__DEV__`**:
+it would otherwise register a shapeless tool that `tools/list` reports as taking any
+object. Pair it, or pass raw JSON Schema.
 
 ## Notes
 


### PR DESCRIPTION
Implements the decision taken in #27: **Option A, extended**. Standard Schema stays the only runtime-validation contract; what `inputSchema`/`outputSchema` accept is widened so Zod 3 and JSON-Schema-only apps stop producing shapeless tools. No runtime dependency is added, and the wire `ToolDescriptor` is unchanged — this is app-side only.

## The problem

`inputSchema`/`outputSchema` had to be a Standard Schema **and** implement the non-standard `~standard.jsonSchema` exporter to give agents a real shape. Zod 3 and plain valibot implement the first but not the second, so those tools registered with no `input_schema` at all and reached the agent as `{ type: "object", additionalProperties: true }` — behind a dev warning that is easy to miss. A plain JSON Schema object was rejected outright.

## Changes

**`Cordierite.types.ts`** — new `CordieriteJsonSchemaObject<Input, Output>`, `CordieritePairedSchema<I, O>`, `CordieriteJsonSchemaConverter`, `CordieriteNormalizedToolSchema`; `CordieriteRuntimeSchema` widened to the three-form union (every member carrying both of the annotation's types); `InferToolArgs`/`InferToolResult` extended; the `jsonSchema<T>()` helper lives here so both entries re-export it through their existing `export *`.

**`schema.ts`** — `requireStandardSchema`/`requireOptionalStandardSchema` become `normalizeToolSchema`/`normalizeOptionalToolSchema`, classifying each slot exactly once at registration; `exportToolSchema` branches on the result; `validateStandardSchema` becomes `validateToolSchema`.

**Wiring** — `client/registry.ts` normalizes once and stores the normalized form on `CordieriteRegisteredTool`; `client/tool-invocation.ts` validates through it. The four call sites that re-declared the generic bound inline (`index.ts`, `client/index.ts`, `client/registry.ts`, `noop.ts`) now all use `CordieriteRuntimeSchema`, so the entries cannot drift. `jsonSchema` is part of `CordierePublicApi`.

### Accepted forms

| `inputSchema` / `outputSchema` | Validated app-side with | Published to agents | `handler` argument type |
| --- | --- | --- | --- |
| Standard Schema **with** a JSON Schema exporter — Zod 4, arktype | `~standard.validate` | its `~standard.jsonSchema` export | the schema's own type |
| `{ schema, jsonSchema }` pair — Zod 3, valibot, anything else | `schema["~standard"].validate` | the `jsonSchema` supplied (an object, or an `{ input, output }` converter) | the schema's own type |
| A raw JSON Schema object (no `~standard`; plain object, valid `type`) | **nothing** — args reach the handler as sent | the object, verbatim | `Record<string, unknown>`, or `T` via `jsonSchema<T>()` |
| Standard Schema **without** an exporter — bare Zod 3, plain valibot | `~standard.validate` | **nothing** — throws in dev | the schema's own type |

A Standard Schema may be an object *or* callable, so arktype's `Type` is accepted. Raw schemas are not validated because no JSON Schema validator is bundled — the package keeps zero third-party runtime dependencies.

**What is rejected**, rather than published as the tool's shape: non-objects and arrays; a `~standard` that is not a Standard Schema; any object mentioning `schema`/`jsonSchema` that is not a valid pair; and anything failing the plain-object rule — a raw schema must be an object literal or `Object.create(null)` (not a class instance) whose own `type`, if present, is a JSON Schema type name or an array of them. `{}` is accepted as the canonical accept-anything schema. The `jsonSchema` half of a pair and every converter result are held to the same rule, so the forms cannot diverge. Every failure throws a `TypeError` naming what to fix.

## Breaking change (development only)

A Standard Schema that yields no JSON Schema now **throws in `__DEV__`** instead of quietly registering shapeless — that includes a missing exporter, and an exporter or paired converter that throws or returns something that is not a plain JSON Schema object. Release builds are unaffected in kind: the tool still registers without a schema, now with one `console.warn` per tool *and slot* (previously dev-only), so an app already shipping such a tool is not broken by upgrading.

Two type-level changes matter only to code that inspected internals directly: `CordieriteRuntimeSchema` is a union rather than an alias for `StandardSchemaV1`, and `CordieriteRegisteredTool.inputSchema`/`.outputSchema` hold the normalized form. Both are in the changelog.

## Acceptance criteria

- [x] A Zod 3 `z.object({...})` and a raw JSON Schema both produce a real `input_schema` on the wire — asserted through `createCordieriteClient` against `tool_registry_snapshot`, using a real `zod@3.25` schema with `zod-to-json-schema` (not a stand-in).
- [x] Handler inference still works for Zod 4 (real `zod@4` schema, exact-type assertion) and for the new inputs.
- [x] `/noop` parity surface updated — every accepted form compiles against both entries.
- [x] README explains the accepted forms in one short table, with Zod 3 / valibot / raw recipes.

## Validation

Run at repo root on this branch:

| Command | Result |
| --- | --- |
| `pnpm build` | 3/3 tasks successful |
| `pnpm typecheck` | 3/3 tasks successful |
| `pnpm lint` | exit 0 — **0 errors**, 175 prettier warnings (**down from 194** on `main`) |
| `pnpm test` | exit 0 — shared 122/122, react-native **261/261** (was 212), cordierite 318/318. **701 passed, 0 failed** |

`daemon-restart.e2e.test.ts` fails intermittently on unmodified `main` in this environment (as does `events.integration.test.ts`); both passed on the final runs and neither was touched.

## Review findings and resolutions

All seven first-round findings were accepted and fixed in `2495d2d`; none were dismissed.

1. **Callable Standard Schemas rejected.** arktype's `Type` is a function carrying `~standard`, so the `typeof === "object"` test threw at registration for a library the docs now recommend. Detection accepts anything indexable (object or function) carrying `~standard.validate`; a callable fixture covers it.
2. **Dev error named a non-existent `zod-to-json-schema` target** (`jsonSchema2020-12`). Message no longer names a target; the README recipe uses `jsonSchema2019-09` — the closest that converter offers — and states that the emitted `$schema` will not be 2020-12, consistent with PROTOCOL/changelog wording.
3. **A paired converter that threw was swallowed into `undefined`**, reintroducing the silent-shapeless failure for exactly the users the pair form targets. Every failure to produce a shape now routes through one `reportShapelessSchema` (dev-throw / prod-warn-once); tests cover a throwing and a non-object-returning converter, and the same for a `~standard` exporter, in both dev and prod.
4. **`raw` was an unguarded catch-all** that published malformed pairs verbatim. An object mentioning `schema`/`jsonSchema` must be a valid pair; both failure shapes throw with the fix named.
5. **Unparameterized raw union member** widened `CordieriteRuntimeSchema<{ a: number }>` to `{ a: number } | Record<string, unknown>`.
6. **No real Zod 4 registration test.** Added one through `createCordieriteClient` asserting a real `input_schema`/`output_schema` from Zod 4's own exporter, so an exporter change is caught.
7. **Minor:** corrected the "omitting `inputSchema` infers `undefined`" comment (it is `unknown`, and always was); §13 now states the react-native zero-third-party-dependency guarantee that §11 and `schema.ts` cite; fixed a stranded line wrap in PROTOCOL.md §5; documented that a `JSONSchema7`-typed value needs `jsonSchema<T>()` or a cast.

Two issues found in my own earlier pass were fixed in `df37407`: the type-level and runtime detection orders disagreed (a Standard Schema also exposing a `schema` property would have inferred from the inner schema while validating with the outer one), and `schema.ts` had a second, independent `__DEV__` check — now a single exported `isDev()` on the logger.

### Second-round review

All five second-round findings were accepted and fixed in `3408e9b`; none were dismissed.

1. **Keyword heuristic was a regression against `main` (real, and the reason for this round).** The raw probe used `in`, which walks the prototype chain, and `type` was checked first — so a validator instance from yup, joi, superstruct or valibot 0.x was classified raw and published as the tool's shape, where `main` rejected it. Those instances also routinely hold circular references, so `JSON.stringify` in `sendSnapshot`/`sendDelta` would throw and lose the *entire* registry snapshot, not just that tool. The heuristic is replaced by a structural rule: plain object (prototype `Object.prototype` or `null`), own-property checks only, and an own `type` that must be a JSON Schema type name or an array of them; `{}` accepted. Tests added for a class instance with a prototype `type` getter (including an assertion that it really is circular and unstringifiable), `{}`, `{ $defs }`, `{ required }`, `{ items }`, `{ not }`, `{ type: "banana" }`, `{ type: [] }`, `{ type: ["string", "banana"] }`, every valid type name, and a null-prototype object.
2. **Same rule for the pair's `jsonSchema` half and converter results**, so the forms behave identically; `{}` accepted there too. Tests for a class-instance `jsonSchema` half, a converter returning a class instance, and a converter returning `{}`.
3. **Single phantom slot collapsed the two sides.** `CordieriteJsonSchemaObject` now takes `<Input, Output>` mirroring Standard Schema's own pair — `Output` feeds `InferToolArgs`, `Input` feeds `InferToolResult`. A two-parameter type test asserts `InferToolArgs`/`InferToolResult` of `CordieriteRuntimeSchema<string, number>` are exactly `number` and `string`, for both a Standard Schema and a raw schema; the assertion was verified to fail to compile when given the wrong expectation, so it is not vacuous.
4. **MCP root-object caveat** added to the README (with a link to #34) and to the skill: an input schema must be object-typed at its root; a root `enum`/`const`/`$ref`/`anyOf` is legal JSON Schema but leaves the agent no named arguments. Documented, not enforced — also noted in ARCHITECTURE §11.
5. **Minor:** the production warning is deduped by tool name *and* slot (a tool failing on both input and output has two things to fix; the old key hid the second — the existing test was updated to assert two warnings, and none on a repeat); README says "no third-party runtime dependencies"; the unrelated `@xmldom/xmldom` deprecation lines were dropped from `pnpm-lock.yaml` (registry metadata, not required by the format — `pnpm install --frozen-lockfile` still passes, and the lockfile diff is now only the three devDependency additions); and the lines this branch touched in `Cordierite.types.ts` and `client.test.ts` are prettier-clean, so no per-file count rises above `main`'s (types 12 → 11, `client.test.ts` 28 → 28, `schema.ts`/`schema.test.ts`/`schema-inference.test.ts` at 0; package total 194 → 175).

## Notes

`zod@^3.25`, `zod-to-json-schema` and `zod4` (aliased `npm:zod@^4`) are added as **devDependencies of `@cordierite/react-native` only**, so the tests exercise both Zod majors for real. The shipped package's dependencies are unchanged.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkzpDHexc8EuFfsFf8yQyh