### PR TITLE
feat: carry per-tool timeoutMs to the daemon and size MCP/CLI transport timeouts (#25)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -150,6 +150,17 @@ Methods:
 `SessionSummary`: `{ sessionId, alias, state, device: { manufacturer?, model?, os? },
 createdAt, claimedAt?, suspendedAt?, toolCount }`.
 
+**`tools.call` deadline.** The effective per-call deadline is `timeoutMs ?? tool.timeoutMs`
+— an explicit caller `timeoutMs` first, then the tool's own declared `timeoutMs` from its
+descriptor (`docs/PROTOCOL.md` §5), then `DEFAULT_CALL_TIMEOUT_MS` (10 000 ms) for a tool
+that declares nothing. Whatever that resolves to is clamped to
+`[MIN_CALL_TIMEOUT_MS, MAX_CALL_TIMEOUT_MS]` = `[1 000, 600 000]` ms; overshooting it
+rejects with `tool_timeout`. Callers that hold their own transport watchdog over a
+`tools.call` (the MCP server, `cordierite invoke`, `cordierite/client`) must size it from
+the same arithmetic — `deriveCallTransportTimeoutMs` (`daemon/calls.ts`) is that clamp plus
+5 000 ms of slack — so the daemon's `tool_timeout` always arrives first and the real error
+type reaches the caller instead of a generic transport failure.
+
 `daemon.status`'s result also reports the effective policy config and audit surfacing:
 `{ ..., policy: { default, destructive, tools? }, audit: { path, failedWrites } }` (§12).
 
@@ -295,6 +306,12 @@ proxies daemon RPC (auto-spawning the daemon like any client):
   a client still holding the older listing keeps demanding `structuredContent` for it until it
   re-lists. `notifications/tools/list_changed` fires on exactly that change, so the window is the
   client's own refresh latency, not something the server can close.
+- A proxied `tools/call` never sends a `timeoutMs` of its own: the daemon already applies
+  the tool's declared deadline (§5), so an agent gets whatever the app asked for without a
+  second knob to keep in sync. What the MCP server *does* size per call is its own daemon
+  connection's request timeout, from `deriveCallTransportTimeoutMs(tool.timeoutMs)` (§5) —
+  otherwise its 10 s default would race the daemon's timer and a long tool would surface as
+  a generic transport error instead of a `tool_timeout`, or not be reachable at all.
 - Two built-in management tools, `cordierite_connect` and `cordierite_wait_for_session`,
   let an agent mint a bootstrap link, deliver it to an emulator/simulator, and wait for the
   claim — without shell access. This is what makes the agent path self-service.
@@ -473,7 +490,13 @@ Client behavior:
   `ToolDescriptor` (§7) is unchanged by any of this — it already carries draft 2020-12
   JSON Schema, so the whole contract is app-side.
 - App-side handler timeout: if a handler exceeds the call timeout hint, abort its
-  `AbortSignal`, reply `tool_timeout`, and ignore the late result.
+  `AbortSignal`, reply `tool_timeout`, and ignore the late result. The hint is the tool's
+  own `timeoutMs`, falling back to the client-wide `defaultToolTimeoutMs`. Only the
+  *explicit* per-tool value travels on the descriptor (`docs/PROTOCOL.md` §5), where it
+  becomes the daemon's default deadline for that tool (§5) — so a tool that declares one
+  has the app timer and the daemon timer agree instead of the daemon giving up at 10 s
+  first. `defaultToolTimeoutMs` deliberately stays app-side: putting it on the wire would
+  silently retune the daemon's deadline for every tool in the app.
 - Cancellation: `tool.handler(args, context)`'s `context.signal` (`AbortSignal`) aborts on
   a `tool_cancel` frame (§7) or when the session's transport is lost (suspend) — the
   latter can't itself deliver `tool_cancel` (there is no socket left), so it aborts every

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -159,7 +159,14 @@ rejects with `tool_timeout`. Callers that hold their own transport watchdog over
 `tools.call` (the MCP server, `cordierite invoke`, `cordierite/client`) must size it from
 the same arithmetic — `deriveCallTransportTimeoutMs` (`daemon/calls.ts`) is that clamp plus
 5 000 ms of slack — so the daemon's `tool_timeout` always arrives first and the real error
-type reaches the caller instead of a generic transport failure.
+type reaches the caller instead of a generic transport failure. A caller that knows the
+effective deadline sizes the watchdog from it (the MCP server reads the tool's
+`timeoutMs` straight off its `tools.list` entry); a caller that does not — `invoke` with no
+`--timeout`, `AppClient.call` with no `timeoutMs`, both of which leave the deadline to the
+tool's own undeclared-to-them value — sizes it from `MAX_CALL_TIMEOUT_MS` instead. That
+backstop is only ever reached by a daemon that accepts a request and then answers nothing:
+a daemon that dies or drops the socket rejects every pending call at once
+(`rpc/client.ts`'s `close` handler), so nothing waits on the long timer in practice.
 
 `daemon.status`'s result also reports the effective policy config and audit surfacing:
 `{ ..., policy: { default, destructive, tools? }, audit: { path, failedWrites } }` (§12).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -150,20 +150,32 @@ Methods:
 `SessionSummary`: `{ sessionId, alias, state, device: { manufacturer?, model?, os? },
 createdAt, claimedAt?, suspendedAt?, toolCount }`.
 
-**`tools.call` deadline.** The effective per-call deadline is `timeoutMs ?? tool.timeoutMs`
-— an explicit caller `timeoutMs` first, then the tool's own declared `timeoutMs` from its
+**`tools.call` deadline.** The daemon's per-call deadline is `timeoutMs ?? tool.timeout_ms`
+— an explicit caller `timeoutMs` first, then the tool's own declared `timeout_ms` from its
 descriptor (`docs/PROTOCOL.md` §5), then `DEFAULT_CALL_TIMEOUT_MS` (10 000 ms) for a tool
 that declares nothing. Whatever that resolves to is clamped to
-`[MIN_CALL_TIMEOUT_MS, MAX_CALL_TIMEOUT_MS]` = `[1 000, 600 000]` ms; overshooting it
-rejects with `tool_timeout`. Callers that hold their own transport watchdog over a
-`tools.call` (the MCP server, `cordierite invoke`, `cordierite/client`) must size it from
-the same arithmetic — `deriveCallTransportTimeoutMs` (`daemon/calls.ts`) is that clamp plus
-5 000 ms of slack — so the daemon's `tool_timeout` always arrives first and the real error
-type reaches the caller instead of a generic transport failure. A caller that knows the
-effective deadline sizes the watchdog from it (the MCP server reads the tool's
-`timeoutMs` straight off its `tools.list` entry); a caller that does not — `invoke` with no
-`--timeout`, `AppClient.call` with no `timeoutMs`, both of which leave the deadline to the
-tool's own undeclared-to-them value — sizes it from `MAX_CALL_TIMEOUT_MS` instead. That
+`[MIN_TOOL_TIMEOUT_MS, MAX_TOOL_TIMEOUT_MS]` = `[1 000, 600 000]` ms; overshooting it
+rejects with `tool_timeout`.
+
+**A caller can shorten the deadline but cannot extend it past the app's own timer.** The
+app runs an independent abort timer per call (§11), set from the tool's declared
+`timeoutMs` or the client-wide `defaultToolTimeoutMs`, and it aborts the handler and
+answers `tool_timeout` at that point no matter what the caller asked for. So a caller
+`timeoutMs` below the app's timer genuinely shortens the call, while one above it only
+moves the daemon's own giving-up point — the app still stops first. For a tool that
+declares nothing, that ceiling is the app's 10 s default: `--timeout 60000` against such a
+tool does not buy it sixty seconds. Extending a tool's budget is the app's decision, made
+by declaring `timeoutMs` on the registration.
+
+Callers that hold their own transport watchdog over a `tools.call` (the MCP server,
+`cordierite invoke`, `cordierite/client`) must size it from the same arithmetic —
+`deriveCallTransportTimeoutMs` (`daemon/calls.ts`) is that clamp plus 5 000 ms of slack —
+so the daemon's `tool_timeout` always arrives first and the real error type reaches the
+caller instead of a generic transport failure. A caller that knows the effective deadline
+sizes the watchdog from it (the MCP server reads the tool's `timeout_ms` straight off its
+`tools.list` entry); a caller that does not — `invoke` with no `--timeout`,
+`AppClient.call` with no `timeoutMs`, both of which leave the deadline to the tool's own
+undeclared-to-them value — sizes it from `MAX_TOOL_TIMEOUT_MS` instead. That
 backstop is only ever reached by a daemon that accepts a request and then answers nothing:
 a daemon that dies or drops the socket rejects every pending call at once
 (`rpc/client.ts`'s `close` handler), so nothing waits on the long timer in practice.
@@ -313,12 +325,23 @@ proxies daemon RPC (auto-spawning the daemon like any client):
   a client still holding the older listing keeps demanding `structuredContent` for it until it
   re-lists. `notifications/tools/list_changed` fires on exactly that change, so the window is the
   client's own refresh latency, not something the server can close.
-- A proxied `tools/call` never sends a `timeoutMs` of its own: the daemon already applies
-  the tool's declared deadline (§5), so an agent gets whatever the app asked for without a
-  second knob to keep in sync. What the MCP server *does* size per call is its own daemon
-  connection's request timeout, from `deriveCallTransportTimeoutMs(tool.timeoutMs)` (§5) —
-  otherwise its 10 s default would race the daemon's timer and a long tool would surface as
-  a generic transport error instead of a `tool_timeout`, or not be reachable at all.
+- A proxied `tools/call` sends the tool's own declared `timeout_ms` (clamped, §5) as the
+  call's `timeoutMs` param, and sizes its daemon connection's request timeout from that same
+  number via `deriveCallTransportTimeoutMs` (§5). It is sent explicitly rather than left to
+  the daemon's `?? tool.timeout_ms` fallback so both numbers come from one value: the MCP
+  server resolves the tool from a `tools/list` snapshot while the daemon reads its live
+  registry, and a re-registration in between would otherwise leave a watchdog sized for the
+  old deadline to fire first and mask the daemon's real `tool_timeout`. A tool that declares
+  nothing gets the same 10 s default folded in by that clamp, so there is one number rather
+  than a conditional. Without any of this the connection's own 10 s default would race the
+  daemon's timer, and a long tool would surface as a generic transport error rather than
+  being reachable at all.
+- None of that lifts the MCP **client's** own per-request timeout, which is a third ceiling
+  outside this daemon's control (the SDK's default is 60 s, and Claude Code allows a stdio
+  tool call far longer). A tool declaring more than the calling agent will wait for still
+  fails on the client side, so a genuinely long tool should report progress — a
+  `progressToken` call resets many clients' idle timer — rather than rely on the deadline
+  alone.
 - Two built-in management tools, `cordierite_connect` and `cordierite_wait_for_session`,
   let an agent mint a bootstrap link, deliver it to an emulator/simulator, and wait for the
   claim — without shell access. This is what makes the agent path self-service.
@@ -498,7 +521,10 @@ Client behavior:
   JSON Schema, so the whole contract is app-side.
 - App-side handler timeout: if a handler exceeds the call timeout hint, abort its
   `AbortSignal`, reply `tool_timeout`, and ignore the late result. The hint is the tool's
-  own `timeoutMs`, falling back to the client-wide `defaultToolTimeoutMs`. Only the
+  own `timeoutMs`, falling back to the client-wide `defaultToolTimeoutMs`. This timer is
+  the real ceiling on a call: a caller's `tools.call` `timeoutMs` can shorten the deadline
+  but never extend it past this point, because the app stops the handler here regardless.
+  Only the
   *explicit* per-tool value travels on the descriptor (`docs/PROTOCOL.md` §5), where it
   becomes the daemon's default deadline for that tool (§5) — so a tool that declares one
   has the app timer and the daemon timer agree instead of the daemon giving up at 10 s

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -131,7 +131,8 @@ must always use the token from its most recent `session_ack`, never a cached old
   { "name": "sum", "description": "Add two numbers.",
     "input_schema": { "type": "object", "properties": { "a": { "type": "number" }, "b": { "type": "number" } }, "required": ["a", "b"] },
     "output_schema": { "type": "object", "properties": { "total": { "type": "number" } } },
-    "annotations": { "readOnlyHint": true } }
+    "annotations": { "readOnlyHint": true },
+    "timeoutMs": 60000 }
 ] }
 ```
 
@@ -232,7 +233,8 @@ can ask "what happened?" after the fact instead of only listening live.
   "description": "Add two numbers.",   // required, 1-4096 chars
   "input_schema": { /* draft 2020-12 JSON Schema */ },   // optional
   "output_schema": { /* draft 2020-12 JSON Schema */ },  // optional
-  "annotations": { "readOnlyHint": true, "destructiveHint": false, "idempotentHint": true } }
+  "annotations": { "readOnlyHint": true, "destructiveHint": false, "idempotentHint": true },
+  "timeoutMs": 60000 }                 // optional, positive integer
 ```
 
 Schemas come from whatever the app registered the tool with: a Standard Schema JSON Schema
@@ -247,6 +249,16 @@ daemon never inspects a schema's internals — only that it is a JSON object.
 (`docs/ARCHITECTURE.md` §12):
 `destructiveHint: true` routes a call through `policy.destructive` instead of
 `policy.default`.
+
+`timeoutMs` is the tool's own declared per-call deadline, in milliseconds, and must be a
+positive integer when present — a snapshot carrying anything else (`0`, a negative, a
+fraction, a string) fails `isToolDescriptor` and invalidates the whole snapshot. The daemon
+uses it as the default deadline for a `tools.call` that carries no `timeoutMs` of its own,
+clamped to `[1000, 600000]` like any caller-supplied value; an explicit caller `timeoutMs`
+still wins (`docs/ARCHITECTURE.md` §5). It is the app's *explicit* per-tool value only —
+never an app-wide default such as `defaultToolTimeoutMs`. Older apps omit the field
+entirely and keep the daemon's 10 s default, so it is safe to add in either direction. It
+is a daemon-side scheduling hint and is never emitted on the MCP `Tool` JSON.
 
 ## 6. Session state machine
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -132,7 +132,7 @@ must always use the token from its most recent `session_ack`, never a cached old
     "input_schema": { "type": "object", "properties": { "a": { "type": "number" }, "b": { "type": "number" } }, "required": ["a", "b"] },
     "output_schema": { "type": "object", "properties": { "total": { "type": "number" } } },
     "annotations": { "readOnlyHint": true },
-    "timeoutMs": 60000 }
+    "timeout_ms": 60000 }
 ] }
 ```
 
@@ -234,7 +234,7 @@ can ask "what happened?" after the fact instead of only listening live.
   "input_schema": { /* draft 2020-12 JSON Schema */ },   // optional
   "output_schema": { /* draft 2020-12 JSON Schema */ },  // optional
   "annotations": { "readOnlyHint": true, "destructiveHint": false, "idempotentHint": true },
-  "timeoutMs": 60000 }                 // optional, positive integer
+  "timeout_ms": 60000 }                // optional, positive integer
 ```
 
 Schemas come from whatever the app registered the tool with: a Standard Schema JSON Schema
@@ -250,12 +250,16 @@ daemon never inspects a schema's internals — only that it is a JSON object.
 `destructiveHint: true` routes a call through `policy.destructive` instead of
 `policy.default`.
 
-`timeoutMs` is the tool's own declared per-call deadline, in milliseconds, and must be a
+`timeout_ms` is the tool's own declared per-call deadline, in milliseconds, and must be a
 positive integer when present — a snapshot carrying anything else (`0`, a negative, a
 fraction, a string) fails `isToolDescriptor` and invalidates the whole snapshot. The daemon
 uses it as the default deadline for a `tools.call` that carries no `timeoutMs` of its own,
 clamped to `[1000, 600000]` like any caller-supplied value; an explicit caller `timeoutMs`
-still wins (`docs/ARCHITECTURE.md` §5). It is the app's *explicit* per-tool value only —
+takes precedence, though a caller can only shorten the effective deadline, never extend it
+past the app's own abort timer (`docs/ARCHITECTURE.md` §5). Note the spellings: `timeout_ms`
+is snake_case here like every other protocol-defined descriptor field, while the RN
+`registerTool` option and the `tools.call` RPC param are `timeoutMs` — those are camelCase
+layers. A camelCase key on this descriptor is an unknown extra, not a deadline. It is the app's *explicit* per-tool value only —
 never an app-wide default such as `defaultToolTimeoutMs`. Older apps omit the field
 entirely and keep the daemon's 10 s default, so it is safe to add in either direction. It
 is a daemon-side scheduling hint and is never emitted on the MCP `Tool` JSON.

--- a/packages/cordierite/README.md
+++ b/packages/cordierite/README.md
@@ -33,7 +33,7 @@ The command writes an unencrypted PEM private key (PKCS#8) to `<state-dir>/key.p
 | `cordierite link [--ttl <s>] [--qr] [--open android\|ios-sim] [--scheme <s>]` | mint a pending session and print its deep link |
 | `cordierite ls` | list sessions: alias, state, device, tool count |
 | `cordierite tools [selector] [name] [--full]` | list a session's tools, or show one tool's full schema |
-| `cordierite invoke [selector] <tool> --input '<json>' [--timeout <ms>]` | call a tool |
+| `cordierite invoke [selector] <tool> --input '<json>' [--timeout <ms>]` | call a tool; `--timeout` (clamped to 1 000–600 000 ms) overrides the tool's own declared `timeoutMs`, which is otherwise the deadline — 10 s for a tool that declares none |
 | `cordierite events [selector] [--follow] [--since <cursor>]` | stream session/tool events (default), or one-shot pull everything retained since `<cursor>` (`--since`); `--json` emits NDJSON |
 | `cordierite revoke [selector]` | revoke a session |
 | `cordierite daemon run\|start\|stop\|status` | daemon lifecycle |

--- a/packages/cordierite/README.md
+++ b/packages/cordierite/README.md
@@ -33,7 +33,7 @@ The command writes an unencrypted PEM private key (PKCS#8) to `<state-dir>/key.p
 | `cordierite link [--ttl <s>] [--qr] [--open android\|ios-sim] [--scheme <s>]` | mint a pending session and print its deep link |
 | `cordierite ls` | list sessions: alias, state, device, tool count |
 | `cordierite tools [selector] [name] [--full]` | list a session's tools, or show one tool's full schema |
-| `cordierite invoke [selector] <tool> --input '<json>' [--timeout <ms>]` | call a tool; `--timeout` (clamped to 1 000–600 000 ms) overrides the tool's own declared `timeoutMs`, which is otherwise the deadline — 10 s for a tool that declares none |
+| `cordierite invoke [selector] <tool> --input '<json>' [--timeout <ms>]` | call a tool. `--timeout` (clamped to 1 000–600 000 ms) can **shorten** the deadline but cannot extend it past the app's own timer: the app aborts the handler at the tool's declared `timeoutMs`, or 10 s for a tool that declares none, whatever the caller asks for. Give a slow tool more room by declaring `timeoutMs` on its registration |
 | `cordierite events [selector] [--follow] [--since <cursor>]` | stream session/tool events (default), or one-shot pull everything retained since `<cursor>` (`--since`); `--json` emits NDJSON |
 | `cordierite revoke [selector]` | revoke a session |
 | `cordierite daemon run\|start\|stop\|status` | daemon lifecycle |

--- a/packages/cordierite/src/__tests__/call-timeouts.test.ts
+++ b/packages/cordierite/src/__tests__/call-timeouts.test.ts
@@ -16,14 +16,16 @@ import {
   MAX_CALL_TIMEOUT_MS,
   MIN_CALL_TIMEOUT_MS,
 } from "../daemon/calls.js";
-import { toMcpTool } from "../mcp/tool-mapping.js";
+import { createMcpToolMapper } from "../mcp/tool-mapping.js";
 import { namespacedToolsSnapshotKey } from "../mcp/tool-namespace.js";
 
 describe("clampTimeout", () => {
   test("falls back to the daemon default when unset or not finite", () => {
     expect(clampTimeout(undefined)).toBe(DEFAULT_CALL_TIMEOUT_MS);
     expect(clampTimeout(Number.NaN)).toBe(DEFAULT_CALL_TIMEOUT_MS);
-    expect(clampTimeout(Number.POSITIVE_INFINITY)).toBe(DEFAULT_CALL_TIMEOUT_MS);
+    expect(clampTimeout(Number.POSITIVE_INFINITY)).toBe(
+      DEFAULT_CALL_TIMEOUT_MS,
+    );
   });
 
   test("passes an in-range value through, truncated to whole milliseconds", () => {
@@ -41,12 +43,18 @@ describe("clampTimeout", () => {
 
 describe("deriveCallTransportTimeoutMs", () => {
   test("is the enforced deadline plus slack", () => {
-    expect(deriveCallTransportTimeoutMs(undefined)).toBe(DEFAULT_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
-    expect(deriveCallTransportTimeoutMs(60_000)).toBe(60_000 + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+    expect(deriveCallTransportTimeoutMs(undefined)).toBe(
+      DEFAULT_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
+    );
+    expect(deriveCallTransportTimeoutMs(60_000)).toBe(
+      60_000 + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
+    );
   });
 
   test("adds slack to the clamped value, not the raw one", () => {
-    expect(deriveCallTransportTimeoutMs(500)).toBe(MIN_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+    expect(deriveCallTransportTimeoutMs(500)).toBe(
+      MIN_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
+    );
     // Clamping first is what keeps this inside Node's ~24.8-day timer range: an unclamped
     // MAX_SAFE_INTEGER would overflow and fire the watchdog immediately.
     const derived = deriveCallTransportTimeoutMs(Number.MAX_SAFE_INTEGER);
@@ -55,8 +63,18 @@ describe("deriveCallTransportTimeoutMs", () => {
   });
 
   test("always exceeds the deadline the daemon will enforce for the same input", () => {
-    for (const timeoutMs of [undefined, 0, 1_000, 10_000, 60_000, 600_000, 900_000]) {
-      expect(deriveCallTransportTimeoutMs(timeoutMs)).toBeGreaterThan(clampTimeout(timeoutMs));
+    for (const timeoutMs of [
+      undefined,
+      0,
+      1_000,
+      10_000,
+      60_000,
+      600_000,
+      900_000,
+    ]) {
+      expect(deriveCallTransportTimeoutMs(timeoutMs)).toBeGreaterThan(
+        clampTimeout(timeoutMs),
+      );
     }
   });
 });
@@ -71,18 +89,28 @@ describe("callers that do not know the effective deadline", () => {
   test("invoke with no --timeout sizes its watchdog for the largest deadline the daemon could enforce", () => {
     // Mirrors `commands/invoke.ts`: `options.timeoutMs ?? MAX_CALL_TIMEOUT_MS`.
     const noCallerTimeout: number | undefined = undefined;
-    expect(deriveCallTransportTimeoutMs(noCallerTimeout ?? MAX_CALL_TIMEOUT_MS)).toBe(
-      MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
-    );
+    expect(
+      deriveCallTransportTimeoutMs(noCallerTimeout ?? MAX_CALL_TIMEOUT_MS),
+    ).toBe(MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
     // …and never below what a tool declaring the maximum would actually be given.
-    expect(deriveCallTransportTimeoutMs(MAX_CALL_TIMEOUT_MS)).toBeGreaterThan(clampTimeout(MAX_CALL_TIMEOUT_MS));
+    expect(deriveCallTransportTimeoutMs(MAX_CALL_TIMEOUT_MS)).toBeGreaterThan(
+      clampTimeout(MAX_CALL_TIMEOUT_MS),
+    );
   });
 
   test("AppClient.call falls back to the same bound, and uses the exact deadline when given one", () => {
-    expect(transportTimeoutForToolCall(undefined)).toBe(MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
-    expect(transportTimeoutForToolCall(Number.NaN)).toBe(MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
-    expect(transportTimeoutForToolCall(60_000)).toBe(60_000 + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
-    expect(transportTimeoutForToolCall(500)).toBe(MIN_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+    expect(transportTimeoutForToolCall(undefined)).toBe(
+      MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
+    );
+    expect(transportTimeoutForToolCall(Number.NaN)).toBe(
+      MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
+    );
+    expect(transportTimeoutForToolCall(60_000)).toBe(
+      60_000 + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
+    );
+    expect(transportTimeoutForToolCall(500)).toBe(
+      MIN_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
+    );
   });
 });
 
@@ -98,6 +126,8 @@ const namespacedTool = (timeoutMs?: number) => ({
 });
 
 describe("toMcpTool", () => {
+  const toMcpTool = createMcpToolMapper(() => {});
+
   test("never emits a timeout on the MCP tool, even for a tool that declares one", () => {
     const mapped = toMcpTool(namespacedTool(60_000), false);
 
@@ -106,11 +136,17 @@ describe("toMcpTool", () => {
     // either spelling.
     expect("timeout_ms" in mapped).toBe(false);
     expect("timeoutMs" in mapped).toBe(false);
-    expect(Object.keys(mapped).sort()).toEqual(["description", "inputSchema", "name"]);
+    expect(Object.keys(mapped).sort()).toEqual([
+      "description",
+      "inputSchema",
+      "name",
+    ]);
   });
 
   test("maps a tool that declares one identically to a tool that does not", () => {
-    expect(toMcpTool(namespacedTool(60_000), false)).toEqual(toMcpTool(namespacedTool(), false));
+    expect(toMcpTool(namespacedTool(60_000), false)).toEqual(
+      toMcpTool(namespacedTool(), false),
+    );
   });
 });
 
@@ -129,6 +165,8 @@ describe("namespacedToolsSnapshotKey", () => {
 
   test("still reacts to a change a client can actually see", () => {
     const renamed = { ...namespacedTool(60_000), mcpName: "slow-login-2" };
-    expect(namespacedToolsSnapshotKey([namespacedTool(60_000)])).not.toBe(namespacedToolsSnapshotKey([renamed]));
+    expect(namespacedToolsSnapshotKey([namespacedTool(60_000)])).not.toBe(
+      namespacedToolsSnapshotKey([renamed]),
+    );
   });
 });

--- a/packages/cordierite/src/__tests__/call-timeouts.test.ts
+++ b/packages/cordierite/src/__tests__/call-timeouts.test.ts
@@ -23,9 +23,7 @@ describe("clampTimeout", () => {
   test("falls back to the daemon default when unset or not finite", () => {
     expect(clampTimeout(undefined)).toBe(DEFAULT_CALL_TIMEOUT_MS);
     expect(clampTimeout(Number.NaN)).toBe(DEFAULT_CALL_TIMEOUT_MS);
-    expect(clampTimeout(Number.POSITIVE_INFINITY)).toBe(
-      DEFAULT_CALL_TIMEOUT_MS,
-    );
+    expect(clampTimeout(Number.POSITIVE_INFINITY)).toBe(DEFAULT_CALL_TIMEOUT_MS);
   });
 
   test("passes an in-range value through, truncated to whole milliseconds", () => {
@@ -43,18 +41,12 @@ describe("clampTimeout", () => {
 
 describe("deriveCallTransportTimeoutMs", () => {
   test("is the enforced deadline plus slack", () => {
-    expect(deriveCallTransportTimeoutMs(undefined)).toBe(
-      DEFAULT_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
-    );
-    expect(deriveCallTransportTimeoutMs(60_000)).toBe(
-      60_000 + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
-    );
+    expect(deriveCallTransportTimeoutMs(undefined)).toBe(DEFAULT_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+    expect(deriveCallTransportTimeoutMs(60_000)).toBe(60_000 + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
   });
 
   test("adds slack to the clamped value, not the raw one", () => {
-    expect(deriveCallTransportTimeoutMs(500)).toBe(
-      MIN_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
-    );
+    expect(deriveCallTransportTimeoutMs(500)).toBe(MIN_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
     // Clamping first is what keeps this inside Node's ~24.8-day timer range: an unclamped
     // MAX_SAFE_INTEGER would overflow and fire the watchdog immediately.
     const derived = deriveCallTransportTimeoutMs(Number.MAX_SAFE_INTEGER);
@@ -63,18 +55,8 @@ describe("deriveCallTransportTimeoutMs", () => {
   });
 
   test("always exceeds the deadline the daemon will enforce for the same input", () => {
-    for (const timeoutMs of [
-      undefined,
-      0,
-      1_000,
-      10_000,
-      60_000,
-      600_000,
-      900_000,
-    ]) {
-      expect(deriveCallTransportTimeoutMs(timeoutMs)).toBeGreaterThan(
-        clampTimeout(timeoutMs),
-      );
+    for (const timeoutMs of [undefined, 0, 1_000, 10_000, 60_000, 600_000, 900_000]) {
+      expect(deriveCallTransportTimeoutMs(timeoutMs)).toBeGreaterThan(clampTimeout(timeoutMs));
     }
   });
 });
@@ -89,28 +71,18 @@ describe("callers that do not know the effective deadline", () => {
   test("invoke with no --timeout sizes its watchdog for the largest deadline the daemon could enforce", () => {
     // Mirrors `commands/invoke.ts`: `options.timeoutMs ?? MAX_CALL_TIMEOUT_MS`.
     const noCallerTimeout: number | undefined = undefined;
-    expect(
-      deriveCallTransportTimeoutMs(noCallerTimeout ?? MAX_CALL_TIMEOUT_MS),
-    ).toBe(MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
-    // …and never below what a tool declaring the maximum would actually be given.
-    expect(deriveCallTransportTimeoutMs(MAX_CALL_TIMEOUT_MS)).toBeGreaterThan(
-      clampTimeout(MAX_CALL_TIMEOUT_MS),
+    expect(deriveCallTransportTimeoutMs(noCallerTimeout ?? MAX_CALL_TIMEOUT_MS)).toBe(
+      MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
     );
+    // …and never below what a tool declaring the maximum would actually be given.
+    expect(deriveCallTransportTimeoutMs(MAX_CALL_TIMEOUT_MS)).toBeGreaterThan(clampTimeout(MAX_CALL_TIMEOUT_MS));
   });
 
   test("AppClient.call falls back to the same bound, and uses the exact deadline when given one", () => {
-    expect(transportTimeoutForToolCall(undefined)).toBe(
-      MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
-    );
-    expect(transportTimeoutForToolCall(Number.NaN)).toBe(
-      MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
-    );
-    expect(transportTimeoutForToolCall(60_000)).toBe(
-      60_000 + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
-    );
-    expect(transportTimeoutForToolCall(500)).toBe(
-      MIN_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
-    );
+    expect(transportTimeoutForToolCall(undefined)).toBe(MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+    expect(transportTimeoutForToolCall(Number.NaN)).toBe(MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+    expect(transportTimeoutForToolCall(60_000)).toBe(60_000 + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+    expect(transportTimeoutForToolCall(500)).toBe(MIN_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
   });
 });
 
@@ -136,17 +108,11 @@ describe("toMcpTool", () => {
     // either spelling.
     expect("timeout_ms" in mapped).toBe(false);
     expect("timeoutMs" in mapped).toBe(false);
-    expect(Object.keys(mapped).sort()).toEqual([
-      "description",
-      "inputSchema",
-      "name",
-    ]);
+    expect(Object.keys(mapped).sort()).toEqual(["description", "inputSchema", "name"]);
   });
 
   test("maps a tool that declares one identically to a tool that does not", () => {
-    expect(toMcpTool(namespacedTool(60_000), false)).toEqual(
-      toMcpTool(namespacedTool(), false),
-    );
+    expect(toMcpTool(namespacedTool(60_000), false)).toEqual(toMcpTool(namespacedTool(), false));
   });
 });
 
@@ -165,8 +131,6 @@ describe("namespacedToolsSnapshotKey", () => {
 
   test("still reacts to a change a client can actually see", () => {
     const renamed = { ...namespacedTool(60_000), mcpName: "slow-login-2" };
-    expect(namespacedToolsSnapshotKey([namespacedTool(60_000)])).not.toBe(
-      namespacedToolsSnapshotKey([renamed]),
-    );
+    expect(namespacedToolsSnapshotKey([namespacedTool(60_000)])).not.toBe(namespacedToolsSnapshotKey([renamed]));
   });
 });

--- a/packages/cordierite/src/__tests__/call-timeouts.test.ts
+++ b/packages/cordierite/src/__tests__/call-timeouts.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, expect, test } from "vitest";
 
+import { transportTimeoutForToolCall } from "../client/app-client.js";
 import {
   CALL_TRANSPORT_TIMEOUT_SLACK_MS,
   clampTimeout,
@@ -15,6 +16,8 @@ import {
   MAX_CALL_TIMEOUT_MS,
   MIN_CALL_TIMEOUT_MS,
 } from "../daemon/calls.js";
+import { toMcpTool } from "../mcp/tool-mapping.js";
+import { namespacedToolsSnapshotKey } from "../mcp/tool-namespace.js";
 
 describe("clampTimeout", () => {
   test("falls back to the daemon default when unset or not finite", () => {
@@ -55,5 +58,77 @@ describe("deriveCallTransportTimeoutMs", () => {
     for (const timeoutMs of [undefined, 0, 1_000, 10_000, 60_000, 600_000, 900_000]) {
       expect(deriveCallTransportTimeoutMs(timeoutMs)).toBeGreaterThan(clampTimeout(timeoutMs));
     }
+  });
+});
+
+/**
+ * `cordierite invoke` and `AppClient.call` differ from the MCP server: they pass the *caller's*
+ * timeout, so `undefined` there means "the daemon will fall back to the tool's own declared
+ * deadline", which neither knows. Sizing their watchdog off the 10 s default would make the caller
+ * the thing that fails a long tool call.
+ */
+describe("callers that do not know the effective deadline", () => {
+  test("invoke with no --timeout sizes its watchdog for the largest deadline the daemon could enforce", () => {
+    // Mirrors `commands/invoke.ts`: `options.timeoutMs ?? MAX_CALL_TIMEOUT_MS`.
+    const noCallerTimeout: number | undefined = undefined;
+    expect(deriveCallTransportTimeoutMs(noCallerTimeout ?? MAX_CALL_TIMEOUT_MS)).toBe(
+      MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS,
+    );
+    // …and never below what a tool declaring the maximum would actually be given.
+    expect(deriveCallTransportTimeoutMs(MAX_CALL_TIMEOUT_MS)).toBeGreaterThan(clampTimeout(MAX_CALL_TIMEOUT_MS));
+  });
+
+  test("AppClient.call falls back to the same bound, and uses the exact deadline when given one", () => {
+    expect(transportTimeoutForToolCall(undefined)).toBe(MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+    expect(transportTimeoutForToolCall(Number.NaN)).toBe(MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+    expect(transportTimeoutForToolCall(60_000)).toBe(60_000 + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+    expect(transportTimeoutForToolCall(500)).toBe(MIN_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+  });
+});
+
+const namespacedTool = (timeoutMs?: number) => ({
+  mcpName: "slow-login",
+  selector: "pixel-8",
+  descriptor: {
+    name: "slow-login",
+    description: "Signs in.",
+    ...(timeoutMs ? { timeout_ms: timeoutMs } : {}),
+  },
+  policy: "allow" as const,
+});
+
+describe("toMcpTool", () => {
+  test("never emits a timeout on the MCP tool, even for a tool that declares one", () => {
+    const mapped = toMcpTool(namespacedTool(60_000), false);
+
+    // The deadline is a daemon-side scheduling hint, not part of the MCP `Tool` contract. This
+    // guards against a future refactor swapping the explicit field mapping for a spread — under
+    // either spelling.
+    expect("timeout_ms" in mapped).toBe(false);
+    expect("timeoutMs" in mapped).toBe(false);
+    expect(Object.keys(mapped).sort()).toEqual(["description", "inputSchema", "name"]);
+  });
+
+  test("maps a tool that declares one identically to a tool that does not", () => {
+    expect(toMcpTool(namespacedTool(60_000), false)).toEqual(toMcpTool(namespacedTool(), false));
+  });
+});
+
+describe("namespacedToolsSnapshotKey", () => {
+  test("ignores the timeout, so a timeout-only re-registration fires no list_changed", () => {
+    // The key exists to decide whether to tell an MCP client its tool list moved. Since the
+    // deadline never reaches the `Tool` JSON, changing only that leaves the client's view
+    // identical — firing `list_changed` would just make it re-fetch the same list.
+    expect(namespacedToolsSnapshotKey([namespacedTool(60_000)])).toBe(
+      namespacedToolsSnapshotKey([namespacedTool(20_000)]),
+    );
+    expect(namespacedToolsSnapshotKey([namespacedTool(60_000)])).toBe(
+      namespacedToolsSnapshotKey([namespacedTool()]),
+    );
+  });
+
+  test("still reacts to a change a client can actually see", () => {
+    const renamed = { ...namespacedTool(60_000), mcpName: "slow-login-2" };
+    expect(namespacedToolsSnapshotKey([namespacedTool(60_000)])).not.toBe(namespacedToolsSnapshotKey([renamed]));
   });
 });

--- a/packages/cordierite/src/__tests__/call-timeouts.test.ts
+++ b/packages/cordierite/src/__tests__/call-timeouts.test.ts
@@ -1,0 +1,59 @@
+/**
+ * `daemon/calls.ts`'s timeout arithmetic (issue #25). `clampTimeout` decides the deadline the
+ * daemon actually enforces for a `tools.call`; `deriveCallTransportTimeoutMs` is what every caller
+ * (the MCP server, `cordierite invoke`) sizes its own socket watchdog off, so that the daemon's
+ * `tool_timeout` always wins the race and the caller reports the real error type.
+ */
+
+import { describe, expect, test } from "vitest";
+
+import {
+  CALL_TRANSPORT_TIMEOUT_SLACK_MS,
+  clampTimeout,
+  DEFAULT_CALL_TIMEOUT_MS,
+  deriveCallTransportTimeoutMs,
+  MAX_CALL_TIMEOUT_MS,
+  MIN_CALL_TIMEOUT_MS,
+} from "../daemon/calls.js";
+
+describe("clampTimeout", () => {
+  test("falls back to the daemon default when unset or not finite", () => {
+    expect(clampTimeout(undefined)).toBe(DEFAULT_CALL_TIMEOUT_MS);
+    expect(clampTimeout(Number.NaN)).toBe(DEFAULT_CALL_TIMEOUT_MS);
+    expect(clampTimeout(Number.POSITIVE_INFINITY)).toBe(DEFAULT_CALL_TIMEOUT_MS);
+  });
+
+  test("passes an in-range value through, truncated to whole milliseconds", () => {
+    expect(clampTimeout(60_000)).toBe(60_000);
+    expect(clampTimeout(1_500.9)).toBe(1_500);
+  });
+
+  test("clamps to the documented bounds", () => {
+    expect(clampTimeout(0)).toBe(MIN_CALL_TIMEOUT_MS);
+    expect(clampTimeout(-1)).toBe(MIN_CALL_TIMEOUT_MS);
+    expect(clampTimeout(MAX_CALL_TIMEOUT_MS + 1)).toBe(MAX_CALL_TIMEOUT_MS);
+    expect(clampTimeout(Number.MAX_SAFE_INTEGER)).toBe(MAX_CALL_TIMEOUT_MS);
+  });
+});
+
+describe("deriveCallTransportTimeoutMs", () => {
+  test("is the enforced deadline plus slack", () => {
+    expect(deriveCallTransportTimeoutMs(undefined)).toBe(DEFAULT_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+    expect(deriveCallTransportTimeoutMs(60_000)).toBe(60_000 + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+  });
+
+  test("adds slack to the clamped value, not the raw one", () => {
+    expect(deriveCallTransportTimeoutMs(500)).toBe(MIN_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+    // Clamping first is what keeps this inside Node's ~24.8-day timer range: an unclamped
+    // MAX_SAFE_INTEGER would overflow and fire the watchdog immediately.
+    const derived = deriveCallTransportTimeoutMs(Number.MAX_SAFE_INTEGER);
+    expect(derived).toBe(MAX_CALL_TIMEOUT_MS + CALL_TRANSPORT_TIMEOUT_SLACK_MS);
+    expect(derived).toBeLessThanOrEqual(2 ** 31 - 1);
+  });
+
+  test("always exceeds the deadline the daemon will enforce for the same input", () => {
+    for (const timeoutMs of [undefined, 0, 1_000, 10_000, 60_000, 600_000, 900_000]) {
+      expect(deriveCallTransportTimeoutMs(timeoutMs)).toBeGreaterThan(clampTimeout(timeoutMs));
+    }
+  });
+});

--- a/packages/cordierite/src/__tests__/mcp-server.integration.test.ts
+++ b/packages/cordierite/src/__tests__/mcp-server.integration.test.ts
@@ -55,9 +55,7 @@ afterEach(async () => {
 });
 
 const failIfCalled = (): never => {
-  throw new Error(
-    "auto-spawn should never be needed: the test daemon is already running.",
-  );
+  throw new Error("auto-spawn should never be needed: the test daemon is already running.");
 };
 
 const pickFreePort = async (): Promise<number> => {
@@ -86,11 +84,7 @@ const startTestDaemon = async (): Promise<TestDaemon> => {
   const port = await pickFreePort();
   await writeFile(
     path.join(stateDir, "config.json"),
-    JSON.stringify({
-      wssPort: port,
-      advertisedIp: "127.0.0.1",
-      scheme: "cordierite",
-    }),
+    JSON.stringify({ wssPort: port, advertisedIp: "127.0.0.1", scheme: "cordierite" }),
   );
 
   const daemon = await startDaemon({ stateDir });
@@ -99,19 +93,13 @@ const startTestDaemon = async (): Promise<TestDaemon> => {
   return { daemon, stateDir, port };
 };
 
-const rpcCall = (
-  socketPath: string,
-  method: string,
-  params?: unknown,
-): Promise<unknown> => {
+const rpcCall = (socketPath: string, method: string, params?: unknown): Promise<unknown> => {
   return new Promise((resolve, reject) => {
     const socket: Socket = connectUds(socketPath);
     let buffer = "";
 
     socket.once("connect", () => {
-      socket.write(
-        `${JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: params ?? {} })}\n`,
-      );
+      socket.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: params ?? {} })}\n`);
     });
 
     socket.on("data", (chunk: Buffer) => {
@@ -125,17 +113,10 @@ const rpcCall = (
       const line = buffer.slice(0, newlineIndex);
       socket.destroy();
 
-      const parsed = JSON.parse(line) as {
-        result?: unknown;
-        error?: { message: string; data?: unknown };
-      };
+      const parsed = JSON.parse(line) as { result?: unknown; error?: { message: string; data?: unknown } };
 
       if (parsed.error) {
-        reject(
-          Object.assign(new Error(parsed.error.message), {
-            data: parsed.error.data,
-          }),
-        );
+        reject(Object.assign(new Error(parsed.error.message), { data: parsed.error.data }));
         return;
       }
 
@@ -146,10 +127,7 @@ const rpcCall = (
   });
 };
 
-const waitForEvent = (
-  daemon: RunningDaemon,
-  kind: string,
-): Promise<{ kind: string; sessionId?: string; alias?: string }> => {
+const waitForEvent = (daemon: RunningDaemon, kind: string): Promise<{ kind: string; sessionId?: string; alias?: string }> => {
   return new Promise((resolve) => {
     const unsubscribe = daemon.eventBus.subscribe((event) => {
       if (event.kind === kind) {
@@ -162,9 +140,7 @@ const waitForEvent = (
 
 const connectClient = (port: number): Promise<WebSocket> => {
   return new Promise((resolve, reject) => {
-    const socket = new WebSocket(`wss://127.0.0.1:${port}`, {
-      rejectUnauthorized: false,
-    });
+    const socket = new WebSocket(`wss://127.0.0.1:${port}`, { rejectUnauthorized: false });
     socket.once("open", () => resolve(socket));
     socket.once("error", reject);
   });
@@ -191,9 +167,7 @@ type ClaimedApp = {
 const createLinkAndDecode = async (
   daemon: RunningDaemon,
 ): Promise<{ sessionId: string; token: string }> => {
-  const result = (await rpcCall(daemon.paths.socketPath, "link.create", {
-    ttlSeconds: 60,
-  })) as {
+  const result = (await rpcCall(daemon.paths.socketPath, "link.create", { ttlSeconds: 60 })) as {
     deepLinkPayload: string;
   };
   const decoded = decodeBootstrap(result.deepLinkPayload);
@@ -202,11 +176,7 @@ const createLinkAndDecode = async (
   return { sessionId: decoded!.sessionId, token: decoded!.token };
 };
 
-const claimApp = async (
-  daemon: RunningDaemon,
-  port: number,
-  deviceModel = "Pixel 8",
-): Promise<ClaimedApp> => {
+const claimApp = async (daemon: RunningDaemon, port: number, deviceModel = "Pixel 8"): Promise<ClaimedApp> => {
   const link = await createLinkAndDecode(daemon);
   const socket = await connectClient(port);
 
@@ -268,10 +238,7 @@ const noDevicesExec: ExecFn = async (command) => {
   return { stdout: "List of devices attached\n\n", stderr: "" };
 };
 
-const createMcpHandle = async (
-  stateDir: string,
-  exec: ExecFn = noDevicesExec,
-): Promise<McpServerHandle> => {
+const createMcpHandle = async (stateDir: string, exec: ExecFn = noDevicesExec): Promise<McpServerHandle> => {
   const handle = await createMcpServer({
     stateDir,
     spawn: failIfCalled,
@@ -284,11 +251,8 @@ const createMcpHandle = async (
 };
 
 /** Connects an SDK `Client` to `handle` over an in-process linked transport pair. */
-const connectInMemoryClient = async (
-  handle: McpServerHandle,
-): Promise<Client> => {
-  const [serverTransport, clientTransport] =
-    InMemoryTransport.createLinkedPair();
+const connectInMemoryClient = async (handle: McpServerHandle): Promise<Client> => {
+  const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
   await handle.connect(serverTransport);
 
   const client = new Client({ name: "test-client", version: "0.0.0" });
@@ -305,28 +269,19 @@ describe("mcp: tools/list and tools/call", () => {
       {
         name: "echo",
         description: "Echoes its input.",
-        input_schema: {
-          type: "object",
-          properties: { text: { type: "string" } },
-        },
+        input_schema: { type: "object", properties: { text: { type: "string" } } },
       },
     ]);
 
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
-    const listed = await client.request(
-      { method: "tools/list", params: {} },
-      ListToolsResultSchema,
-    );
+    const listed = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
     const proxiedTools = withoutBuiltinTools(listed.tools);
     expect(proxiedTools).toHaveLength(1);
     expect(proxiedTools[0]!.name).toBe("echo");
     expect(proxiedTools[0]!.description).toBe("Echoes its input.");
-    expect(proxiedTools[0]!.inputSchema).toEqual({
-      type: "object",
-      properties: { text: { type: "string" } },
-    });
+    expect(proxiedTools[0]!.inputSchema).toEqual({ type: "object", properties: { text: { type: "string" } } });
 
     app.socket.on("message", (data) => {
       const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
@@ -344,10 +299,7 @@ describe("mcp: tools/list and tools/call", () => {
     });
 
     const called = await client.request(
-      {
-        method: "tools/call",
-        params: { name: "echo", arguments: { text: "hello" } },
-      },
+      { method: "tools/call", params: { name: "echo", arguments: { text: "hello" } } },
       CallToolResultSchema,
     );
 
@@ -385,16 +337,8 @@ describe("mcp: tools/list and tools/call", () => {
         description: "Returns one of two shapes.",
         output_schema: {
           anyOf: [
-            {
-              type: "object",
-              properties: { ok: { type: "boolean" } },
-              required: ["ok"],
-            },
-            {
-              type: "object",
-              properties: { error: { type: "string" } },
-              required: ["error"],
-            },
+            { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] },
+            { type: "object", properties: { error: { type: "string" } }, required: ["error"] },
           ],
         },
       },
@@ -428,15 +372,9 @@ describe("mcp: tools/list and tools/call", () => {
     // the output schemas `callTool` below enforces — exactly what a real client does.
     const listed = await client.listTools();
     const proxiedTools = withoutBuiltinTools(listed.tools);
-    expect(proxiedTools.map((tool) => tool.name).sort()).toEqual([
-      "get-profile",
-      "get-status",
-      "list-todos",
-    ]);
+    expect(proxiedTools.map((tool) => tool.name).sort()).toEqual(["get-profile", "get-status", "list-todos"]);
 
-    const objectTool = proxiedTools.find(
-      (tool) => tool.name === "get-profile",
-    )!;
+    const objectTool = proxiedTools.find((tool) => tool.name === "get-profile")!;
     const arrayTool = proxiedTools.find((tool) => tool.name === "list-todos")!;
     const unionTool = proxiedTools.find((tool) => tool.name === "get-status")!;
     expect(objectTool.outputSchema).toEqual({
@@ -448,10 +386,7 @@ describe("mcp: tools/list and tools/call", () => {
     expect(arrayTool.outputSchema).toBeUndefined();
     expect(unionTool.outputSchema).toBeUndefined();
 
-    const profile = await client.callTool({
-      name: "get-profile",
-      arguments: {},
-    });
+    const profile = await client.callTool({ name: "get-profile", arguments: {} });
     expect(profile.isError).not.toBe(true);
     expect(profile.structuredContent).toEqual({ name: "Ada" });
 
@@ -460,9 +395,7 @@ describe("mcp: tools/list and tools/call", () => {
     const todos = await client.callTool({ name: "list-todos", arguments: {} });
     expect(todos.isError).not.toBe(true);
     expect(todos.structuredContent).toBeUndefined();
-    expect(todos.content).toEqual([
-      { type: "text", text: JSON.stringify(["write tests", "ship it"]) },
-    ]);
+    expect(todos.content).toEqual([{ type: "text", text: JSON.stringify(["write tests", "ship it"]) }]);
 
     // A dropped schema never turns a good result into an error: the union tool's result *is* an
     // object, so it still travels as `structuredContent` — the client just has no schema to
@@ -470,9 +403,7 @@ describe("mcp: tools/list and tools/call", () => {
     const status = await client.callTool({ name: "get-status", arguments: {} });
     expect(status.isError).not.toBe(true);
     expect(status.structuredContent).toEqual({ ok: true });
-    expect(status.content).toEqual([
-      { type: "text", text: JSON.stringify({ ok: true }) },
-    ]);
+    expect(status.content).toEqual([{ type: "text", text: JSON.stringify({ ok: true }) }]);
 
     app.socket.close();
   });
@@ -481,11 +412,7 @@ describe("mcp: tools/list and tools/call", () => {
     const { daemon, stateDir, port } = await startTestDaemon();
     const app = await claimApp(daemon, port);
     await snapshotTools(daemon, app, [
-      {
-        name: "lies",
-        description: "Claims an object, returns a number.",
-        output_schema: { type: "object" },
-      },
+      { name: "lies", description: "Claims an object, returns a number.", output_schema: { type: "object" } },
     ]);
 
     const handle = await createMcpHandle(stateDir);
@@ -496,12 +423,7 @@ describe("mcp: tools/list and tools/call", () => {
 
       if (msg.type === "tool_call") {
         app.socket.send(
-          JSON.stringify({
-            type: "tool_result",
-            session_id: app.sessionId,
-            id: msg.id,
-            result: 42,
-          }),
+          JSON.stringify({ type: "tool_result", session_id: app.sessionId, id: msg.id, result: 42 }),
         );
       }
     });
@@ -514,12 +436,8 @@ describe("mcp: tools/list and tools/call", () => {
 
     expect(result.isError).toBe(true);
     expect(result.structuredContent).toBeUndefined();
-    expect((result.content as Array<{ text: string }>)[0]!.text).toContain(
-      "tool_output_validation_error",
-    );
-    expect((result.content as Array<{ text: string }>)[0]!.text).toContain(
-      "a number",
-    );
+    expect((result.content as Array<{ text: string }>)[0]!.text).toContain("tool_output_validation_error");
+    expect((result.content as Array<{ text: string }>)[0]!.text).toContain("a number");
 
     app.socket.close();
   });
@@ -529,11 +447,7 @@ describe("mcp: tools/list and tools/call", () => {
     const { daemon, stateDir, port } = await startTestDaemon();
     const app = await claimApp(daemon, port);
     await snapshotTools(daemon, app, [
-      {
-        name: "nullish",
-        description: "Claims an object, returns null.",
-        output_schema: { type: "object" },
-      },
+      { name: "nullish", description: "Claims an object, returns null.", output_schema: { type: "object" } },
     ]);
 
     const handle = await createMcpHandle(stateDir);
@@ -544,12 +458,7 @@ describe("mcp: tools/list and tools/call", () => {
 
       if (msg.type === "tool_call") {
         app.socket.send(
-          JSON.stringify({
-            type: "tool_result",
-            session_id: app.sessionId,
-            id: msg.id,
-            result: null,
-          }),
+          JSON.stringify({ type: "tool_result", session_id: app.sessionId, id: msg.id, result: null }),
         );
       }
     });
@@ -633,22 +542,11 @@ describe("mcp: tools/list and tools/call", () => {
 
       if (msg.type === "tool_call") {
         app.socket.send(
-          JSON.stringify({
-            type: "tool_call_progress",
-            session_id: app.sessionId,
-            id: msg.id,
-            progress: 0.5,
-            message: "halfway",
-          }),
+          JSON.stringify({ type: "tool_call_progress", session_id: app.sessionId, id: msg.id, progress: 0.5, message: "halfway" }),
         );
         setTimeout(() => {
           app.socket.send(
-            JSON.stringify({
-              type: "tool_result",
-              session_id: app.sessionId,
-              id: msg.id,
-              result: "done",
-            }),
+            JSON.stringify({ type: "tool_result", session_id: app.sessionId, id: msg.id, result: "done" }),
           );
         }, 50);
       }
@@ -664,10 +562,7 @@ describe("mcp: tools/list and tools/call", () => {
       CallToolResultSchema,
       {
         onprogress: (progress) => {
-          progressUpdates.push({
-            progress: progress.progress,
-            message: progress.message,
-          });
+          progressUpdates.push({ progress: progress.progress, message: progress.message });
         },
       },
     );
@@ -686,10 +581,7 @@ describe("mcp: tools/list and tools/call", () => {
     const receivedByApp: Record<string, unknown>[] = [];
     const gotToolCancel = new Promise<Record<string, unknown>>((resolve) => {
       app.socket.on("message", (data) => {
-        const msg = JSON.parse(data.toString("utf8")) as Record<
-          string,
-          unknown
-        >;
+        const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
         receivedByApp.push(msg);
         // Deliberately never reply to tool_call — the point is that cancellation reaches the app
         // while the call is still pending.
@@ -729,15 +621,9 @@ describe("mcp: tools/list and tools/call", () => {
     controller.abort("user cancelled");
 
     const cancelMessage = await gotToolCancel;
-    expect(cancelMessage).toMatchObject({
-      type: "tool_cancel",
-      session_id: app.sessionId,
-      reason: "mcp_client_cancelled",
-    });
+    expect(cancelMessage).toMatchObject({ type: "tool_cancel", session_id: app.sessionId, reason: "mcp_client_cancelled" });
 
-    const toolCallMessage = receivedByApp.find(
-      (msg) => msg.type === "tool_call",
-    );
+    const toolCallMessage = receivedByApp.find((msg) => msg.type === "tool_call");
     expect(cancelMessage.id).toBe(toolCallMessage?.id);
 
     await callPromise;
@@ -751,20 +637,14 @@ describe("mcp: tools/list and tools/call", () => {
       {
         name: "echo",
         description: "Echoes its input.",
-        input_schema: {
-          type: "object",
-          properties: { text: { type: "string" } },
-        },
+        input_schema: { type: "object", properties: { text: { type: "string" } } },
       },
     ]);
 
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
-    const listed = await client.request(
-      { method: "tools/list", params: {} },
-      ListToolsResultSchema,
-    );
+    const listed = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
     // Names only, sorted: full descriptors (incl. built-ins' free-text descriptions) would make this
     // snapshot brittle against unrelated wording tweaks; the shape/schema mapping is what's locked.
     const shapes = listed.tools
@@ -789,15 +669,9 @@ describe("mcp: tools/list and tools/call", () => {
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
-    const listed = await client.request(
-      { method: "tools/list", params: {} },
-      ListToolsResultSchema,
-    );
+    const listed = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
     const proxiedTools = withoutBuiltinTools(listed.tools);
-    expect(proxiedTools[0]!.inputSchema).toEqual({
-      type: "object",
-      additionalProperties: true,
-    });
+    expect(proxiedTools[0]!.inputSchema).toEqual({ type: "object", additionalProperties: true });
 
     app.socket.close();
   });
@@ -823,16 +697,10 @@ describe("mcp: tools/list and tools/call", () => {
 
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
-    const listed = await client.request(
-      { method: "tools/list", params: {} },
-      ListToolsResultSchema,
-    );
+    const listed = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
     const proxiedTools = withoutBuiltinTools(listed.tools);
 
-    expect(proxiedTools[0]!.annotations).toEqual({
-      destructiveHint: true,
-      readOnlyHint: false,
-    });
+    expect(proxiedTools[0]!.annotations).toEqual({ destructiveHint: true, readOnlyHint: false });
 
     app.socket.close();
   });
@@ -879,17 +747,12 @@ describe("mcp: tools/list and tools/call", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      {
-        method: "tools/call",
-        params: { name: "does-not-exist", arguments: {} },
-      },
+      { method: "tools/call", params: { name: "does-not-exist", arguments: {} } },
       CallToolResultSchema,
     );
 
     expect(result.isError).toBe(true);
-    expect((result.content[0] as { text: string }).text).toContain(
-      "tool_not_found",
-    );
+    expect((result.content[0] as { text: string }).text).toContain("tool_not_found");
   });
 });
 
@@ -902,13 +765,8 @@ describe("mcp: namespacing and list_changed", () => {
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
-    const singleSessionListing = await client.request(
-      { method: "tools/list", params: {} },
-      ListToolsResultSchema,
-    );
-    expect(
-      withoutBuiltinTools(singleSessionListing.tools).map((tool) => tool.name),
-    ).toEqual(["echo"]);
+    const singleSessionListing = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+    expect(withoutBuiltinTools(singleSessionListing.tools).map((tool) => tool.name)).toEqual(["echo"]);
 
     let listChangedCount = 0;
     client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
@@ -924,16 +782,11 @@ describe("mcp: namespacing and list_changed", () => {
 
     expect(listChangedCount).toBeGreaterThan(0);
 
-    const multiSessionListing = await client.request(
-      { method: "tools/list", params: {} },
-      ListToolsResultSchema,
-    );
+    const multiSessionListing = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
     const names = withoutBuiltinTools(multiSessionListing.tools)
       .map((tool) => tool.name)
       .sort();
-    expect(names).toEqual(
-      [`${appA.alias}__echo`, `${appB.alias}__echo`].sort(),
-    );
+    expect(names).toEqual([`${appA.alias}__echo`, `${appB.alias}__echo`].sort());
 
     appA.socket.close();
     appB.socket.close();
@@ -947,10 +800,7 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      {
-        method: "tools/call",
-        params: { name: "cordierite_connect", arguments: {} },
-      },
+      { method: "tools/call", params: { name: "cordierite_connect", arguments: {} } },
       CallToolResultSchema,
     );
 
@@ -966,9 +816,7 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     expect(data.sessionId).toBeTruthy();
     expect(data.qr.length).toBeGreaterThan(0);
     expect(data.delivered).toBeUndefined();
-    expect(data.note).toMatch(
-      /no booted iOS simulator or attached Android device/iu,
-    );
+    expect(data.note).toMatch(/no booted iOS simulator or attached Android device/iu);
     // The agent has to be told to render the QR and ask, or it goes straight to a silent wait.
     expect(data.instructions).toMatch(/show the user the "qr" field/iu);
     expect(data.instructions).toMatch(/cordierite_wait_for_session/u);
@@ -989,11 +837,7 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
       if (command === "xcrun" && args.includes("--json")) {
         return {
           stdout: JSON.stringify({
-            devices: {
-              "iOS 17.0": [
-                { state: "Booted", udid: "SIM-1", name: "iPhone 15" },
-              ],
-            },
+            devices: { "iOS 17.0": [{ state: "Booted", udid: "SIM-1", name: "iPhone 15" }] },
           }),
           stderr: "",
         };
@@ -1006,10 +850,7 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      {
-        method: "tools/call",
-        params: { name: "cordierite_connect", arguments: {} },
-      },
+      { method: "tools/call", params: { name: "cordierite_connect", arguments: {} } },
       CallToolResultSchema,
     );
 
@@ -1031,11 +872,7 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     expect(data.qr).toBeUndefined();
     expect(data.note).toMatch(/iPhone 15 \(SIM-1\)/u);
 
-    expect(
-      calls.some(
-        (call) => call.args.includes("openurl") && call.args.includes("SIM-1"),
-      ),
-    ).toBe(true);
+    expect(calls.some((call) => call.args.includes("openurl") && call.args.includes("SIM-1"))).toBe(true);
   });
 
   test('target "none" forces the QR path even with a device booted', async () => {
@@ -1046,9 +883,7 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
       calls.push(`${command} ${args.join(" ")}`);
       return {
         stdout: JSON.stringify({
-          devices: {
-            "iOS 17.0": [{ state: "Booted", udid: "SIM-1", name: "iPhone 15" }],
-          },
+          devices: { "iOS 17.0": [{ state: "Booted", udid: "SIM-1", name: "iPhone 15" }] },
         }),
         stderr: "",
       };
@@ -1058,18 +893,11 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      {
-        method: "tools/call",
-        params: { name: "cordierite_connect", arguments: { target: "none" } },
-      },
+      { method: "tools/call", params: { name: "cordierite_connect", arguments: { target: "none" } } },
       CallToolResultSchema,
     );
 
-    const data = result.structuredContent as {
-      qr?: string;
-      delivered?: true;
-      note?: string;
-    };
+    const data = result.structuredContent as { qr?: string; delivered?: true; note?: string };
     expect(data.delivered).toBeUndefined();
     expect(data.qr!.length).toBeGreaterThan(0);
     expect(data.note).toMatch(/target: "none"/u);
@@ -1102,18 +930,11 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      {
-        method: "tools/call",
-        params: { name: "cordierite_connect", arguments: {} },
-      },
+      { method: "tools/call", params: { name: "cordierite_connect", arguments: {} } },
       CallToolResultSchema,
     );
 
-    const data = result.structuredContent as {
-      qr?: string;
-      delivered?: true;
-      note?: string;
-    };
+    const data = result.structuredContent as { qr?: string; delivered?: true; note?: string };
     expect(data.delivered).toBeUndefined();
     expect(data.qr!.length).toBeGreaterThan(0);
     expect(data.note).toMatch(/SIM-1/u);
@@ -1126,17 +947,12 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      {
-        method: "tools/call",
-        params: { name: "cordierite_connect", arguments: { device: "SIM-1" } },
-      },
+      { method: "tools/call", params: { name: "cordierite_connect", arguments: { device: "SIM-1" } } },
       CallToolResultSchema,
     );
 
     expect(result.isError).toBe(true);
-    expect(JSON.stringify(result.content)).toMatch(
-      /device.{0,4} requires an explicit/u,
-    );
+    expect(JSON.stringify(result.content)).toMatch(/device.{0,4} requires an explicit/u);
   });
 
   test("cordierite_wait_for_session resolves once a fake client claims the minted session", async () => {
@@ -1145,28 +961,16 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const connectResult = await client.request(
-      {
-        method: "tools/call",
-        params: { name: "cordierite_connect", arguments: {} },
-      },
+      { method: "tools/call", params: { name: "cordierite_connect", arguments: {} } },
       CallToolResultSchema,
     );
-    const { sessionId, deepLink } = connectResult.structuredContent as {
-      sessionId: string;
-      deepLink: string;
-    };
+    const { sessionId, deepLink } = connectResult.structuredContent as { sessionId: string; deepLink: string };
 
     const payload = deepLink.split("cordierite=")[1]!;
     const decoded = decodeBootstrap(payload)!;
 
     const waitPromise = client.request(
-      {
-        method: "tools/call",
-        params: {
-          name: "cordierite_wait_for_session",
-          arguments: { sessionId, timeoutMs: 5000 },
-        },
-      },
+      { method: "tools/call", params: { name: "cordierite_wait_for_session", arguments: { sessionId, timeoutMs: 5000 } } },
       CallToolResultSchema,
     );
 
@@ -1186,11 +990,7 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
 
     const waitResult = await waitPromise;
     expect(waitResult.isError).not.toBe(true);
-    const data = waitResult.structuredContent as {
-      sessionId: string;
-      claimed: true;
-      alias: string;
-    };
+    const data = waitResult.structuredContent as { sessionId: string; claimed: true; alias: string };
     expect(data.sessionId).toBe(sessionId);
     expect(data.claimed).toBe(true);
     expect(data.alias.length).toBeGreaterThan(0);
@@ -1207,20 +1007,14 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
       if (command === "xcrun" && args.includes("--json")) {
         return {
           stdout: JSON.stringify({
-            devices: {
-              "iOS 17.0": [
-                { state: "Booted", udid: "SIM-1", name: "iPhone 15" },
-              ],
-            },
+            devices: { "iOS 17.0": [{ state: "Booted", udid: "SIM-1", name: "iPhone 15" }] },
           }),
           stderr: "",
         };
       }
 
       if (args.includes("openurl")) {
-        throw Object.assign(new Error("Command failed"), {
-          stderr: "no matching URL scheme",
-        });
+        throw Object.assign(new Error("Command failed"), { stderr: "no matching URL scheme" });
       }
 
       return { stdout: "List of devices attached\n\n", stderr: "" };
@@ -1230,10 +1024,7 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      {
-        method: "tools/call",
-        params: { name: "cordierite_connect", arguments: {} },
-      },
+      { method: "tools/call", params: { name: "cordierite_connect", arguments: {} } },
       CallToolResultSchema,
     );
 
@@ -1254,9 +1045,7 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
 
     // The fallback link has to be a fresh mint: the first one was minted for 127.0.0.1 on the
     // assumption it was going to a local simulator, which is the wrong address for a scanner.
-    expect(
-      decodeBootstrap(data.deepLink.split("cordierite=")[1]!),
-    ).not.toBeNull();
+    expect(decodeBootstrap(data.deepLink.split("cordierite=")[1]!)).not.toBeNull();
   });
 
   test("cordierite_wait_for_session returns immediately for a session claimed before it was called", async () => {
@@ -1271,20 +1060,13 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const result = await client.request(
       {
         method: "tools/call",
-        params: {
-          name: "cordierite_wait_for_session",
-          arguments: { sessionId: app.sessionId, timeoutMs: 5000 },
-        },
+        params: { name: "cordierite_wait_for_session", arguments: { sessionId: app.sessionId, timeoutMs: 5000 } },
       },
       CallToolResultSchema,
     );
 
     expect(result.isError).not.toBe(true);
-    const data = result.structuredContent as {
-      sessionId: string;
-      claimed: true;
-      alias: string;
-    };
+    const data = result.structuredContent as { sessionId: string; claimed: true; alias: string };
     expect(data.sessionId).toBe(app.sessionId);
     expect(data.claimed).toBe(true);
     expect(data.alias).toBe(app.alias);
@@ -1298,25 +1080,17 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const connectResult = await client.request(
-      {
-        method: "tools/call",
-        params: { name: "cordierite_connect", arguments: { target: "none" } },
-      },
+      { method: "tools/call", params: { name: "cordierite_connect", arguments: { target: "none" } } },
       CallToolResultSchema,
     );
-    const { sessionId } = connectResult.structuredContent as {
-      sessionId: string;
-    };
+    const { sessionId } = connectResult.structuredContent as { sessionId: string };
 
     // A generous timeout: the point is that the call comes back on the connection dropping, not on
     // the clock. Without an onClose handler this sits silently for the full 30s.
     const waitPromise = client.request(
       {
         method: "tools/call",
-        params: {
-          name: "cordierite_wait_for_session",
-          arguments: { sessionId, timeoutMs: 30_000 },
-        },
+        params: { name: "cordierite_wait_for_session", arguments: { sessionId, timeoutMs: 30_000 } },
       },
       CallToolResultSchema,
     );
@@ -1352,46 +1126,22 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const app = await claimApp(daemon, port);
 
     const emitted = waitForEvent(daemon, "app_event");
-    app.socket.send(
-      JSON.stringify({
-        type: "event",
-        session_id: app.sessionId,
-        name: "greeting",
-        payload: { hi: true },
-        ts: Date.now(),
-      }),
-    );
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "greeting", payload: { hi: true }, ts: Date.now() }));
     await emitted;
 
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
     const first = await client.request(
-      {
-        method: "tools/call",
-        params: { name: "cordierite_events", arguments: {} },
-      },
+      { method: "tools/call", params: { name: "cordierite_events", arguments: {} } },
       CallToolResultSchema,
     );
     expect(first.isError).not.toBe(true);
-    const firstData = first.structuredContent as {
-      events: Array<{ kind: string; data: { name: string } }>;
-      cursor: number;
-    };
-    expect(
-      firstData.events.some(
-        (event) => event.kind === "app_event" && event.data.name === "greeting",
-      ),
-    ).toBe(true);
+    const firstData = first.structuredContent as { events: Array<{ kind: string; data: { name: string } }>; cursor: number };
+    expect(firstData.events.some((event) => event.kind === "app_event" && event.data.name === "greeting")).toBe(true);
 
     const second = await client.request(
-      {
-        method: "tools/call",
-        params: {
-          name: "cordierite_events",
-          arguments: { since: firstData.cursor },
-        },
-      },
+      { method: "tools/call", params: { name: "cordierite_events", arguments: { since: firstData.cursor } } },
       CallToolResultSchema,
     );
     const secondData = second.structuredContent as { events: unknown[] };
@@ -1406,13 +1156,7 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
 
     const emitted = waitForEvent(daemon, "app_event");
     app.socket.send(
-      JSON.stringify({
-        type: "event",
-        session_id: app.sessionId,
-        name: "already-happened",
-        payload: { n: 1 },
-        ts: Date.now(),
-      }),
+      JSON.stringify({ type: "event", session_id: app.sessionId, name: "already-happened", payload: { n: 1 }, ts: Date.now() }),
     );
     await emitted;
 
@@ -1422,19 +1166,13 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const result = await client.request(
       {
         method: "tools/call",
-        params: {
-          name: "cordierite_wait_for_event",
-          arguments: { name: "already-happened", timeoutMs: 2000 },
-        },
+        params: { name: "cordierite_wait_for_event", arguments: { name: "already-happened", timeoutMs: 2000 } },
       },
       CallToolResultSchema,
     );
 
     expect(result.isError).not.toBe(true);
-    const data = result.structuredContent as {
-      name: string;
-      payload: { n: number };
-    };
+    const data = result.structuredContent as { name: string; payload: { n: number } };
     expect(data.name).toBe("already-happened");
     expect(data.payload).toEqual({ n: 1 });
 
@@ -1451,43 +1189,22 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const waitPromise = client.request(
       {
         method: "tools/call",
-        params: {
-          name: "cordierite_wait_for_event",
-          arguments: { name: "target", timeoutMs: 5000 },
-        },
+        params: { name: "cordierite_wait_for_event", arguments: { name: "target", timeoutMs: 5000 } },
       },
       CallToolResultSchema,
     );
 
     const otherEmitted = waitForEvent(daemon, "app_event");
-    app.socket.send(
-      JSON.stringify({
-        type: "event",
-        session_id: app.sessionId,
-        name: "not-it",
-        ts: Date.now(),
-      }),
-    );
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "not-it", ts: Date.now() }));
     await otherEmitted;
 
     const targetEmitted = waitForEvent(daemon, "app_event");
-    app.socket.send(
-      JSON.stringify({
-        type: "event",
-        session_id: app.sessionId,
-        name: "target",
-        payload: { ok: true },
-        ts: Date.now(),
-      }),
-    );
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "target", payload: { ok: true }, ts: Date.now() }));
     await targetEmitted;
 
     const result = await waitPromise;
     expect(result.isError).not.toBe(true);
-    const data = result.structuredContent as {
-      name: string;
-      payload: { ok: boolean };
-    };
+    const data = result.structuredContent as { name: string; payload: { ok: boolean } };
     expect(data.name).toBe("target");
     expect(data.payload).toEqual({ ok: true });
 
@@ -1504,22 +1221,13 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const result = await client.request(
       {
         method: "tools/call",
-        params: {
-          name: "cordierite_wait_for_event",
-          arguments: {
-            selector: app.alias,
-            name: "never-arrives",
-            timeoutMs: 300,
-          },
-        },
+        params: { name: "cordierite_wait_for_event", arguments: { selector: app.alias, name: "never-arrives", timeoutMs: 300 } },
       },
       CallToolResultSchema,
     );
 
     expect(result.isError).toBe(true);
-    expect((result.content as Array<{ text: string }>)[0]!.text).toContain(
-      "tool_timeout",
-    );
+    expect((result.content as Array<{ text: string }>)[0]!.text).toContain("tool_timeout");
 
     app.socket.close();
   }, 10_000);
@@ -1534,47 +1242,26 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const waitPromise = client.request(
       {
         method: "tools/call",
-        params: {
-          name: "cordierite_wait_for_event",
-          arguments: {
-            name: "screen_changed",
-            match: { screen: "Checkout" },
-            timeoutMs: 5000,
-          },
-        },
+        params: { name: "cordierite_wait_for_event", arguments: { name: "screen_changed", match: { screen: "Checkout" }, timeoutMs: 5000 } },
       },
       CallToolResultSchema,
     );
 
     const nonMatching = waitForEvent(daemon, "app_event");
     app.socket.send(
-      JSON.stringify({
-        type: "event",
-        session_id: app.sessionId,
-        name: "screen_changed",
-        payload: { screen: "Home" },
-        ts: Date.now(),
-      }),
+      JSON.stringify({ type: "event", session_id: app.sessionId, name: "screen_changed", payload: { screen: "Home" }, ts: Date.now() }),
     );
     await nonMatching;
 
     const matching = waitForEvent(daemon, "app_event");
     app.socket.send(
-      JSON.stringify({
-        type: "event",
-        session_id: app.sessionId,
-        name: "screen_changed",
-        payload: { screen: "Checkout", total: 42 },
-        ts: Date.now(),
-      }),
+      JSON.stringify({ type: "event", session_id: app.sessionId, name: "screen_changed", payload: { screen: "Checkout", total: 42 }, ts: Date.now() }),
     );
     await matching;
 
     const result = await waitPromise;
     expect(result.isError).not.toBe(true);
-    const data = result.structuredContent as {
-      payload: { screen: string; total: number };
-    };
+    const data = result.structuredContent as { payload: { screen: string; total: number } };
     expect(data.payload).toEqual({ screen: "Checkout", total: 42 });
 
     app.socket.close();
@@ -1590,18 +1277,13 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const result = await client.request(
       {
         method: "tools/call",
-        params: {
-          name: "cordierite_wait_for_event",
-          arguments: { name: "x", match: { nested: { a: 1 } } },
-        },
+        params: { name: "cordierite_wait_for_event", arguments: { name: "x", match: { nested: { a: 1 } } } },
       },
       CallToolResultSchema,
     );
 
     expect(result.isError).toBe(true);
-    expect((result.content as Array<{ text: string }>)[0]!.text).toContain(
-      "invalid_request",
-    );
+    expect((result.content as Array<{ text: string }>)[0]!.text).toContain("invalid_request");
 
     app.socket.close();
   });
@@ -1611,28 +1293,14 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const app = await claimApp(daemon, port);
 
     const first = waitForEvent(daemon, "app_event");
-    app.socket.send(
-      JSON.stringify({
-        type: "event",
-        session_id: app.sessionId,
-        name: "ping",
-        payload: { n: 1 },
-        ts: Date.now(),
-      }),
-    );
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "ping", payload: { n: 1 }, ts: Date.now() }));
     await first;
 
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
     const drained = await client.request(
-      {
-        method: "tools/call",
-        params: {
-          name: "cordierite_events",
-          arguments: { selector: app.alias },
-        },
-      },
+      { method: "tools/call", params: { name: "cordierite_events", arguments: { selector: app.alias } } },
       CallToolResultSchema,
     );
     const cursor = (drained.structuredContent as { cursor: number }).cursor;
@@ -1640,10 +1308,7 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const waitPromise = client.request(
       {
         method: "tools/call",
-        params: {
-          name: "cordierite_wait_for_event",
-          arguments: { name: "ping", since: cursor, timeoutMs: 5000 },
-        },
+        params: { name: "cordierite_wait_for_event", arguments: { name: "ping", since: cursor, timeoutMs: 5000 } },
       },
       CallToolResultSchema,
     );
@@ -1653,15 +1318,7 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     const second = waitForEvent(daemon, "app_event");
-    app.socket.send(
-      JSON.stringify({
-        type: "event",
-        session_id: app.sessionId,
-        name: "ping",
-        payload: { n: 2 },
-        ts: Date.now(),
-      }),
-    );
+    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "ping", payload: { n: 2 }, ts: Date.now() }));
     await second;
 
     const result = await waitPromise;
@@ -1678,34 +1335,20 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const client = await connectInMemoryClient(handle);
 
     const nonIntegerSince = await client.request(
-      {
-        method: "tools/call",
-        params: { name: "cordierite_events", arguments: { since: 1.5 } },
-      },
+      { method: "tools/call", params: { name: "cordierite_events", arguments: { since: 1.5 } } },
       CallToolResultSchema,
     );
     expect(nonIntegerSince.isError).toBe(true);
-    expect(
-      (nonIntegerSince.content as Array<{ text: string }>)[0]!.text,
-    ).toContain("invalid_request");
+    expect((nonIntegerSince.content as Array<{ text: string }>)[0]!.text).toContain("invalid_request");
 
     const zeroLimit = await client.request(
-      {
-        method: "tools/call",
-        params: { name: "cordierite_events", arguments: { limit: 0 } },
-      },
+      { method: "tools/call", params: { name: "cordierite_events", arguments: { limit: 0 } } },
       CallToolResultSchema,
     );
     expect(zeroLimit.isError).toBe(true);
 
     const unknownKind = await client.request(
-      {
-        method: "tools/call",
-        params: {
-          name: "cordierite_events",
-          arguments: { kinds: ["not_a_real_kind"] },
-        },
-      },
+      { method: "tools/call", params: { name: "cordierite_events", arguments: { kinds: ["not_a_real_kind"] } } },
       CallToolResultSchema,
     );
     expect(unknownKind.isError).toBe(true);
@@ -1720,13 +1363,8 @@ describe("mcp: cordierite://sessions resource", () => {
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
-    const listed = await client.request(
-      { method: "resources/list", params: {} },
-      ListResourcesResultSchema,
-    );
-    expect(listed.resources.map((resource) => resource.uri)).toContain(
-      "cordierite://sessions",
-    );
+    const listed = await client.request({ method: "resources/list", params: {} }, ListResourcesResultSchema);
+    expect(listed.resources.map((resource) => resource.uri)).toContain("cordierite://sessions");
 
     const read = await client.request(
       { method: "resources/read", params: { uri: "cordierite://sessions" } },
@@ -1755,9 +1393,7 @@ describe("mcp: stdout purity", () => {
       capturedChunks.push(chunk.toString("utf8"));
     });
 
-    await handle.connect(
-      new StdioServerTransport(clientToServer, serverToClient),
-    );
+    await handle.connect(new StdioServerTransport(clientToServer, serverToClient));
 
     // A minimal hand-rolled client-side transport speaking the same newline-delimited JSON framing
     // as StdioServerTransport (see `@modelcontextprotocol/sdk/shared/stdio.js`), driving the SDK
@@ -1799,10 +1435,7 @@ describe("mcp: stdout purity", () => {
     const client = new Client({ name: "test-stdio-client", version: "0.0.0" });
     await client.connect(clientTransport as never);
 
-    await client.request(
-      { method: "tools/list", params: {} },
-      ListToolsResultSchema,
-    );
+    await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
 
     expect(capturedChunks.length).toBeGreaterThan(0);
 

--- a/packages/cordierite/src/__tests__/mcp-server.integration.test.ts
+++ b/packages/cordierite/src/__tests__/mcp-server.integration.test.ts
@@ -573,13 +573,24 @@ describe("mcp: tools/list and tools/call", () => {
     const app = await claimApp(daemon, port);
     // 20 s > DEFAULT_CALL_TIMEOUT_MS (10 s): before this fix the descriptor's timeout never left
     // the app, the daemon applied its 10 s default, and the answer below arrived to a call that
-    // had already been rejected as `tool_timeout`.
+    // had already been rejected as `tool_timeout`. The gap between the 11 s reply and this 20 s
+    // deadline is headroom for a slow runner, so drift cannot turn this into a real timeout.
     await snapshotTools(daemon, app, [
-      { name: "slow-login", timeoutMs: 20_000 },
+      { name: "slow-login", timeout_ms: 20_000 },
     ]);
 
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
+
+    // The deadline is a daemon-side scheduling hint, never part of the MCP tool contract.
+    const listed = await client.request(
+      { method: "tools/list", params: {} },
+      ListToolsResultSchema,
+    );
+    const proxied = withoutBuiltinTools(listed.tools)[0]!;
+    expect(proxied.name).toBe("slow-login");
+    expect("timeout_ms" in proxied).toBe(false);
+    expect("timeoutMs" in proxied).toBe(false);
 
     app.socket.on("message", (data) => {
       const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
@@ -594,23 +605,23 @@ describe("mcp: tools/list and tools/call", () => {
               result: { loggedIn: true },
             }),
           );
-        }, 12_000);
+        }, 11_000);
       }
     });
 
     const called = await client.request(
       { method: "tools/call", params: { name: "slow-login", arguments: {} } },
       CallToolResultSchema,
-      // Well above the MCP server's own derived transport timeout (20 s + 5 s slack) so this
-      // client's watchdog can never be what the assertion actually measures.
-      { timeout: 40_000 },
+      // Above the MCP server's own derived transport timeout (20 s + 5 s slack) so this client's
+      // watchdog can never be what the assertion actually measures.
+      { timeout: 35_000 },
     );
 
     expect(called.isError).not.toBe(true);
     expect(called.structuredContent).toEqual({ loggedIn: true });
 
     app.socket.close();
-  }, 60_000);
+  }, 45_000);
 
   test("tool_call_progress frames map to MCP progress notifications when the client sends a progressToken", async () => {
     const { daemon, stateDir, port } = await startTestDaemon();

--- a/packages/cordierite/src/__tests__/mcp-server.integration.test.ts
+++ b/packages/cordierite/src/__tests__/mcp-server.integration.test.ts
@@ -27,7 +27,7 @@ import {
   ToolListChangedNotificationSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
-import { decodeBootstrap } from "@cordierite/shared";
+import { decodeBootstrap, type ToolDescriptor } from "@cordierite/shared";
 
 import { startDaemon, type RunningDaemon } from "../daemon/daemon.js";
 import { createMcpServer, type McpServerHandle } from "../mcp/server.js";
@@ -55,7 +55,9 @@ afterEach(async () => {
 });
 
 const failIfCalled = (): never => {
-  throw new Error("auto-spawn should never be needed: the test daemon is already running.");
+  throw new Error(
+    "auto-spawn should never be needed: the test daemon is already running.",
+  );
 };
 
 const pickFreePort = async (): Promise<number> => {
@@ -84,7 +86,11 @@ const startTestDaemon = async (): Promise<TestDaemon> => {
   const port = await pickFreePort();
   await writeFile(
     path.join(stateDir, "config.json"),
-    JSON.stringify({ wssPort: port, advertisedIp: "127.0.0.1", scheme: "cordierite" }),
+    JSON.stringify({
+      wssPort: port,
+      advertisedIp: "127.0.0.1",
+      scheme: "cordierite",
+    }),
   );
 
   const daemon = await startDaemon({ stateDir });
@@ -93,13 +99,19 @@ const startTestDaemon = async (): Promise<TestDaemon> => {
   return { daemon, stateDir, port };
 };
 
-const rpcCall = (socketPath: string, method: string, params?: unknown): Promise<unknown> => {
+const rpcCall = (
+  socketPath: string,
+  method: string,
+  params?: unknown,
+): Promise<unknown> => {
   return new Promise((resolve, reject) => {
     const socket: Socket = connectUds(socketPath);
     let buffer = "";
 
     socket.once("connect", () => {
-      socket.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: params ?? {} })}\n`);
+      socket.write(
+        `${JSON.stringify({ jsonrpc: "2.0", id: 1, method, params: params ?? {} })}\n`,
+      );
     });
 
     socket.on("data", (chunk: Buffer) => {
@@ -113,10 +125,17 @@ const rpcCall = (socketPath: string, method: string, params?: unknown): Promise<
       const line = buffer.slice(0, newlineIndex);
       socket.destroy();
 
-      const parsed = JSON.parse(line) as { result?: unknown; error?: { message: string; data?: unknown } };
+      const parsed = JSON.parse(line) as {
+        result?: unknown;
+        error?: { message: string; data?: unknown };
+      };
 
       if (parsed.error) {
-        reject(Object.assign(new Error(parsed.error.message), { data: parsed.error.data }));
+        reject(
+          Object.assign(new Error(parsed.error.message), {
+            data: parsed.error.data,
+          }),
+        );
         return;
       }
 
@@ -127,7 +146,10 @@ const rpcCall = (socketPath: string, method: string, params?: unknown): Promise<
   });
 };
 
-const waitForEvent = (daemon: RunningDaemon, kind: string): Promise<{ kind: string; sessionId?: string; alias?: string }> => {
+const waitForEvent = (
+  daemon: RunningDaemon,
+  kind: string,
+): Promise<{ kind: string; sessionId?: string; alias?: string }> => {
   return new Promise((resolve) => {
     const unsubscribe = daemon.eventBus.subscribe((event) => {
       if (event.kind === kind) {
@@ -140,7 +162,9 @@ const waitForEvent = (daemon: RunningDaemon, kind: string): Promise<{ kind: stri
 
 const connectClient = (port: number): Promise<WebSocket> => {
   return new Promise((resolve, reject) => {
-    const socket = new WebSocket(`wss://127.0.0.1:${port}`, { rejectUnauthorized: false });
+    const socket = new WebSocket(`wss://127.0.0.1:${port}`, {
+      rejectUnauthorized: false,
+    });
     socket.once("open", () => resolve(socket));
     socket.once("error", reject);
   });
@@ -167,7 +191,9 @@ type ClaimedApp = {
 const createLinkAndDecode = async (
   daemon: RunningDaemon,
 ): Promise<{ sessionId: string; token: string }> => {
-  const result = (await rpcCall(daemon.paths.socketPath, "link.create", { ttlSeconds: 60 })) as {
+  const result = (await rpcCall(daemon.paths.socketPath, "link.create", {
+    ttlSeconds: 60,
+  })) as {
     deepLinkPayload: string;
   };
   const decoded = decodeBootstrap(result.deepLinkPayload);
@@ -176,7 +202,11 @@ const createLinkAndDecode = async (
   return { sessionId: decoded!.sessionId, token: decoded!.token };
 };
 
-const claimApp = async (daemon: RunningDaemon, port: number, deviceModel = "Pixel 8"): Promise<ClaimedApp> => {
+const claimApp = async (
+  daemon: RunningDaemon,
+  port: number,
+  deviceModel = "Pixel 8",
+): Promise<ClaimedApp> => {
   const link = await createLinkAndDecode(daemon);
   const socket = await connectClient(port);
 
@@ -199,12 +229,7 @@ const claimApp = async (daemon: RunningDaemon, port: number, deviceModel = "Pixe
 const snapshotTools = async (
   daemon: RunningDaemon,
   app: ClaimedApp,
-  tools: Array<{
-    name: string;
-    description?: string;
-    input_schema?: Record<string, unknown>;
-    output_schema?: Record<string, unknown>;
-  }>,
+  tools: Array<Partial<ToolDescriptor> & { name: string }>,
 ): Promise<void> => {
   const toolsChanged = waitForEvent(daemon, "tools_changed");
   app.socket.send(
@@ -243,7 +268,10 @@ const noDevicesExec: ExecFn = async (command) => {
   return { stdout: "List of devices attached\n\n", stderr: "" };
 };
 
-const createMcpHandle = async (stateDir: string, exec: ExecFn = noDevicesExec): Promise<McpServerHandle> => {
+const createMcpHandle = async (
+  stateDir: string,
+  exec: ExecFn = noDevicesExec,
+): Promise<McpServerHandle> => {
   const handle = await createMcpServer({
     stateDir,
     spawn: failIfCalled,
@@ -256,8 +284,11 @@ const createMcpHandle = async (stateDir: string, exec: ExecFn = noDevicesExec): 
 };
 
 /** Connects an SDK `Client` to `handle` over an in-process linked transport pair. */
-const connectInMemoryClient = async (handle: McpServerHandle): Promise<Client> => {
-  const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+const connectInMemoryClient = async (
+  handle: McpServerHandle,
+): Promise<Client> => {
+  const [serverTransport, clientTransport] =
+    InMemoryTransport.createLinkedPair();
   await handle.connect(serverTransport);
 
   const client = new Client({ name: "test-client", version: "0.0.0" });
@@ -274,19 +305,28 @@ describe("mcp: tools/list and tools/call", () => {
       {
         name: "echo",
         description: "Echoes its input.",
-        input_schema: { type: "object", properties: { text: { type: "string" } } },
+        input_schema: {
+          type: "object",
+          properties: { text: { type: "string" } },
+        },
       },
     ]);
 
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
-    const listed = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+    const listed = await client.request(
+      { method: "tools/list", params: {} },
+      ListToolsResultSchema,
+    );
     const proxiedTools = withoutBuiltinTools(listed.tools);
     expect(proxiedTools).toHaveLength(1);
     expect(proxiedTools[0]!.name).toBe("echo");
     expect(proxiedTools[0]!.description).toBe("Echoes its input.");
-    expect(proxiedTools[0]!.inputSchema).toEqual({ type: "object", properties: { text: { type: "string" } } });
+    expect(proxiedTools[0]!.inputSchema).toEqual({
+      type: "object",
+      properties: { text: { type: "string" } },
+    });
 
     app.socket.on("message", (data) => {
       const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
@@ -304,7 +344,10 @@ describe("mcp: tools/list and tools/call", () => {
     });
 
     const called = await client.request(
-      { method: "tools/call", params: { name: "echo", arguments: { text: "hello" } } },
+      {
+        method: "tools/call",
+        params: { name: "echo", arguments: { text: "hello" } },
+      },
       CallToolResultSchema,
     );
 
@@ -342,8 +385,16 @@ describe("mcp: tools/list and tools/call", () => {
         description: "Returns one of two shapes.",
         output_schema: {
           anyOf: [
-            { type: "object", properties: { ok: { type: "boolean" } }, required: ["ok"] },
-            { type: "object", properties: { error: { type: "string" } }, required: ["error"] },
+            {
+              type: "object",
+              properties: { ok: { type: "boolean" } },
+              required: ["ok"],
+            },
+            {
+              type: "object",
+              properties: { error: { type: "string" } },
+              required: ["error"],
+            },
           ],
         },
       },
@@ -377,9 +428,15 @@ describe("mcp: tools/list and tools/call", () => {
     // the output schemas `callTool` below enforces — exactly what a real client does.
     const listed = await client.listTools();
     const proxiedTools = withoutBuiltinTools(listed.tools);
-    expect(proxiedTools.map((tool) => tool.name).sort()).toEqual(["get-profile", "get-status", "list-todos"]);
+    expect(proxiedTools.map((tool) => tool.name).sort()).toEqual([
+      "get-profile",
+      "get-status",
+      "list-todos",
+    ]);
 
-    const objectTool = proxiedTools.find((tool) => tool.name === "get-profile")!;
+    const objectTool = proxiedTools.find(
+      (tool) => tool.name === "get-profile",
+    )!;
     const arrayTool = proxiedTools.find((tool) => tool.name === "list-todos")!;
     const unionTool = proxiedTools.find((tool) => tool.name === "get-status")!;
     expect(objectTool.outputSchema).toEqual({
@@ -391,7 +448,10 @@ describe("mcp: tools/list and tools/call", () => {
     expect(arrayTool.outputSchema).toBeUndefined();
     expect(unionTool.outputSchema).toBeUndefined();
 
-    const profile = await client.callTool({ name: "get-profile", arguments: {} });
+    const profile = await client.callTool({
+      name: "get-profile",
+      arguments: {},
+    });
     expect(profile.isError).not.toBe(true);
     expect(profile.structuredContent).toEqual({ name: "Ada" });
 
@@ -400,7 +460,9 @@ describe("mcp: tools/list and tools/call", () => {
     const todos = await client.callTool({ name: "list-todos", arguments: {} });
     expect(todos.isError).not.toBe(true);
     expect(todos.structuredContent).toBeUndefined();
-    expect(todos.content).toEqual([{ type: "text", text: JSON.stringify(["write tests", "ship it"]) }]);
+    expect(todos.content).toEqual([
+      { type: "text", text: JSON.stringify(["write tests", "ship it"]) },
+    ]);
 
     // A dropped schema never turns a good result into an error: the union tool's result *is* an
     // object, so it still travels as `structuredContent` — the client just has no schema to
@@ -408,7 +470,9 @@ describe("mcp: tools/list and tools/call", () => {
     const status = await client.callTool({ name: "get-status", arguments: {} });
     expect(status.isError).not.toBe(true);
     expect(status.structuredContent).toEqual({ ok: true });
-    expect(status.content).toEqual([{ type: "text", text: JSON.stringify({ ok: true }) }]);
+    expect(status.content).toEqual([
+      { type: "text", text: JSON.stringify({ ok: true }) },
+    ]);
 
     app.socket.close();
   });
@@ -417,7 +481,11 @@ describe("mcp: tools/list and tools/call", () => {
     const { daemon, stateDir, port } = await startTestDaemon();
     const app = await claimApp(daemon, port);
     await snapshotTools(daemon, app, [
-      { name: "lies", description: "Claims an object, returns a number.", output_schema: { type: "object" } },
+      {
+        name: "lies",
+        description: "Claims an object, returns a number.",
+        output_schema: { type: "object" },
+      },
     ]);
 
     const handle = await createMcpHandle(stateDir);
@@ -428,7 +496,12 @@ describe("mcp: tools/list and tools/call", () => {
 
       if (msg.type === "tool_call") {
         app.socket.send(
-          JSON.stringify({ type: "tool_result", session_id: app.sessionId, id: msg.id, result: 42 }),
+          JSON.stringify({
+            type: "tool_result",
+            session_id: app.sessionId,
+            id: msg.id,
+            result: 42,
+          }),
         );
       }
     });
@@ -441,8 +514,12 @@ describe("mcp: tools/list and tools/call", () => {
 
     expect(result.isError).toBe(true);
     expect(result.structuredContent).toBeUndefined();
-    expect((result.content as Array<{ text: string }>)[0]!.text).toContain("tool_output_validation_error");
-    expect((result.content as Array<{ text: string }>)[0]!.text).toContain("a number");
+    expect((result.content as Array<{ text: string }>)[0]!.text).toContain(
+      "tool_output_validation_error",
+    );
+    expect((result.content as Array<{ text: string }>)[0]!.text).toContain(
+      "a number",
+    );
 
     app.socket.close();
   });
@@ -452,7 +529,11 @@ describe("mcp: tools/list and tools/call", () => {
     const { daemon, stateDir, port } = await startTestDaemon();
     const app = await claimApp(daemon, port);
     await snapshotTools(daemon, app, [
-      { name: "nullish", description: "Claims an object, returns null.", output_schema: { type: "object" } },
+      {
+        name: "nullish",
+        description: "Claims an object, returns null.",
+        output_schema: { type: "object" },
+      },
     ]);
 
     const handle = await createMcpHandle(stateDir);
@@ -463,7 +544,12 @@ describe("mcp: tools/list and tools/call", () => {
 
       if (msg.type === "tool_call") {
         app.socket.send(
-          JSON.stringify({ type: "tool_result", session_id: app.sessionId, id: msg.id, result: null }),
+          JSON.stringify({
+            type: "tool_result",
+            session_id: app.sessionId,
+            id: msg.id,
+            result: null,
+          }),
         );
       }
     });
@@ -482,6 +568,50 @@ describe("mcp: tools/list and tools/call", () => {
     app.socket.close();
   });
 
+  test("a tool declaring a timeoutMs above the daemon default gets it, over MCP, end to end (issue #25)", async () => {
+    const { daemon, stateDir, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+    // 20 s > DEFAULT_CALL_TIMEOUT_MS (10 s): before this fix the descriptor's timeout never left
+    // the app, the daemon applied its 10 s default, and the answer below arrived to a call that
+    // had already been rejected as `tool_timeout`.
+    await snapshotTools(daemon, app, [
+      { name: "slow-login", timeoutMs: 20_000 },
+    ]);
+
+    const handle = await createMcpHandle(stateDir);
+    const client = await connectInMemoryClient(handle);
+
+    app.socket.on("message", (data) => {
+      const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
+
+      if (msg.type === "tool_call") {
+        setTimeout(() => {
+          app.socket.send(
+            JSON.stringify({
+              type: "tool_result",
+              session_id: app.sessionId,
+              id: msg.id,
+              result: { loggedIn: true },
+            }),
+          );
+        }, 12_000);
+      }
+    });
+
+    const called = await client.request(
+      { method: "tools/call", params: { name: "slow-login", arguments: {} } },
+      CallToolResultSchema,
+      // Well above the MCP server's own derived transport timeout (20 s + 5 s slack) so this
+      // client's watchdog can never be what the assertion actually measures.
+      { timeout: 40_000 },
+    );
+
+    expect(called.isError).not.toBe(true);
+    expect(called.structuredContent).toEqual({ loggedIn: true });
+
+    app.socket.close();
+  }, 60_000);
+
   test("tool_call_progress frames map to MCP progress notifications when the client sends a progressToken", async () => {
     const { daemon, stateDir, port } = await startTestDaemon();
     const app = await claimApp(daemon, port);
@@ -492,11 +622,22 @@ describe("mcp: tools/list and tools/call", () => {
 
       if (msg.type === "tool_call") {
         app.socket.send(
-          JSON.stringify({ type: "tool_call_progress", session_id: app.sessionId, id: msg.id, progress: 0.5, message: "halfway" }),
+          JSON.stringify({
+            type: "tool_call_progress",
+            session_id: app.sessionId,
+            id: msg.id,
+            progress: 0.5,
+            message: "halfway",
+          }),
         );
         setTimeout(() => {
           app.socket.send(
-            JSON.stringify({ type: "tool_result", session_id: app.sessionId, id: msg.id, result: "done" }),
+            JSON.stringify({
+              type: "tool_result",
+              session_id: app.sessionId,
+              id: msg.id,
+              result: "done",
+            }),
           );
         }, 50);
       }
@@ -512,7 +653,10 @@ describe("mcp: tools/list and tools/call", () => {
       CallToolResultSchema,
       {
         onprogress: (progress) => {
-          progressUpdates.push({ progress: progress.progress, message: progress.message });
+          progressUpdates.push({
+            progress: progress.progress,
+            message: progress.message,
+          });
         },
       },
     );
@@ -531,7 +675,10 @@ describe("mcp: tools/list and tools/call", () => {
     const receivedByApp: Record<string, unknown>[] = [];
     const gotToolCancel = new Promise<Record<string, unknown>>((resolve) => {
       app.socket.on("message", (data) => {
-        const msg = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
+        const msg = JSON.parse(data.toString("utf8")) as Record<
+          string,
+          unknown
+        >;
         receivedByApp.push(msg);
         // Deliberately never reply to tool_call — the point is that cancellation reaches the app
         // while the call is still pending.
@@ -571,9 +718,15 @@ describe("mcp: tools/list and tools/call", () => {
     controller.abort("user cancelled");
 
     const cancelMessage = await gotToolCancel;
-    expect(cancelMessage).toMatchObject({ type: "tool_cancel", session_id: app.sessionId, reason: "mcp_client_cancelled" });
+    expect(cancelMessage).toMatchObject({
+      type: "tool_cancel",
+      session_id: app.sessionId,
+      reason: "mcp_client_cancelled",
+    });
 
-    const toolCallMessage = receivedByApp.find((msg) => msg.type === "tool_call");
+    const toolCallMessage = receivedByApp.find(
+      (msg) => msg.type === "tool_call",
+    );
     expect(cancelMessage.id).toBe(toolCallMessage?.id);
 
     await callPromise;
@@ -587,14 +740,20 @@ describe("mcp: tools/list and tools/call", () => {
       {
         name: "echo",
         description: "Echoes its input.",
-        input_schema: { type: "object", properties: { text: { type: "string" } } },
+        input_schema: {
+          type: "object",
+          properties: { text: { type: "string" } },
+        },
       },
     ]);
 
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
-    const listed = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+    const listed = await client.request(
+      { method: "tools/list", params: {} },
+      ListToolsResultSchema,
+    );
     // Names only, sorted: full descriptors (incl. built-ins' free-text descriptions) would make this
     // snapshot brittle against unrelated wording tweaks; the shape/schema mapping is what's locked.
     const shapes = listed.tools
@@ -619,9 +778,15 @@ describe("mcp: tools/list and tools/call", () => {
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
-    const listed = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+    const listed = await client.request(
+      { method: "tools/list", params: {} },
+      ListToolsResultSchema,
+    );
     const proxiedTools = withoutBuiltinTools(listed.tools);
-    expect(proxiedTools[0]!.inputSchema).toEqual({ type: "object", additionalProperties: true });
+    expect(proxiedTools[0]!.inputSchema).toEqual({
+      type: "object",
+      additionalProperties: true,
+    });
 
     app.socket.close();
   });
@@ -647,10 +812,16 @@ describe("mcp: tools/list and tools/call", () => {
 
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
-    const listed = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+    const listed = await client.request(
+      { method: "tools/list", params: {} },
+      ListToolsResultSchema,
+    );
     const proxiedTools = withoutBuiltinTools(listed.tools);
 
-    expect(proxiedTools[0]!.annotations).toEqual({ destructiveHint: true, readOnlyHint: false });
+    expect(proxiedTools[0]!.annotations).toEqual({
+      destructiveHint: true,
+      readOnlyHint: false,
+    });
 
     app.socket.close();
   });
@@ -697,12 +868,17 @@ describe("mcp: tools/list and tools/call", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      { method: "tools/call", params: { name: "does-not-exist", arguments: {} } },
+      {
+        method: "tools/call",
+        params: { name: "does-not-exist", arguments: {} },
+      },
       CallToolResultSchema,
     );
 
     expect(result.isError).toBe(true);
-    expect((result.content[0] as { text: string }).text).toContain("tool_not_found");
+    expect((result.content[0] as { text: string }).text).toContain(
+      "tool_not_found",
+    );
   });
 });
 
@@ -715,8 +891,13 @@ describe("mcp: namespacing and list_changed", () => {
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
-    const singleSessionListing = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
-    expect(withoutBuiltinTools(singleSessionListing.tools).map((tool) => tool.name)).toEqual(["echo"]);
+    const singleSessionListing = await client.request(
+      { method: "tools/list", params: {} },
+      ListToolsResultSchema,
+    );
+    expect(
+      withoutBuiltinTools(singleSessionListing.tools).map((tool) => tool.name),
+    ).toEqual(["echo"]);
 
     let listChangedCount = 0;
     client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
@@ -732,11 +913,16 @@ describe("mcp: namespacing and list_changed", () => {
 
     expect(listChangedCount).toBeGreaterThan(0);
 
-    const multiSessionListing = await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+    const multiSessionListing = await client.request(
+      { method: "tools/list", params: {} },
+      ListToolsResultSchema,
+    );
     const names = withoutBuiltinTools(multiSessionListing.tools)
       .map((tool) => tool.name)
       .sort();
-    expect(names).toEqual([`${appA.alias}__echo`, `${appB.alias}__echo`].sort());
+    expect(names).toEqual(
+      [`${appA.alias}__echo`, `${appB.alias}__echo`].sort(),
+    );
 
     appA.socket.close();
     appB.socket.close();
@@ -750,7 +936,10 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      { method: "tools/call", params: { name: "cordierite_connect", arguments: {} } },
+      {
+        method: "tools/call",
+        params: { name: "cordierite_connect", arguments: {} },
+      },
       CallToolResultSchema,
     );
 
@@ -766,7 +955,9 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     expect(data.sessionId).toBeTruthy();
     expect(data.qr.length).toBeGreaterThan(0);
     expect(data.delivered).toBeUndefined();
-    expect(data.note).toMatch(/no booted iOS simulator or attached Android device/iu);
+    expect(data.note).toMatch(
+      /no booted iOS simulator or attached Android device/iu,
+    );
     // The agent has to be told to render the QR and ask, or it goes straight to a silent wait.
     expect(data.instructions).toMatch(/show the user the "qr" field/iu);
     expect(data.instructions).toMatch(/cordierite_wait_for_session/u);
@@ -787,7 +978,11 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
       if (command === "xcrun" && args.includes("--json")) {
         return {
           stdout: JSON.stringify({
-            devices: { "iOS 17.0": [{ state: "Booted", udid: "SIM-1", name: "iPhone 15" }] },
+            devices: {
+              "iOS 17.0": [
+                { state: "Booted", udid: "SIM-1", name: "iPhone 15" },
+              ],
+            },
           }),
           stderr: "",
         };
@@ -800,7 +995,10 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      { method: "tools/call", params: { name: "cordierite_connect", arguments: {} } },
+      {
+        method: "tools/call",
+        params: { name: "cordierite_connect", arguments: {} },
+      },
       CallToolResultSchema,
     );
 
@@ -822,7 +1020,11 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     expect(data.qr).toBeUndefined();
     expect(data.note).toMatch(/iPhone 15 \(SIM-1\)/u);
 
-    expect(calls.some((call) => call.args.includes("openurl") && call.args.includes("SIM-1"))).toBe(true);
+    expect(
+      calls.some(
+        (call) => call.args.includes("openurl") && call.args.includes("SIM-1"),
+      ),
+    ).toBe(true);
   });
 
   test('target "none" forces the QR path even with a device booted', async () => {
@@ -833,7 +1035,9 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
       calls.push(`${command} ${args.join(" ")}`);
       return {
         stdout: JSON.stringify({
-          devices: { "iOS 17.0": [{ state: "Booted", udid: "SIM-1", name: "iPhone 15" }] },
+          devices: {
+            "iOS 17.0": [{ state: "Booted", udid: "SIM-1", name: "iPhone 15" }],
+          },
         }),
         stderr: "",
       };
@@ -843,11 +1047,18 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      { method: "tools/call", params: { name: "cordierite_connect", arguments: { target: "none" } } },
+      {
+        method: "tools/call",
+        params: { name: "cordierite_connect", arguments: { target: "none" } },
+      },
       CallToolResultSchema,
     );
 
-    const data = result.structuredContent as { qr?: string; delivered?: true; note?: string };
+    const data = result.structuredContent as {
+      qr?: string;
+      delivered?: true;
+      note?: string;
+    };
     expect(data.delivered).toBeUndefined();
     expect(data.qr!.length).toBeGreaterThan(0);
     expect(data.note).toMatch(/target: "none"/u);
@@ -880,11 +1091,18 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      { method: "tools/call", params: { name: "cordierite_connect", arguments: {} } },
+      {
+        method: "tools/call",
+        params: { name: "cordierite_connect", arguments: {} },
+      },
       CallToolResultSchema,
     );
 
-    const data = result.structuredContent as { qr?: string; delivered?: true; note?: string };
+    const data = result.structuredContent as {
+      qr?: string;
+      delivered?: true;
+      note?: string;
+    };
     expect(data.delivered).toBeUndefined();
     expect(data.qr!.length).toBeGreaterThan(0);
     expect(data.note).toMatch(/SIM-1/u);
@@ -897,12 +1115,17 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      { method: "tools/call", params: { name: "cordierite_connect", arguments: { device: "SIM-1" } } },
+      {
+        method: "tools/call",
+        params: { name: "cordierite_connect", arguments: { device: "SIM-1" } },
+      },
       CallToolResultSchema,
     );
 
     expect(result.isError).toBe(true);
-    expect(JSON.stringify(result.content)).toMatch(/device.{0,4} requires an explicit/u);
+    expect(JSON.stringify(result.content)).toMatch(
+      /device.{0,4} requires an explicit/u,
+    );
   });
 
   test("cordierite_wait_for_session resolves once a fake client claims the minted session", async () => {
@@ -911,16 +1134,28 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const connectResult = await client.request(
-      { method: "tools/call", params: { name: "cordierite_connect", arguments: {} } },
+      {
+        method: "tools/call",
+        params: { name: "cordierite_connect", arguments: {} },
+      },
       CallToolResultSchema,
     );
-    const { sessionId, deepLink } = connectResult.structuredContent as { sessionId: string; deepLink: string };
+    const { sessionId, deepLink } = connectResult.structuredContent as {
+      sessionId: string;
+      deepLink: string;
+    };
 
     const payload = deepLink.split("cordierite=")[1]!;
     const decoded = decodeBootstrap(payload)!;
 
     const waitPromise = client.request(
-      { method: "tools/call", params: { name: "cordierite_wait_for_session", arguments: { sessionId, timeoutMs: 5000 } } },
+      {
+        method: "tools/call",
+        params: {
+          name: "cordierite_wait_for_session",
+          arguments: { sessionId, timeoutMs: 5000 },
+        },
+      },
       CallToolResultSchema,
     );
 
@@ -940,7 +1175,11 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
 
     const waitResult = await waitPromise;
     expect(waitResult.isError).not.toBe(true);
-    const data = waitResult.structuredContent as { sessionId: string; claimed: true; alias: string };
+    const data = waitResult.structuredContent as {
+      sessionId: string;
+      claimed: true;
+      alias: string;
+    };
     expect(data.sessionId).toBe(sessionId);
     expect(data.claimed).toBe(true);
     expect(data.alias.length).toBeGreaterThan(0);
@@ -957,14 +1196,20 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
       if (command === "xcrun" && args.includes("--json")) {
         return {
           stdout: JSON.stringify({
-            devices: { "iOS 17.0": [{ state: "Booted", udid: "SIM-1", name: "iPhone 15" }] },
+            devices: {
+              "iOS 17.0": [
+                { state: "Booted", udid: "SIM-1", name: "iPhone 15" },
+              ],
+            },
           }),
           stderr: "",
         };
       }
 
       if (args.includes("openurl")) {
-        throw Object.assign(new Error("Command failed"), { stderr: "no matching URL scheme" });
+        throw Object.assign(new Error("Command failed"), {
+          stderr: "no matching URL scheme",
+        });
       }
 
       return { stdout: "List of devices attached\n\n", stderr: "" };
@@ -974,7 +1219,10 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const result = await client.request(
-      { method: "tools/call", params: { name: "cordierite_connect", arguments: {} } },
+      {
+        method: "tools/call",
+        params: { name: "cordierite_connect", arguments: {} },
+      },
       CallToolResultSchema,
     );
 
@@ -995,7 +1243,9 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
 
     // The fallback link has to be a fresh mint: the first one was minted for 127.0.0.1 on the
     // assumption it was going to a local simulator, which is the wrong address for a scanner.
-    expect(decodeBootstrap(data.deepLink.split("cordierite=")[1]!)).not.toBeNull();
+    expect(
+      decodeBootstrap(data.deepLink.split("cordierite=")[1]!),
+    ).not.toBeNull();
   });
 
   test("cordierite_wait_for_session returns immediately for a session claimed before it was called", async () => {
@@ -1010,13 +1260,20 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const result = await client.request(
       {
         method: "tools/call",
-        params: { name: "cordierite_wait_for_session", arguments: { sessionId: app.sessionId, timeoutMs: 5000 } },
+        params: {
+          name: "cordierite_wait_for_session",
+          arguments: { sessionId: app.sessionId, timeoutMs: 5000 },
+        },
       },
       CallToolResultSchema,
     );
 
     expect(result.isError).not.toBe(true);
-    const data = result.structuredContent as { sessionId: string; claimed: true; alias: string };
+    const data = result.structuredContent as {
+      sessionId: string;
+      claimed: true;
+      alias: string;
+    };
     expect(data.sessionId).toBe(app.sessionId);
     expect(data.claimed).toBe(true);
     expect(data.alias).toBe(app.alias);
@@ -1030,17 +1287,25 @@ describe("mcp: cordierite_connect / cordierite_wait_for_session", () => {
     const client = await connectInMemoryClient(handle);
 
     const connectResult = await client.request(
-      { method: "tools/call", params: { name: "cordierite_connect", arguments: { target: "none" } } },
+      {
+        method: "tools/call",
+        params: { name: "cordierite_connect", arguments: { target: "none" } },
+      },
       CallToolResultSchema,
     );
-    const { sessionId } = connectResult.structuredContent as { sessionId: string };
+    const { sessionId } = connectResult.structuredContent as {
+      sessionId: string;
+    };
 
     // A generous timeout: the point is that the call comes back on the connection dropping, not on
     // the clock. Without an onClose handler this sits silently for the full 30s.
     const waitPromise = client.request(
       {
         method: "tools/call",
-        params: { name: "cordierite_wait_for_session", arguments: { sessionId, timeoutMs: 30_000 } },
+        params: {
+          name: "cordierite_wait_for_session",
+          arguments: { sessionId, timeoutMs: 30_000 },
+        },
       },
       CallToolResultSchema,
     );
@@ -1076,22 +1341,46 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const app = await claimApp(daemon, port);
 
     const emitted = waitForEvent(daemon, "app_event");
-    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "greeting", payload: { hi: true }, ts: Date.now() }));
+    app.socket.send(
+      JSON.stringify({
+        type: "event",
+        session_id: app.sessionId,
+        name: "greeting",
+        payload: { hi: true },
+        ts: Date.now(),
+      }),
+    );
     await emitted;
 
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
     const first = await client.request(
-      { method: "tools/call", params: { name: "cordierite_events", arguments: {} } },
+      {
+        method: "tools/call",
+        params: { name: "cordierite_events", arguments: {} },
+      },
       CallToolResultSchema,
     );
     expect(first.isError).not.toBe(true);
-    const firstData = first.structuredContent as { events: Array<{ kind: string; data: { name: string } }>; cursor: number };
-    expect(firstData.events.some((event) => event.kind === "app_event" && event.data.name === "greeting")).toBe(true);
+    const firstData = first.structuredContent as {
+      events: Array<{ kind: string; data: { name: string } }>;
+      cursor: number;
+    };
+    expect(
+      firstData.events.some(
+        (event) => event.kind === "app_event" && event.data.name === "greeting",
+      ),
+    ).toBe(true);
 
     const second = await client.request(
-      { method: "tools/call", params: { name: "cordierite_events", arguments: { since: firstData.cursor } } },
+      {
+        method: "tools/call",
+        params: {
+          name: "cordierite_events",
+          arguments: { since: firstData.cursor },
+        },
+      },
       CallToolResultSchema,
     );
     const secondData = second.structuredContent as { events: unknown[] };
@@ -1106,7 +1395,13 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
 
     const emitted = waitForEvent(daemon, "app_event");
     app.socket.send(
-      JSON.stringify({ type: "event", session_id: app.sessionId, name: "already-happened", payload: { n: 1 }, ts: Date.now() }),
+      JSON.stringify({
+        type: "event",
+        session_id: app.sessionId,
+        name: "already-happened",
+        payload: { n: 1 },
+        ts: Date.now(),
+      }),
     );
     await emitted;
 
@@ -1116,13 +1411,19 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const result = await client.request(
       {
         method: "tools/call",
-        params: { name: "cordierite_wait_for_event", arguments: { name: "already-happened", timeoutMs: 2000 } },
+        params: {
+          name: "cordierite_wait_for_event",
+          arguments: { name: "already-happened", timeoutMs: 2000 },
+        },
       },
       CallToolResultSchema,
     );
 
     expect(result.isError).not.toBe(true);
-    const data = result.structuredContent as { name: string; payload: { n: number } };
+    const data = result.structuredContent as {
+      name: string;
+      payload: { n: number };
+    };
     expect(data.name).toBe("already-happened");
     expect(data.payload).toEqual({ n: 1 });
 
@@ -1139,22 +1440,43 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const waitPromise = client.request(
       {
         method: "tools/call",
-        params: { name: "cordierite_wait_for_event", arguments: { name: "target", timeoutMs: 5000 } },
+        params: {
+          name: "cordierite_wait_for_event",
+          arguments: { name: "target", timeoutMs: 5000 },
+        },
       },
       CallToolResultSchema,
     );
 
     const otherEmitted = waitForEvent(daemon, "app_event");
-    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "not-it", ts: Date.now() }));
+    app.socket.send(
+      JSON.stringify({
+        type: "event",
+        session_id: app.sessionId,
+        name: "not-it",
+        ts: Date.now(),
+      }),
+    );
     await otherEmitted;
 
     const targetEmitted = waitForEvent(daemon, "app_event");
-    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "target", payload: { ok: true }, ts: Date.now() }));
+    app.socket.send(
+      JSON.stringify({
+        type: "event",
+        session_id: app.sessionId,
+        name: "target",
+        payload: { ok: true },
+        ts: Date.now(),
+      }),
+    );
     await targetEmitted;
 
     const result = await waitPromise;
     expect(result.isError).not.toBe(true);
-    const data = result.structuredContent as { name: string; payload: { ok: boolean } };
+    const data = result.structuredContent as {
+      name: string;
+      payload: { ok: boolean };
+    };
     expect(data.name).toBe("target");
     expect(data.payload).toEqual({ ok: true });
 
@@ -1171,13 +1493,22 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const result = await client.request(
       {
         method: "tools/call",
-        params: { name: "cordierite_wait_for_event", arguments: { selector: app.alias, name: "never-arrives", timeoutMs: 300 } },
+        params: {
+          name: "cordierite_wait_for_event",
+          arguments: {
+            selector: app.alias,
+            name: "never-arrives",
+            timeoutMs: 300,
+          },
+        },
       },
       CallToolResultSchema,
     );
 
     expect(result.isError).toBe(true);
-    expect((result.content as Array<{ text: string }>)[0]!.text).toContain("tool_timeout");
+    expect((result.content as Array<{ text: string }>)[0]!.text).toContain(
+      "tool_timeout",
+    );
 
     app.socket.close();
   }, 10_000);
@@ -1192,26 +1523,47 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const waitPromise = client.request(
       {
         method: "tools/call",
-        params: { name: "cordierite_wait_for_event", arguments: { name: "screen_changed", match: { screen: "Checkout" }, timeoutMs: 5000 } },
+        params: {
+          name: "cordierite_wait_for_event",
+          arguments: {
+            name: "screen_changed",
+            match: { screen: "Checkout" },
+            timeoutMs: 5000,
+          },
+        },
       },
       CallToolResultSchema,
     );
 
     const nonMatching = waitForEvent(daemon, "app_event");
     app.socket.send(
-      JSON.stringify({ type: "event", session_id: app.sessionId, name: "screen_changed", payload: { screen: "Home" }, ts: Date.now() }),
+      JSON.stringify({
+        type: "event",
+        session_id: app.sessionId,
+        name: "screen_changed",
+        payload: { screen: "Home" },
+        ts: Date.now(),
+      }),
     );
     await nonMatching;
 
     const matching = waitForEvent(daemon, "app_event");
     app.socket.send(
-      JSON.stringify({ type: "event", session_id: app.sessionId, name: "screen_changed", payload: { screen: "Checkout", total: 42 }, ts: Date.now() }),
+      JSON.stringify({
+        type: "event",
+        session_id: app.sessionId,
+        name: "screen_changed",
+        payload: { screen: "Checkout", total: 42 },
+        ts: Date.now(),
+      }),
     );
     await matching;
 
     const result = await waitPromise;
     expect(result.isError).not.toBe(true);
-    const data = result.structuredContent as { payload: { screen: string; total: number } };
+    const data = result.structuredContent as {
+      payload: { screen: string; total: number };
+    };
     expect(data.payload).toEqual({ screen: "Checkout", total: 42 });
 
     app.socket.close();
@@ -1227,13 +1579,18 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const result = await client.request(
       {
         method: "tools/call",
-        params: { name: "cordierite_wait_for_event", arguments: { name: "x", match: { nested: { a: 1 } } } },
+        params: {
+          name: "cordierite_wait_for_event",
+          arguments: { name: "x", match: { nested: { a: 1 } } },
+        },
       },
       CallToolResultSchema,
     );
 
     expect(result.isError).toBe(true);
-    expect((result.content as Array<{ text: string }>)[0]!.text).toContain("invalid_request");
+    expect((result.content as Array<{ text: string }>)[0]!.text).toContain(
+      "invalid_request",
+    );
 
     app.socket.close();
   });
@@ -1243,14 +1600,28 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const app = await claimApp(daemon, port);
 
     const first = waitForEvent(daemon, "app_event");
-    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "ping", payload: { n: 1 }, ts: Date.now() }));
+    app.socket.send(
+      JSON.stringify({
+        type: "event",
+        session_id: app.sessionId,
+        name: "ping",
+        payload: { n: 1 },
+        ts: Date.now(),
+      }),
+    );
     await first;
 
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
     const drained = await client.request(
-      { method: "tools/call", params: { name: "cordierite_events", arguments: { selector: app.alias } } },
+      {
+        method: "tools/call",
+        params: {
+          name: "cordierite_events",
+          arguments: { selector: app.alias },
+        },
+      },
       CallToolResultSchema,
     );
     const cursor = (drained.structuredContent as { cursor: number }).cursor;
@@ -1258,7 +1629,10 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const waitPromise = client.request(
       {
         method: "tools/call",
-        params: { name: "cordierite_wait_for_event", arguments: { name: "ping", since: cursor, timeoutMs: 5000 } },
+        params: {
+          name: "cordierite_wait_for_event",
+          arguments: { name: "ping", since: cursor, timeoutMs: 5000 },
+        },
       },
       CallToolResultSchema,
     );
@@ -1268,7 +1642,15 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
 
     const second = waitForEvent(daemon, "app_event");
-    app.socket.send(JSON.stringify({ type: "event", session_id: app.sessionId, name: "ping", payload: { n: 2 }, ts: Date.now() }));
+    app.socket.send(
+      JSON.stringify({
+        type: "event",
+        session_id: app.sessionId,
+        name: "ping",
+        payload: { n: 2 },
+        ts: Date.now(),
+      }),
+    );
     await second;
 
     const result = await waitPromise;
@@ -1285,20 +1667,34 @@ describe("mcp: cordierite_events / cordierite_wait_for_event", () => {
     const client = await connectInMemoryClient(handle);
 
     const nonIntegerSince = await client.request(
-      { method: "tools/call", params: { name: "cordierite_events", arguments: { since: 1.5 } } },
+      {
+        method: "tools/call",
+        params: { name: "cordierite_events", arguments: { since: 1.5 } },
+      },
       CallToolResultSchema,
     );
     expect(nonIntegerSince.isError).toBe(true);
-    expect((nonIntegerSince.content as Array<{ text: string }>)[0]!.text).toContain("invalid_request");
+    expect(
+      (nonIntegerSince.content as Array<{ text: string }>)[0]!.text,
+    ).toContain("invalid_request");
 
     const zeroLimit = await client.request(
-      { method: "tools/call", params: { name: "cordierite_events", arguments: { limit: 0 } } },
+      {
+        method: "tools/call",
+        params: { name: "cordierite_events", arguments: { limit: 0 } },
+      },
       CallToolResultSchema,
     );
     expect(zeroLimit.isError).toBe(true);
 
     const unknownKind = await client.request(
-      { method: "tools/call", params: { name: "cordierite_events", arguments: { kinds: ["not_a_real_kind"] } } },
+      {
+        method: "tools/call",
+        params: {
+          name: "cordierite_events",
+          arguments: { kinds: ["not_a_real_kind"] },
+        },
+      },
       CallToolResultSchema,
     );
     expect(unknownKind.isError).toBe(true);
@@ -1313,8 +1709,13 @@ describe("mcp: cordierite://sessions resource", () => {
     const handle = await createMcpHandle(stateDir);
     const client = await connectInMemoryClient(handle);
 
-    const listed = await client.request({ method: "resources/list", params: {} }, ListResourcesResultSchema);
-    expect(listed.resources.map((resource) => resource.uri)).toContain("cordierite://sessions");
+    const listed = await client.request(
+      { method: "resources/list", params: {} },
+      ListResourcesResultSchema,
+    );
+    expect(listed.resources.map((resource) => resource.uri)).toContain(
+      "cordierite://sessions",
+    );
 
     const read = await client.request(
       { method: "resources/read", params: { uri: "cordierite://sessions" } },
@@ -1343,7 +1744,9 @@ describe("mcp: stdout purity", () => {
       capturedChunks.push(chunk.toString("utf8"));
     });
 
-    await handle.connect(new StdioServerTransport(clientToServer, serverToClient));
+    await handle.connect(
+      new StdioServerTransport(clientToServer, serverToClient),
+    );
 
     // A minimal hand-rolled client-side transport speaking the same newline-delimited JSON framing
     // as StdioServerTransport (see `@modelcontextprotocol/sdk/shared/stdio.js`), driving the SDK
@@ -1385,7 +1788,10 @@ describe("mcp: stdout purity", () => {
     const client = new Client({ name: "test-stdio-client", version: "0.0.0" });
     await client.connect(clientTransport as never);
 
-    await client.request({ method: "tools/list", params: {} }, ListToolsResultSchema);
+    await client.request(
+      { method: "tools/list", params: {} },
+      ListToolsResultSchema,
+    );
 
     expect(capturedChunks.length).toBeGreaterThan(0);
 

--- a/packages/cordierite/src/__tests__/output.test.ts
+++ b/packages/cordierite/src/__tests__/output.test.ts
@@ -32,6 +32,26 @@ describe("output rendering", () => {
     expect(rendered.stdout).toMatchSnapshot();
   });
 
+  test("tools detail shows a declared timeout_ms, and no timeout line when the tool declares none", () => {
+    const renderDetail = (timeoutMs?: number): string | undefined =>
+      renderResult(
+        {
+          ok: true,
+          data: {
+            name: "login",
+            description: "Signs a test user in.",
+            ...(timeoutMs !== undefined ? { timeout_ms: timeoutMs } : {}),
+          },
+          meta: { command: "tools", timestamp: FIXED_NOW.toISOString(), duration_ms: 4 },
+        },
+        { command: "tools", json: false, color: false },
+      ).stdout;
+
+    expect(renderDetail(60_000)).toContain("Timeout (ms)  60000");
+    // A tool on the daemon's default must not render a number it never declared.
+    expect(renderDetail()).not.toContain("Timeout (ms)");
+  });
+
   test("tools detail output renders full schema/annotations", () => {
     const rendered = renderResult(
       {

--- a/packages/cordierite/src/__tests__/tool-invocation.integration.test.ts
+++ b/packages/cordierite/src/__tests__/tool-invocation.integration.test.ts
@@ -430,7 +430,7 @@ describe("tools.call: timeout", () => {
     // Declared well below DEFAULT_CALL_TIMEOUT_MS (10 s) so the assertion below distinguishes the
     // two: if the descriptor's timeout were still being dropped on the wire, this call would sit
     // there for 10 s and blow the 5 s test budget.
-    await snapshotTools(daemon, app, [{ name: "hangs", timeoutMs: 1000 }]);
+    await snapshotTools(daemon, app, [{ name: "hangs", timeout_ms: 1000 }]);
 
     const startedAt = Date.now();
     await expect(
@@ -445,10 +445,10 @@ describe("tools.call: timeout", () => {
     app.socket.close();
   }, 10_000);
 
-  test("an explicit caller timeoutMs still overrides the tool's declared one (issue #25)", async () => {
+  test("an explicit caller timeoutMs still shortens a longer declared deadline (issue #25)", async () => {
     const { daemon, port } = await startTestDaemon();
     const app = await claimApp(daemon, port);
-    await snapshotTools(daemon, app, [{ name: "hangs", timeoutMs: 600_000 }]);
+    await snapshotTools(daemon, app, [{ name: "hangs", timeout_ms: 600_000 }]);
 
     const startedAt = Date.now();
     await expect(
@@ -467,19 +467,21 @@ describe("tools.call: timeout", () => {
 
 describe("caller transport timeouts over a slow tool", () => {
   test(
-    "invoke (with and without --timeout) and cordierite/client all outlive a 12 s call (issue #25)",
+    "invoke (with and without --timeout) and cordierite/client all outlive the daemon's 10 s default (issue #25)",
     async () => {
       const { daemon, port } = await startTestDaemon();
       const app = await claimApp(daemon, port);
       await snapshotTools(daemon, app, [
         { name: "slow-explicit" },
-        // Declares its own deadline, so a caller that passes none still gets 30 s daemon-side.
-        { name: "slow-declared", timeoutMs: 30_000 },
+        // Declares its own deadline, so a caller that passes none still gets 20 s daemon-side.
+        { name: "slow-declared", timeout_ms: 20_000 },
       ]);
 
-      // 18 s clears both watchdogs these callers used to fall back to — the bare 10 s default and
-      // the 10 s + 5 s slack derived from it — so each of the three calls below would previously
-      // have failed as a generic transport timeout rather than returning a result.
+      // 11 s clears the 10 s default these calls would otherwise be held to, and the declared 20 s
+      // leaves nine seconds of headroom above it, so a slow runner drifting a second or two turns
+      // this into neither a hard `tool_timeout` nor a false pass. The watchdog arithmetic itself is
+      // asserted exactly — and instantly — in call-timeouts.test.ts rather than by sleeping past
+      // each candidate timer here.
       app.socket.on("message", (data) => {
         const message = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
 
@@ -493,7 +495,7 @@ describe("caller transport timeouts over a slow tool", () => {
                 result: { loggedIn: true, tool: message.name },
               }),
             );
-          }, 18_000);
+          }, 11_000);
         }
       });
 
@@ -521,7 +523,7 @@ describe("caller transport timeouts over a slow tool", () => {
 
       app.socket.close();
     },
-    60_000,
+    25_000,
   );
 });
 

--- a/packages/cordierite/src/__tests__/tool-invocation.integration.test.ts
+++ b/packages/cordierite/src/__tests__/tool-invocation.integration.test.ts
@@ -14,8 +14,15 @@ import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import WebSocket from "ws";
 
-import { decodeBootstrap, TOOL_ERROR_TYPES, type EventKind, type EventNotification } from "@cordierite/shared";
+import {
+  decodeBootstrap,
+  TOOL_ERROR_TYPES,
+  type EventKind,
+  type EventNotification,
+  type ToolDescriptor,
+} from "@cordierite/shared";
 
+import { handleInvokeCommand } from "../commands/invoke.js";
 import { startDaemon, type RunningDaemon } from "../daemon/daemon.js";
 import { writeTestHostKey } from "./fixtures.js";
 
@@ -264,7 +271,7 @@ const claimApp = async (daemon: RunningDaemon, port: number, deviceModel = "Pixe
 const snapshotTools = async (
   daemon: RunningDaemon,
   app: ClaimedApp,
-  tools: Array<{ name: string; description?: string; input_schema?: Record<string, unknown> }>,
+  tools: Array<Partial<ToolDescriptor> & { name: string }>,
 ): Promise<void> => {
   const toolsChanged = waitForEvent(daemon, "tools_changed");
   app.socket.send(
@@ -415,6 +422,86 @@ describe("tools.call: timeout", () => {
 
     app.socket.close();
   }, 5000);
+
+  test("the tool's own declared timeoutMs is the default when the caller passes none (issue #25)", async () => {
+    const { daemon, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+    // Declared well below DEFAULT_CALL_TIMEOUT_MS (10 s) so the assertion below distinguishes the
+    // two: if the descriptor's timeout were still being dropped on the wire, this call would sit
+    // there for 10 s and blow the 5 s test budget.
+    await snapshotTools(daemon, app, [{ name: "hangs", timeoutMs: 1000 }]);
+
+    const startedAt = Date.now();
+    await expect(
+      rpcCall(daemon.paths.socketPath, "tools.call", {
+        selector: app.alias,
+        name: "hangs",
+        args: {},
+      }),
+    ).rejects.toMatchObject({ data: { type: "tool_timeout" } });
+    expect(Date.now() - startedAt).toBeLessThan(5000);
+
+    app.socket.close();
+  }, 10_000);
+
+  test("an explicit caller timeoutMs still overrides the tool's declared one (issue #25)", async () => {
+    const { daemon, port } = await startTestDaemon();
+    const app = await claimApp(daemon, port);
+    await snapshotTools(daemon, app, [{ name: "hangs", timeoutMs: 600_000 }]);
+
+    const startedAt = Date.now();
+    await expect(
+      rpcCall(daemon.paths.socketPath, "tools.call", {
+        selector: app.alias,
+        name: "hangs",
+        args: {},
+        timeoutMs: 1000,
+      }),
+    ).rejects.toMatchObject({ data: { type: "tool_timeout" } });
+    expect(Date.now() - startedAt).toBeLessThan(5000);
+
+    app.socket.close();
+  }, 10_000);
+});
+
+describe("cordierite invoke --timeout", () => {
+  test(
+    "a --timeout above the daemon default survives the CLI's own socket watchdog (issue #25)",
+    async () => {
+      const { daemon, port } = await startTestDaemon();
+      const app = await claimApp(daemon, port);
+      await snapshotTools(daemon, app, [{ name: "slow-login" }]);
+
+      app.socket.on("message", (data) => {
+        const message = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
+
+        if (message.type === "tool_call") {
+          setTimeout(() => {
+            app.socket.send(
+              JSON.stringify({
+                type: "tool_result",
+                session_id: app.sessionId,
+                id: message.id,
+                result: { loggedIn: true },
+              }),
+            );
+          }, 12_000);
+        }
+      });
+
+      // Before the fix `stream.call` fell back to its 10 s default here, so this died at 10 s with
+      // a generic transport error no matter what `--timeout` said.
+      const result = await handleInvokeCommand(
+        { selector: app.alias, tool: "slow-login", args: {}, timeoutMs: 30_000 },
+        { stateDir: daemon.paths.root },
+      );
+
+      expect(result).toEqual({ ok: true, data: { loggedIn: true } });
+
+      app.socket.close();
+    },
+    60_000,
+  );
 });
 
 describe("tools.call: concurrency", () => {

--- a/packages/cordierite/src/__tests__/tool-invocation.integration.test.ts
+++ b/packages/cordierite/src/__tests__/tool-invocation.integration.test.ts
@@ -22,6 +22,7 @@ import {
   type ToolDescriptor,
 } from "@cordierite/shared";
 
+import { connect } from "../client/index.js";
 import { handleInvokeCommand } from "../commands/invoke.js";
 import { startDaemon, type RunningDaemon } from "../daemon/daemon.js";
 import { writeTestHostKey } from "./fixtures.js";
@@ -464,14 +465,21 @@ describe("tools.call: timeout", () => {
   }, 10_000);
 });
 
-describe("cordierite invoke --timeout", () => {
+describe("caller transport timeouts over a slow tool", () => {
   test(
-    "a --timeout above the daemon default survives the CLI's own socket watchdog (issue #25)",
+    "invoke (with and without --timeout) and cordierite/client all outlive a 12 s call (issue #25)",
     async () => {
       const { daemon, port } = await startTestDaemon();
       const app = await claimApp(daemon, port);
-      await snapshotTools(daemon, app, [{ name: "slow-login" }]);
+      await snapshotTools(daemon, app, [
+        { name: "slow-explicit" },
+        // Declares its own deadline, so a caller that passes none still gets 30 s daemon-side.
+        { name: "slow-declared", timeoutMs: 30_000 },
+      ]);
 
+      // 18 s clears both watchdogs these callers used to fall back to — the bare 10 s default and
+      // the 10 s + 5 s slack derived from it — so each of the three calls below would previously
+      // have failed as a generic transport timeout rather than returning a result.
       app.socket.on("message", (data) => {
         const message = JSON.parse(data.toString("utf8")) as Record<string, unknown>;
 
@@ -482,21 +490,34 @@ describe("cordierite invoke --timeout", () => {
                 type: "tool_result",
                 session_id: app.sessionId,
                 id: message.id,
-                result: { loggedIn: true },
+                result: { loggedIn: true, tool: message.name },
               }),
             );
-          }, 12_000);
+          }, 18_000);
         }
       });
 
-      // Before the fix `stream.call` fell back to its 10 s default here, so this died at 10 s with
-      // a generic transport error no matter what `--timeout` said.
-      const result = await handleInvokeCommand(
-        { selector: app.alias, tool: "slow-login", args: {}, timeoutMs: 30_000 },
-        { stateDir: daemon.paths.root },
-      );
+      const client = await connect({ stateDir: daemon.paths.root, selector: app.sessionId });
 
-      expect(result).toEqual({ ok: true, data: { loggedIn: true } });
+      try {
+        const [explicit, declared, viaClient] = await Promise.all([
+          handleInvokeCommand(
+            { selector: app.alias, tool: "slow-explicit", args: {}, timeoutMs: 30_000 },
+            { stateDir: daemon.paths.root },
+          ),
+          handleInvokeCommand(
+            { selector: app.alias, tool: "slow-declared", args: {} },
+            { stateDir: daemon.paths.root },
+          ),
+          client.call("slow-declared", {}),
+        ]);
+
+        expect(explicit).toEqual({ ok: true, data: { loggedIn: true, tool: "slow-explicit" } });
+        expect(declared).toEqual({ ok: true, data: { loggedIn: true, tool: "slow-declared" } });
+        expect(viaClient).toEqual({ loggedIn: true, tool: "slow-declared" });
+      } finally {
+        client.close();
+      }
 
       app.socket.close();
     },

--- a/packages/cordierite/src/cli/create-cli.ts
+++ b/packages/cordierite/src/cli/create-cli.ts
@@ -37,7 +37,11 @@ export const createCli = () => {
   cli
     .command("invoke [selector] [tool]", "Call a tool on a session.")
     .option("--input <json>", "Tool input arguments as a JSON object.")
-    .option("--timeout <ms>", "Call timeout in milliseconds (default: 10000).");
+    .option(
+      "--timeout <ms>",
+      "Call timeout in milliseconds. Shortens the deadline; it cannot extend one past the app's " +
+        "own timer, which is the tool's declared timeoutMs (else 10000).",
+    );
 
   cli
     .command("events [selector]", "Stream session/tool events until interrupted.")

--- a/packages/cordierite/src/client/app-client.ts
+++ b/packages/cordierite/src/client/app-client.ts
@@ -34,10 +34,11 @@ type ToolArgs<TTools, K extends keyof TTools> = TTools[K] extends { args: infer 
 type ToolResult<TTools, K extends keyof TTools> = TTools[K] extends { result: infer TResult } ? TResult : unknown;
 
 export type CallOptions = {
-  /** Forwarded to the daemon as the tool's own deadline (clamped server-side to [1s, 600s],
-   * default 10s) — NOT this call's transport timeout, which is derived from it automatically so a
-   * `tool_timeout` from the daemon always arrives before this client's own transport timeout would
-   * otherwise fire and misreport it as `connection_error`. */
+  /** Forwarded to the daemon as this call's deadline, clamped server-side to [1s, 600s]. Omitted,
+   * the daemon falls back to the tool's own declared `timeoutMs` (`registerTool`), and to 10s for a
+   * tool that declares none. Either way this is NOT the call's transport timeout, which is derived
+   * automatically so a `tool_timeout` from the daemon always arrives before this client's own
+   * transport timeout would otherwise fire and misreport it as `connection_error`. */
   timeoutMs?: number;
 };
 
@@ -132,17 +133,29 @@ const DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MS = 30_000;
  * `MAX_CALL_TIMEOUT_MS` clamp so this client can compute a transport timeout that always exceeds
  * whatever server-side deadline the daemon will actually enforce for a given `timeoutMs` — not
  * imported directly to keep `cordierite/client` from pulling in daemon-internal modules. */
-const DAEMON_DEFAULT_CALL_TIMEOUT_MS = 10_000;
 const DAEMON_MIN_CALL_TIMEOUT_MS = 1_000;
 const DAEMON_MAX_CALL_TIMEOUT_MS = 600_000;
 /** Extra headroom so the daemon's own `tool_timeout` always wins the race against this client's
  * transport timeout, even accounting for RPC round-trip and event-loop scheduling delay. */
 const CALL_TRANSPORT_TIMEOUT_SLACK_MS = 5_000;
 
+/**
+ * Transport timeout for one `tools.call`. With an explicit `timeoutMs` the daemon-side deadline is
+ * known exactly, so this is that clamped value plus slack.
+ *
+ * Without one the daemon defaults to the *tool's own* declared `timeoutMs` (issue #25), which this
+ * client does not know at call time and would need an extra `tools.list` round trip (racy against
+ * re-registration) to learn — so it falls back to the largest deadline the daemon could possibly
+ * enforce. That is deliberately generous: this watchdog only exists for a daemon that accepts the
+ * request and then never answers, since a daemon that dies or drops the socket already rejects
+ * every pending call immediately (`rpc/client.ts`'s `close` handler). Sizing it off the 10 s
+ * default instead would make this client the thing that fails a long tool call, reporting a
+ * generic transport error in place of the daemon's real one.
+ */
 const transportTimeoutForToolCall = (timeoutMs: number | undefined): number => {
   const clamped =
     timeoutMs === undefined || !Number.isFinite(timeoutMs)
-      ? DAEMON_DEFAULT_CALL_TIMEOUT_MS
+      ? DAEMON_MAX_CALL_TIMEOUT_MS
       : Math.min(Math.max(Math.trunc(timeoutMs), DAEMON_MIN_CALL_TIMEOUT_MS), DAEMON_MAX_CALL_TIMEOUT_MS);
 
   return clamped + CALL_TRANSPORT_TIMEOUT_SLACK_MS;

--- a/packages/cordierite/src/client/app-client.ts
+++ b/packages/cordierite/src/client/app-client.ts
@@ -8,6 +8,8 @@
  * why the notification listener has to be registered before the `events.since` drain call is sent.
  */
 import {
+  clampToolTimeoutMs,
+  MAX_TOOL_TIMEOUT_MS,
   RPC_METHODS,
   type EventNotification,
   type EventsSinceResult,
@@ -129,14 +131,11 @@ export type AppClient<TTools = ToolMap> = {
 
 const DEFAULT_WAIT_FOR_EVENT_TIMEOUT_MS = 30_000;
 
-/** Mirrors `daemon/calls.ts`'s `DEFAULT_CALL_TIMEOUT_MS`/`MIN_CALL_TIMEOUT_MS`/
- * `MAX_CALL_TIMEOUT_MS` clamp so this client can compute a transport timeout that always exceeds
- * whatever server-side deadline the daemon will actually enforce for a given `timeoutMs` — not
- * imported directly to keep `cordierite/client` from pulling in daemon-internal modules. */
-const DAEMON_MIN_CALL_TIMEOUT_MS = 1_000;
-const DAEMON_MAX_CALL_TIMEOUT_MS = 600_000;
 /** Extra headroom so the daemon's own `tool_timeout` always wins the race against this client's
- * transport timeout, even accounting for RPC round-trip and event-loop scheduling delay. */
+ * transport timeout, even accounting for RPC round-trip and event-loop scheduling delay. Kept
+ * local because it is a property of this transport, not of the protocol; the *bounds* it is added
+ * to come from `@cordierite/shared`, so this client and the daemon cannot disagree about the
+ * deadline itself. */
 const CALL_TRANSPORT_TIMEOUT_SLACK_MS = 5_000;
 
 /**
@@ -152,11 +151,11 @@ const CALL_TRANSPORT_TIMEOUT_SLACK_MS = 5_000;
  * default instead would make this client the thing that fails a long tool call, reporting a
  * generic transport error in place of the daemon's real one.
  */
-const transportTimeoutForToolCall = (timeoutMs: number | undefined): number => {
+export const transportTimeoutForToolCall = (timeoutMs: number | undefined): number => {
   const clamped =
     timeoutMs === undefined || !Number.isFinite(timeoutMs)
-      ? DAEMON_MAX_CALL_TIMEOUT_MS
-      : Math.min(Math.max(Math.trunc(timeoutMs), DAEMON_MIN_CALL_TIMEOUT_MS), DAEMON_MAX_CALL_TIMEOUT_MS);
+      ? MAX_TOOL_TIMEOUT_MS
+      : clampToolTimeoutMs(timeoutMs);
 
   return clamped + CALL_TRANSPORT_TIMEOUT_SLACK_MS;
 };

--- a/packages/cordierite/src/commands/invoke.ts
+++ b/packages/cordierite/src/commands/invoke.ts
@@ -7,6 +7,7 @@
 import { RPC_METHODS, type ToolsCallResult } from "@cordierite/shared";
 
 import type { CliResult, InvokeCommandData } from "../cli/result-types.js";
+import { deriveCallTransportTimeoutMs } from "../daemon/calls.js";
 import { DaemonRpcError, openDaemonStream, type SpawnFn } from "../rpc/client.js";
 
 export type InvokeCommandOptions = {
@@ -31,12 +32,18 @@ export const handleInvokeCommand = async (
   const stream = await openDaemonStream({ stateDir: context.stateDir, spawn: context.spawn });
 
   try {
-    const callPromise = stream.call<ToolsCallResult>(RPC_METHODS.toolsCall, {
-      selector: options.selector,
-      name: options.tool,
-      args: options.args,
-      timeoutMs: options.timeoutMs,
-    });
+    const callPromise = stream.call<ToolsCallResult>(
+      RPC_METHODS.toolsCall,
+      {
+        selector: options.selector,
+        name: options.tool,
+        args: options.args,
+        timeoutMs: options.timeoutMs,
+      },
+      // Without this the socket watchdog defaults to 10 s and `--timeout 60000` still dies at 10 s
+      // with a generic transport error instead of the daemon's own `tool_timeout` (issue #25).
+      deriveCallTransportTimeoutMs(options.timeoutMs),
+    );
 
     if (!signal) {
       const result = await callPromise;

--- a/packages/cordierite/src/commands/invoke.ts
+++ b/packages/cordierite/src/commands/invoke.ts
@@ -7,7 +7,7 @@
 import { RPC_METHODS, type ToolsCallResult } from "@cordierite/shared";
 
 import type { CliResult, InvokeCommandData } from "../cli/result-types.js";
-import { deriveCallTransportTimeoutMs } from "../daemon/calls.js";
+import { deriveCallTransportTimeoutMs, MAX_CALL_TIMEOUT_MS } from "../daemon/calls.js";
 import { DaemonRpcError, openDaemonStream, type SpawnFn } from "../rpc/client.js";
 
 export type InvokeCommandOptions = {
@@ -42,7 +42,11 @@ export const handleInvokeCommand = async (
       },
       // Without this the socket watchdog defaults to 10 s and `--timeout 60000` still dies at 10 s
       // with a generic transport error instead of the daemon's own `tool_timeout` (issue #25).
-      deriveCallTransportTimeoutMs(options.timeoutMs),
+      // With no `--timeout` the daemon falls back to the *tool's* declared deadline, which this
+      // command does not know without an extra `tools.list` round trip, so the watchdog is sized
+      // for the largest deadline the daemon could enforce. It is only ever a backstop for a daemon
+      // that answers nothing: one that dies or drops the socket rejects pending calls at once.
+      deriveCallTransportTimeoutMs(options.timeoutMs ?? MAX_CALL_TIMEOUT_MS),
     );
 
     if (!signal) {

--- a/packages/cordierite/src/daemon/calls.ts
+++ b/packages/cordierite/src/daemon/calls.ts
@@ -96,12 +96,25 @@ type PendingCall = {
 
 const generateCallId = (): string => `call_${randomBytes(16).toString("base64url")}`;
 
-const clampTimeout = (timeoutMs: number | undefined): number => {
+/** Extra headroom added on top of the daemon-side deadline so a caller's transport timeout never
+ * beats the daemon's own `tool_timeout` — mirrored (deliberately duplicated) in
+ * `client/app-client.ts`, which must not import daemon-internal modules. */
+export const CALL_TRANSPORT_TIMEOUT_SLACK_MS = 5_000;
+
+/** The deadline the daemon will actually enforce for a `tools.call` with this `timeoutMs`. */
+export const clampTimeout = (timeoutMs: number | undefined): number => {
   if (timeoutMs === undefined || !Number.isFinite(timeoutMs)) {
     return DEFAULT_CALL_TIMEOUT_MS;
   }
 
   return Math.min(Math.max(Math.trunc(timeoutMs), MIN_CALL_TIMEOUT_MS), MAX_CALL_TIMEOUT_MS);
+};
+
+/** Transport timeout a caller should use for a `tools.call` that will be given `timeoutMs`
+ * daemon-side. Always clamps first: adding slack to an unclamped value could overflow Node's
+ * 32-bit timer range (~24.8 days), which silently fires the timer immediately. */
+export const deriveCallTransportTimeoutMs = (timeoutMs: number | undefined): number => {
+  return clampTimeout(timeoutMs) + CALL_TRANSPORT_TIMEOUT_SLACK_MS;
 };
 
 /** Event kinds that terminate every pending call for a session (ARCHITECTURE.md §6/§5: "On

--- a/packages/cordierite/src/daemon/calls.ts
+++ b/packages/cordierite/src/daemon/calls.ts
@@ -15,21 +15,27 @@
 
 import { randomBytes } from "node:crypto";
 
-import type {
-  ToolCallMessage,
-  ToolCallProgressMessage,
-  ToolCancelMessage,
-  ToolErrorMessage,
-  ToolResultMessage,
+import {
+  clampToolTimeoutMs,
+  DEFAULT_TOOL_TIMEOUT_MS,
+  MAX_TOOL_TIMEOUT_MS,
+  MIN_TOOL_TIMEOUT_MS,
+  type ToolCallMessage,
+  type ToolCallProgressMessage,
+  type ToolCancelMessage,
+  type ToolErrorMessage,
+  type ToolResultMessage,
 } from "@cordierite/shared";
 
 import type { EventBus } from "./event-bus.js";
 import { RpcApplicationError } from "./rpc-server.js";
 import { systemTimers, type TimerFns, type TimerHandle } from "./timers.js";
 
-export const DEFAULT_CALL_TIMEOUT_MS = 10_000;
-export const MIN_CALL_TIMEOUT_MS = 1_000;
-export const MAX_CALL_TIMEOUT_MS = 600_000;
+/** Re-exported under this module's historical names; the values live in `@cordierite/shared` so the
+ * RN SDK's app-side abort timer and this timer cannot drift apart (issue #25). */
+export const DEFAULT_CALL_TIMEOUT_MS = DEFAULT_TOOL_TIMEOUT_MS;
+export const MIN_CALL_TIMEOUT_MS = MIN_TOOL_TIMEOUT_MS;
+export const MAX_CALL_TIMEOUT_MS = MAX_TOOL_TIMEOUT_MS;
 
 /** Identifies the session a call belongs to; carried through so progress/lifecycle events can be
  * tagged with the alias without this module needing to look sessions back up. */
@@ -107,7 +113,7 @@ export const clampTimeout = (timeoutMs: number | undefined): number => {
     return DEFAULT_CALL_TIMEOUT_MS;
   }
 
-  return Math.min(Math.max(Math.trunc(timeoutMs), MIN_CALL_TIMEOUT_MS), MAX_CALL_TIMEOUT_MS);
+  return clampToolTimeoutMs(timeoutMs);
 };
 
 /** Transport timeout a caller should use for a `tools.call` that will be given `timeoutMs`

--- a/packages/cordierite/src/daemon/daemon.ts
+++ b/packages/cordierite/src/daemon/daemon.ts
@@ -595,7 +595,15 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
           // be exposed to the RPC caller and stamped on every event in this call's lifecycle — the
           // MCP server correlates its own in-flight `tools.call` against `tool_call_progress`
           // notifications by this id, unambiguous under concurrent calls.
-          const { callId, result: callResult } = activeCallsManager.call(session, name, args, timeoutMs);
+          const { callId, result: callResult } = activeCallsManager.call(
+            session,
+            name,
+            args,
+            // The caller's explicit `timeoutMs` wins; otherwise the tool's own declared deadline is
+            // the default, and only if it declares none does `clampTimeout` fall back to
+            // DEFAULT_CALL_TIMEOUT_MS (issue #25).
+            timeoutMs ?? tool.timeoutMs,
+          );
 
           // If the connection that issued this tools.call drops while the call is still pending
           // (CLI Ctrl-C, MCP client disconnect), tell the app to stop rather than leaving an

--- a/packages/cordierite/src/daemon/daemon.ts
+++ b/packages/cordierite/src/daemon/daemon.ts
@@ -602,7 +602,7 @@ export const startDaemon = async (options: DaemonOptions): Promise<RunningDaemon
             // The caller's explicit `timeoutMs` wins; otherwise the tool's own declared deadline is
             // the default, and only if it declares none does `clampTimeout` fall back to
             // DEFAULT_CALL_TIMEOUT_MS (issue #25).
-            timeoutMs ?? tool.timeoutMs,
+            timeoutMs ?? tool.timeout_ms,
           );
 
           // If the connection that issued this tools.call drops while the call is still pending

--- a/packages/cordierite/src/mcp/server.ts
+++ b/packages/cordierite/src/mcp/server.ts
@@ -27,6 +27,7 @@ import {
 import { RPC_METHODS, type EventKind, type EventNotification, type SessionsListResult, type ToolsCallResult } from "@cordierite/shared";
 
 import type { ExecFn } from "../cli/open-target.js";
+import { deriveCallTransportTimeoutMs } from "../daemon/calls.js";
 import { DaemonRpcError, openDaemonStream, type SpawnFn } from "../rpc/client.js";
 import {
   CONNECT_TOOL_DESCRIPTOR,
@@ -265,13 +266,20 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
         : undefined;
 
     if (progressToken === undefined) {
-      const result = await stream.call<ToolsCallResult>(RPC_METHODS.toolsCall, {
-        selector: tool.selector,
-        name: tool.descriptor.name,
-        args,
-        caller: "mcp",
-        ...(consent ? { consent } : {}),
-      });
+      const result = await stream.call<ToolsCallResult>(
+        RPC_METHODS.toolsCall,
+        {
+          selector: tool.selector,
+          name: tool.descriptor.name,
+          args,
+          caller: "mcp",
+          ...(consent ? { consent } : {}),
+        },
+        // Sized off the deadline the daemon will actually enforce for this tool, so its
+        // `tool_timeout` always arrives before this transport watchdog fires and the agent sees the
+        // real error type instead of a generic transport failure (issue #25).
+        deriveCallTransportTimeoutMs(tool.descriptor.timeoutMs),
+      );
 
       return result.result;
     }
@@ -339,13 +347,17 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
       });
 
       try {
-        const result = await progressStream.call<ToolsCallResult>(RPC_METHODS.toolsCall, {
-          selector: tool.selector,
-          name: tool.descriptor.name,
-          args,
-          caller: "mcp",
-          ...(consent ? { consent } : {}),
-        });
+        const result = await progressStream.call<ToolsCallResult>(
+          RPC_METHODS.toolsCall,
+          {
+            selector: tool.selector,
+            name: tool.descriptor.name,
+            args,
+            caller: "mcp",
+            ...(consent ? { consent } : {}),
+          },
+          deriveCallTransportTimeoutMs(tool.descriptor.timeoutMs),
+        );
 
         return result.result;
       } finally {

--- a/packages/cordierite/src/mcp/server.ts
+++ b/packages/cordierite/src/mcp/server.ts
@@ -27,7 +27,7 @@ import {
 import { RPC_METHODS, type EventKind, type EventNotification, type SessionsListResult, type ToolsCallResult } from "@cordierite/shared";
 
 import type { ExecFn } from "../cli/open-target.js";
-import { deriveCallTransportTimeoutMs } from "../daemon/calls.js";
+import { clampTimeout, deriveCallTransportTimeoutMs } from "../daemon/calls.js";
 import { DaemonRpcError, openDaemonStream, type SpawnFn } from "../rpc/client.js";
 import {
   CONNECT_TOOL_DESCRIPTOR,
@@ -265,6 +265,16 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
         ? "client"
         : undefined;
 
+    // The deadline this call runs under, resolved once from the `tools.list` snapshot it was
+    // matched against, and sent explicitly rather than left to the daemon's `?? tool.timeout_ms`
+    // fallback. `clampTimeout` folds in the 10 s default for a tool that declares nothing, so
+    // there is exactly one number here and the watchdog below can never be sized off a different
+    // read: the daemon consults its live registry, which a re-registration between that snapshot
+    // and this call could have moved, and a watchdog built for the older value would fire first
+    // and mask the daemon's real `tool_timeout` (issue #25).
+    const timeoutMs = clampTimeout(tool.descriptor.timeout_ms);
+    const transportTimeoutMs = deriveCallTransportTimeoutMs(timeoutMs);
+
     if (progressToken === undefined) {
       const result = await stream.call<ToolsCallResult>(
         RPC_METHODS.toolsCall,
@@ -273,12 +283,10 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
           name: tool.descriptor.name,
           args,
           caller: "mcp",
+          timeoutMs,
           ...(consent ? { consent } : {}),
         },
-        // Sized off the deadline the daemon will actually enforce for this tool, so its
-        // `tool_timeout` always arrives before this transport watchdog fires and the agent sees the
-        // real error type instead of a generic transport failure (issue #25).
-        deriveCallTransportTimeoutMs(tool.descriptor.timeoutMs),
+        transportTimeoutMs,
       );
 
       return result.result;
@@ -354,9 +362,10 @@ export const createMcpServer = async (options: CreateMcpServerOptions): Promise<
             name: tool.descriptor.name,
             args,
             caller: "mcp",
+            timeoutMs,
             ...(consent ? { consent } : {}),
           },
-          deriveCallTransportTimeoutMs(tool.descriptor.timeoutMs),
+          transportTimeoutMs,
         );
 
         return result.result;

--- a/packages/cordierite/src/mcp/tool-namespace.ts
+++ b/packages/cordierite/src/mcp/tool-namespace.ts
@@ -49,7 +49,7 @@ export const buildNamespacedTools = (
         input_schema: entry.input_schema,
         output_schema: entry.output_schema,
         annotations: entry.annotations,
-        timeoutMs: entry.timeoutMs,
+        timeout_ms: entry.timeout_ms,
       };
 
       tools.push({
@@ -72,11 +72,24 @@ export const findNamespacedTool = (
 };
 
 /** A stable, order-independent key used to detect whether the effective tool list actually
- * changed (name, target session, and full descriptor) — used to decide whether to fire
- * `notifications/tools/list_changed` rather than on every qualifying daemon event. */
+ * changed (name, target session, and the descriptor fields a client can see) — used to decide
+ * whether to fire `notifications/tools/list_changed` rather than on every qualifying daemon event.
+ *
+ * `timeout_ms` is deliberately excluded: it never reaches the MCP `Tool` JSON (`tool-mapping.ts`),
+ * so an app re-registering a tool with only a different deadline changes nothing a client could
+ * observe, and telling it the list changed would just make it re-fetch an identical list. */
 export const namespacedToolsSnapshotKey = (tools: readonly NamespacedTool[]): string => {
   const sorted = tools
-    .map((tool) => ({ name: tool.mcpName, selector: tool.selector, descriptor: tool.descriptor, policy: tool.policy }))
+    .map((tool) => {
+      const { timeout_ms: _timeoutMs, ...clientVisibleDescriptor } = tool.descriptor;
+
+      return {
+        name: tool.mcpName,
+        selector: tool.selector,
+        descriptor: clientVisibleDescriptor,
+        policy: tool.policy,
+      };
+    })
     .sort((a, b) => a.name.localeCompare(b.name));
 
   return JSON.stringify(sorted);

--- a/packages/cordierite/src/mcp/tool-namespace.ts
+++ b/packages/cordierite/src/mcp/tool-namespace.ts
@@ -49,6 +49,7 @@ export const buildNamespacedTools = (
         input_schema: entry.input_schema,
         output_schema: entry.output_schema,
         annotations: entry.annotations,
+        timeoutMs: entry.timeoutMs,
       };
 
       tools.push({

--- a/packages/cordierite/src/output.ts
+++ b/packages/cordierite/src/output.ts
@@ -156,6 +156,9 @@ const renderToolDetail = (colors: ColorPalette, tool: ToolDescriptor): string[] 
     ["Input schema", tool.input_schema],
     ["Output schema", tool.output_schema],
     ["Annotations", tool.annotations],
+    // Only rendered for a tool that declares one; `renderFields` drops undefined rows, so a tool
+    // on the daemon's default deadline shows no line at all rather than a misleading "10000".
+    ["Timeout (ms)", tool.timeout_ms],
   ]);
 };
 

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -309,7 +309,7 @@ handler: async ({ url }, { signal }) => {
 },
 ```
 
-**Long-running tools:** a tool call gets 10 seconds by default. Declare `timeoutMs` on the registration for anything slower — a real `login()`, a `seedCart()` that hits your backend — and that deadline is the one enforced end to end: the app aborts the handler's `signal` at it, and it also travels to the daemon on the tool descriptor, so an agent calling the tool over MCP (or `cordierite invoke` with no `--timeout`) gets the same budget instead of a `tool_timeout` at 10 s:
+**Long-running tools:** a tool call gets 10 seconds by default. Declaring `timeoutMs` on the registration is the *only* way to raise that — a real `login()`, a `seedCart()` that hits your backend. That deadline is then the one enforced end to end: the app aborts the handler's `signal` at it, and it also travels to the daemon as the descriptor's `timeout_ms`, so an agent calling the tool over MCP (or `cordierite invoke` with no `--timeout`) gets the same budget instead of a `tool_timeout` at 10 s:
 
 ```ts
 useCordieriteTool(
@@ -323,7 +323,7 @@ useCordieriteTool(
 );
 ```
 
-The value is clamped daemon-side to `[1_000, 600_000]` ms, and a caller that passes its own timeout (`cordierite invoke --timeout`, `app.call(name, args, { timeoutMs })`) still overrides it. `createCordieriteClient`'s `defaultToolTimeoutMs` changes only the app-side fallback for tools that declare nothing; it is deliberately not sent to the daemon, so set `timeoutMs` per tool when the host needs to know.
+The SDK clamps the value to `[1_000, 600_000]` ms before either timer is set, so the handler's abort timer and the daemon's call deadline are always the same number (a value outside that range is clamped with a dev warning). A caller that passes its own timeout (`cordierite invoke --timeout`, `app.call(name, args, { timeoutMs })`) can **shorten** the deadline but cannot extend it past this one: the app aborts the handler at its own timer regardless — so for a tool that declares nothing, a caller asking for 60 s still gets the app's 10 s default. `createCordieriteClient`'s `defaultToolTimeoutMs` changes only that app-side fallback for tools that declare nothing; it is deliberately not sent to the daemon, so declare `timeoutMs` per tool when the host needs to know.
 
 **Gating a tool by build variant:** `useCordieriteTool` takes a third `options` argument, `{ enabled?: boolean }` (default `true`). `enabled: false` never registers the tool, and removing it (or a hook that was already mounted) leaves no registration behind. Toggling `enabled` at runtime registers/unregisters cleanly — this is the supported way to make registration conditional, so put the condition in the argument instead of wrapping the hook call in an `if`, which is a rules-of-hooks violation:
 

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -309,6 +309,22 @@ handler: async ({ url }, { signal }) => {
 },
 ```
 
+**Long-running tools:** a tool call gets 10 seconds by default. Declare `timeoutMs` on the registration for anything slower — a real `login()`, a `seedCart()` that hits your backend — and that deadline is the one enforced end to end: the app aborts the handler's `signal` at it, and it also travels to the daemon on the tool descriptor, so an agent calling the tool over MCP (or `cordierite invoke` with no `--timeout`) gets the same budget instead of a `tool_timeout` at 10 s:
+
+```ts
+useCordieriteTool(
+  {
+    name: "login",
+    description: "Signs a test user in against the real backend",
+    timeoutMs: 60_000,
+    handler: async ({ userId }, { signal }) => loginAsUser(userId, { signal }),
+  },
+  []
+);
+```
+
+The value is clamped daemon-side to `[1_000, 600_000]` ms, and a caller that passes its own timeout (`cordierite invoke --timeout`, `app.call(name, args, { timeoutMs })`) still overrides it. `createCordieriteClient`'s `defaultToolTimeoutMs` changes only the app-side fallback for tools that declare nothing; it is deliberately not sent to the daemon, so set `timeoutMs` per tool when the host needs to know.
+
 **Gating a tool by build variant:** `useCordieriteTool` takes a third `options` argument, `{ enabled?: boolean }` (default `true`). `enabled: false` never registers the tool, and removing it (or a hook that was already mounted) leaves no registration behind. Toggling `enabled` at runtime registers/unregisters cleanly — this is the supported way to make registration conditional, so put the condition in the argument instead of wrapping the hook call in an `if`, which is a rules-of-hooks violation:
 
 ```ts

--- a/packages/react-native/src/Cordierite.types.ts
+++ b/packages/react-native/src/Cordierite.types.ts
@@ -392,9 +392,14 @@ export type CordieriteToolDefinition<
   outputSchema?: TOutputSchema;
   annotations?: ToolAnnotations;
   /**
-   * Overrides the default 10 s app-side handler timeout (matches the daemon's `tools.call`
-   * default ceiling, ARCHITECTURE.md §11). On timeout the app replies `tool_timeout`; a later
-   * result from the same invocation is ignored with a dev warning.
+   * Overrides the default 10 s app-side handler timeout (ARCHITECTURE.md §11). On timeout the app
+   * replies `tool_timeout`; a later result from the same invocation is ignored with a dev warning.
+   *
+   * Declared here it also travels on the tool descriptor and becomes the daemon's default deadline
+   * for this tool, so a caller that passes no timeout of its own (an MCP agent, `cordierite invoke`
+   * with no `--timeout`) gets the same budget instead of the daemon's 10 s. Must be a positive
+   * integer to make that trip — anything else stays app-side only, with a dev warning. The
+   * client-wide `defaultToolTimeoutMs` is deliberately never sent.
    */
   timeoutMs?: number;
 };

--- a/packages/react-native/src/__tests__/client.test.ts
+++ b/packages/react-native/src/__tests__/client.test.ts
@@ -16,6 +16,7 @@ import type {
 } from "../Cordierite.types";
 import { createCordieriteClient } from "../client";
 import type { AppStateLike, AppStateStatus } from "../client/app-state";
+import { createToolRegistry, type RegistryDelta } from "../client/registry";
 import type { ClientTimerHandle, ClientTimers } from "../client/timers";
 
 (globalThis as { __DEV__?: boolean }).__DEV__ = true;
@@ -1045,10 +1046,62 @@ describe("createCordieriteClient: tool registry", () => {
       {
         name: "declared",
         description: "Declares its own deadline",
-        timeoutMs: 60_000,
+        timeout_ms: 60_000,
       },
       { name: "undeclared", description: "Declares nothing" },
     ]);
+  });
+
+  test("an out-of-range timeoutMs is clamped once, so the app timer and the wire agree (issue #25)", () => {
+    const deltas: RegistryDelta[] = [];
+    const registry = createToolRegistry({
+      defaultTimeoutMs: 45_000,
+      onDelta: (delta) => deltas.push(delta),
+    });
+
+    const warnings: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+
+    try {
+      registry.registerTool({
+        name: "way-too-long",
+        description: "Declares longer than the daemon will ever allow",
+        timeoutMs: 900_000,
+        handler: () => {},
+      });
+      registry.registerTool({
+        name: "undeclared",
+        description: "Declares nothing",
+        handler: () => {},
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    // The descriptor is what the daemon's call timer will be built from …
+    expect(registry.getDescriptors()).toEqual([
+      {
+        name: "way-too-long",
+        description: "Declares longer than the daemon will ever allow",
+        timeout_ms: 600_000,
+      },
+      { name: "undeclared", description: "Declares nothing" },
+    ]);
+
+    // … and the registry entry is what this app's abort timer uses. They must be the same number,
+    // or the handler keeps running for five minutes after the daemon has already given up.
+    expect(registry.entries.get("way-too-long")?.timeoutMs).toBe(600_000);
+    // A tool that declares nothing still falls back to the app-wide default, unchanged.
+    expect(registry.entries.get("undeclared")?.timeoutMs).toBe(45_000);
+
+    expect(
+      warnings.some((args) =>
+        args.some((arg) => typeof arg === "string" && arg.includes("clamped")),
+      ),
+    ).toBe(true);
   });
 
   test("a registry-sync send failure is reported on the unified error channel, not thrown (v1 defect: unhandled fire-and-forget)", async () => {

--- a/packages/react-native/src/__tests__/client.test.ts
+++ b/packages/react-native/src/__tests__/client.test.ts
@@ -1021,6 +1021,36 @@ describe("createCordieriteClient: tool registry", () => {
     ).toBe(true);
   });
 
+  test("only an explicitly declared timeoutMs reaches the descriptor, never defaultToolTimeoutMs (issue #25)", () => {
+    const nativeModule = createMockModule();
+    const client = createCordieriteClient(nativeModule, {
+      defaultToolTimeoutMs: 45_000,
+    });
+
+    client.registerTool({
+      name: "declared",
+      description: "Declares its own deadline",
+      timeoutMs: 60_000,
+      handler: () => {},
+    });
+    client.registerTool({
+      name: "undeclared",
+      description: "Declares nothing",
+      handler: () => {},
+    });
+
+    // The app-wide default is an app-side abort-timer fallback only: putting it on the wire would
+    // silently retune every older app's daemon-side deadline.
+    expect(client.getRegisteredTools()).toEqual([
+      {
+        name: "declared",
+        description: "Declares its own deadline",
+        timeoutMs: 60_000,
+      },
+      { name: "undeclared", description: "Declares nothing" },
+    ]);
+  });
+
   test("a registry-sync send failure is reported on the unified error channel, not thrown (v1 defect: unhandled fire-and-forget)", async () => {
     const nativeModule = createMockModule();
     const client = createCordieriteClient(nativeModule);

--- a/packages/react-native/src/__tests__/schema.test.ts
+++ b/packages/react-native/src/__tests__/schema.test.ts
@@ -920,6 +920,33 @@ describe("toToolDescriptor: timeoutMs", () => {
     });
   });
 
+  test.each([
+    ["zero", 0],
+    ["negative", -1],
+    ["fractional", 1500.5],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])(
+    "drops a timeoutMs that is %s, with a dev warning, rather than sending a descriptor the daemon rejects",
+    (_label, timeoutMs) => {
+      const warnings = withDevWarnCaptured(() => {
+        const descriptor = toToolDescriptor({
+          name: "odd-timeout",
+          description: "d",
+          timeoutMs,
+        });
+
+        // `isToolDescriptor` rejects the whole registry snapshot over one bad field, so emitting
+        // this would close the session instead of degrading to the daemon's default.
+        expect("timeoutMs" in descriptor).toBe(false);
+      });
+
+      expect(
+        warnings.some((args) => args.some((arg) => arg.includes("timeoutMs"))),
+      ).toBe(true);
+    },
+  );
+
   test("omits the key entirely when the tool declares no timeout", () => {
     const descriptor = toToolDescriptor({
       name: "plain-tool",

--- a/packages/react-native/src/__tests__/schema.test.ts
+++ b/packages/react-native/src/__tests__/schema.test.ts
@@ -904,3 +904,31 @@ describe("toToolDescriptor: schemas MCP cannot represent (issue #26)", () => {
     expect(relevant[0]!.join(" ")).toContain("shapeless");
   });
 });
+
+describe("toToolDescriptor: timeoutMs", () => {
+  test("carries an explicitly declared timeoutMs onto the wire descriptor", () => {
+    const descriptor = toToolDescriptor({
+      name: "slow-tool",
+      description: "d",
+      timeoutMs: 60_000,
+    });
+
+    expect(descriptor).toEqual({
+      name: "slow-tool",
+      description: "d",
+      timeoutMs: 60_000,
+    });
+  });
+
+  test("omits the key entirely when the tool declares no timeout", () => {
+    const descriptor = toToolDescriptor({
+      name: "plain-tool",
+      description: "d",
+    });
+
+    // Not merely `undefined`: the key must be absent so the frame never carries
+    // `"timeoutMs": undefined` and the daemon keeps its own default.
+    expect("timeoutMs" in descriptor).toBe(false);
+    expect(Object.keys(descriptor)).toEqual(["name", "description"]);
+  });
+});

--- a/packages/react-native/src/__tests__/schema.test.ts
+++ b/packages/react-native/src/__tests__/schema.test.ts
@@ -1,4 +1,8 @@
-import type { StandardSchemaV1 } from "@cordierite/shared";
+import {
+  MAX_TOOL_TIMEOUT_MS,
+  MIN_TOOL_TIMEOUT_MS,
+  type StandardSchemaV1,
+} from "@cordierite/shared";
 import { describe, expect, test } from "vitest";
 import { z as z3 } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
@@ -905,40 +909,42 @@ describe("toToolDescriptor: schemas MCP cannot represent (issue #26)", () => {
   });
 });
 
-describe("toToolDescriptor: timeoutMs", () => {
-  test("carries an explicitly declared timeoutMs onto the wire descriptor", () => {
+describe("toToolDescriptor: timeout_ms", () => {
+  test("carries an explicitly declared timeoutMs onto the wire descriptor as timeout_ms", () => {
     const descriptor = toToolDescriptor({
       name: "slow-tool",
       description: "d",
       timeoutMs: 60_000,
     });
 
+    // The registration option is camelCase; the wire field is snake_case like every other
+    // protocol-defined descriptor field.
     expect(descriptor).toEqual({
       name: "slow-tool",
       description: "d",
-      timeoutMs: 60_000,
+      timeout_ms: 60_000,
     });
   });
 
   test.each([
-    ["zero", 0],
-    ["negative", -1],
-    ["fractional", 1500.5],
-    ["NaN", Number.NaN],
-    ["Infinity", Number.POSITIVE_INFINITY],
+    ["below the minimum", 500, MIN_TOOL_TIMEOUT_MS],
+    ["zero", 0, MIN_TOOL_TIMEOUT_MS],
+    ["negative", -1, MIN_TOOL_TIMEOUT_MS],
+    ["above the maximum", 900_000, MAX_TOOL_TIMEOUT_MS],
+    ["fractional", 1500.5, 1500],
   ])(
-    "drops a timeoutMs that is %s, with a dev warning, rather than sending a descriptor the daemon rejects",
-    (_label, timeoutMs) => {
+    "clamps a timeoutMs %s into the range the daemon enforces, with a dev warning",
+    (_label, timeoutMs, expected) => {
       const warnings = withDevWarnCaptured(() => {
         const descriptor = toToolDescriptor({
-          name: "odd-timeout",
+          name: `clamped-${String(timeoutMs)}`,
           description: "d",
           timeoutMs,
         });
 
-        // `isToolDescriptor` rejects the whole registry snapshot over one bad field, so emitting
-        // this would close the session instead of degrading to the daemon's default.
-        expect("timeoutMs" in descriptor).toBe(false);
+        // Sending the raw value would leave the app's abort timer and the daemon's call timer
+        // disagreeing about when this tool is out of time.
+        expect(descriptor.timeout_ms).toBe(expected);
       });
 
       expect(
@@ -946,6 +952,51 @@ describe("toToolDescriptor: timeoutMs", () => {
       ).toBe(true);
     },
   );
+
+  test.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])(
+    "drops a timeoutMs that is %s, with a dev warning, rather than sending a descriptor the daemon rejects",
+    (_label, timeoutMs) => {
+      const warnings = withDevWarnCaptured(() => {
+        const descriptor = toToolDescriptor({
+          name: `unclampable-${String(timeoutMs)}`,
+          description: "d",
+          timeoutMs,
+        });
+
+        // `isToolDescriptor` rejects the whole registry snapshot over one bad field, so emitting
+        // this would close the session instead of degrading to the daemon's default.
+        expect("timeout_ms" in descriptor).toBe(false);
+      });
+
+      expect(
+        warnings.some((args) => args.some((arg) => arg.includes("timeoutMs"))),
+      ).toBe(true);
+    },
+  );
+
+  test("warns only once per tool name, like the shapeless-schema warning", () => {
+    const warnings = withDevWarnCaptured(() => {
+      toToolDescriptor({
+        name: "noisy-timeout",
+        description: "d",
+        timeoutMs: 5,
+      });
+      toToolDescriptor({
+        name: "noisy-timeout",
+        description: "d",
+        timeoutMs: 5,
+      });
+    });
+
+    expect(
+      warnings.filter((args) =>
+        args.some((arg) => arg.includes("noisy-timeout")),
+      ),
+    ).toHaveLength(1);
+  });
 
   test("omits the key entirely when the tool declares no timeout", () => {
     const descriptor = toToolDescriptor({
@@ -955,7 +1006,7 @@ describe("toToolDescriptor: timeoutMs", () => {
 
     // Not merely `undefined`: the key must be absent so the frame never carries
     // `"timeoutMs": undefined` and the daemon keeps its own default.
-    expect("timeoutMs" in descriptor).toBe(false);
+    expect("timeout_ms" in descriptor).toBe(false);
     expect(Object.keys(descriptor)).toEqual(["name", "description"]);
   });
 });

--- a/packages/react-native/src/__tests__/schema.test.ts
+++ b/packages/react-native/src/__tests__/schema.test.ts
@@ -935,7 +935,7 @@ describe("toToolDescriptor: timeout_ms", () => {
   ])(
     "clamps a timeoutMs %s into the range the daemon enforces, with a dev warning",
     (_label, timeoutMs, expected) => {
-      const warnings = withDevWarnCaptured(() => {
+      const warnings = withWarningsCaptured(() => {
         const descriptor = toToolDescriptor({
           name: `clamped-${String(timeoutMs)}`,
           description: "d",
@@ -959,7 +959,7 @@ describe("toToolDescriptor: timeout_ms", () => {
   ])(
     "drops a timeoutMs that is %s, with a dev warning, rather than sending a descriptor the daemon rejects",
     (_label, timeoutMs) => {
-      const warnings = withDevWarnCaptured(() => {
+      const warnings = withWarningsCaptured(() => {
         const descriptor = toToolDescriptor({
           name: `unclampable-${String(timeoutMs)}`,
           description: "d",
@@ -978,7 +978,7 @@ describe("toToolDescriptor: timeout_ms", () => {
   );
 
   test("warns only once per tool name, like the shapeless-schema warning", () => {
-    const warnings = withDevWarnCaptured(() => {
+    const warnings = withWarningsCaptured(() => {
       toToolDescriptor({
         name: "noisy-timeout",
         description: "d",

--- a/packages/react-native/src/client/registry.ts
+++ b/packages/react-native/src/client/registry.ts
@@ -63,6 +63,7 @@ export const createToolRegistry = (deps: ToolRegistryDeps): ToolRegistry => {
       inputSchema,
       outputSchema,
       annotations: registration.annotations,
+      timeoutMs: registration.timeoutMs,
     });
 
     if (entries.has(registration.name)) {

--- a/packages/react-native/src/client/registry.ts
+++ b/packages/react-native/src/client/registry.ts
@@ -80,7 +80,11 @@ export const createToolRegistry = (deps: ToolRegistryDeps): ToolRegistry => {
       inputSchema,
       outputSchema,
       handler: registration.handler as CordieriteToolHandler,
-      timeoutMs: registration.timeoutMs ?? deps.defaultTimeoutMs,
+      // Read back off the descriptor, not off `registration`, so this abort timer is the exact
+      // number the daemon's call timer will use (issue #25): `toToolDescriptor` has already
+      // clamped it to the shared bounds, or dropped a value the daemon could not accept — in
+      // which case both sides fall back to their own default rather than disagreeing.
+      timeoutMs: descriptor.timeout_ms ?? deps.defaultTimeoutMs,
     });
 
     logger.debug("registerTool", registration.name);

--- a/packages/react-native/src/schema.ts
+++ b/packages/react-native/src/schema.ts
@@ -291,7 +291,8 @@ const hasJsonSchemaExporter = (
 };
 
 type ConverterOutcome =
-  { ok: true; schema: ToolSchemaDescriptor } | { ok: false; reason: string };
+  | { ok: true; schema: ToolSchemaDescriptor }
+  | { ok: false; reason: string };
 
 const describe = (value: unknown): string => {
   if (Array.isArray(value)) {
@@ -476,10 +477,39 @@ export const validateToolSchema = async (
 /** A tool definition whose schemas have already been through `normalizeToolSchema`. */
 export type CordieriteNormalizedToolDefinition = Pick<
   CordieriteToolDefinition,
-  "name" | "description" | "annotations"
+  "name" | "description" | "annotations" | "timeoutMs"
 > & {
   inputSchema?: CordieriteNormalizedToolSchema;
   outputSchema?: CordieriteNormalizedToolSchema;
+};
+
+/**
+ * The daemon's `isToolDescriptor` requires `timeoutMs` to be a positive integer when present, and
+ * rejects the *whole* registry snapshot otherwise (closing the session as `invalid_registry`). An
+ * app-side `timeoutMs` has never been validated — it only ever fed a local `setTimeout` — so a tool
+ * that happens to declare `0` or a computed fraction must not start taking the session down now
+ * that the value travels on the wire. Anything the daemon would reject is dropped from the
+ * descriptor (the app-side abort timer still uses it verbatim) with a dev warning.
+ */
+const toWireTimeoutMs = (
+  timeoutMs: number | undefined,
+  toolName: string,
+): number | undefined => {
+  if (timeoutMs === undefined) {
+    return undefined;
+  }
+
+  if (Number.isInteger(timeoutMs) && timeoutMs > 0) {
+    return timeoutMs;
+  }
+
+  logger.devWarn(
+    `Tool "${toolName}" declares a timeoutMs of ${String(timeoutMs)}, which is not a positive ` +
+      "integer number of milliseconds. It will not be sent to the daemon, so calls to this tool " +
+      "get the daemon's default 10s deadline; the app-side handler timeout is unaffected.",
+  );
+
+  return undefined;
 };
 
 export const toToolDescriptor = (
@@ -495,6 +525,7 @@ export const toToolDescriptor = (
     "output",
     definition.name,
   );
+  const wireTimeoutMs = toWireTimeoutMs(definition.timeoutMs, definition.name);
 
   if (inputSchema !== undefined && !isObjectRootedSchema(inputSchema)) {
     warnNonObjectRootedSchema(definition.name, "input", inputSchema);
@@ -515,8 +546,6 @@ export const toToolDescriptor = (
     // Only the tool's *explicit* `timeoutMs` travels on the wire — never the app-wide
     // `defaultToolTimeoutMs`, which stays a purely app-side fallback. Omitted entirely (no
     // `timeoutMs: undefined` key) when the tool declares none, so the daemon keeps its own default.
-    ...(definition.timeoutMs !== undefined
-      ? { timeoutMs: definition.timeoutMs }
-      : {}),
+    ...(wireTimeoutMs !== undefined ? { timeoutMs: wireTimeoutMs } : {}),
   };
 };

--- a/packages/react-native/src/schema.ts
+++ b/packages/react-native/src/schema.ts
@@ -1,5 +1,8 @@
 import {
+  clampToolTimeoutMs,
   isObjectRootedSchema,
+  MAX_TOOL_TIMEOUT_MS,
+  MIN_TOOL_TIMEOUT_MS,
   type StandardSchemaV1,
   type StandardSchemaV1JsonSchema,
   type ToolDescriptor,
@@ -483,15 +486,34 @@ export type CordieriteNormalizedToolDefinition = Pick<
   outputSchema?: CordieriteNormalizedToolSchema;
 };
 
+/** Dedupes the timeout warnings below per tool name, matching `warnMissingSchemaExporter`. */
+const timeoutWarningsSeen = new Set<string>();
+
+const warnOnceAboutTimeout = (toolName: string, message: string): void => {
+  if (timeoutWarningsSeen.has(toolName)) {
+    return;
+  }
+  timeoutWarningsSeen.add(toolName);
+  logger.devWarn(message);
+};
+
 /**
- * The daemon's `isToolDescriptor` requires `timeoutMs` to be a positive integer when present, and
- * rejects the *whole* registry snapshot otherwise (closing the session as `invalid_registry`). An
- * app-side `timeoutMs` has never been validated — it only ever fed a local `setTimeout` — so a tool
- * that happens to declare `0` or a computed fraction must not start taking the session down now
- * that the value travels on the wire. Anything the daemon would reject is dropped from the
- * descriptor (the app-side abort timer still uses it verbatim) with a dev warning.
+ * Normalizes a tool's declared `timeoutMs` into the one number both timers use (issue #25).
+ *
+ * A declared timeout now feeds two clocks: this app's abort timer and, via the descriptor, the
+ * daemon's `tools.call` timer. The daemon clamps whatever it is given to
+ * [{@link MIN_TOOL_TIMEOUT_MS}, {@link MAX_TOOL_TIMEOUT_MS}], so passing an out-of-range value
+ * through untouched would make the two disagree — declare 900_000 and the daemon gives up at ten
+ * minutes while the handler runs five minutes longer; declare 500 and this app aborts before the
+ * daemon's one-second floor. Clamping here, with the shared bounds, keeps a single deadline.
+ *
+ * A value the daemon's `isToolDescriptor` could never accept is dropped instead of clamped: the
+ * guard rejects the *whole* registry snapshot over one bad field, closing the session as
+ * `invalid_registry`. An app-side `timeoutMs` was never validated before (it only fed a local
+ * `setTimeout`), so a tool declaring something odd must degrade to the default rather than take
+ * the session down.
  */
-const toWireTimeoutMs = (
+export const normalizeToolTimeoutMs = (
   timeoutMs: number | undefined,
   toolName: string,
 ): number | undefined => {
@@ -499,17 +521,28 @@ const toWireTimeoutMs = (
     return undefined;
   }
 
-  if (Number.isInteger(timeoutMs) && timeoutMs > 0) {
-    return timeoutMs;
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    warnOnceAboutTimeout(
+      toolName,
+      `Tool "${toolName}" declares a timeoutMs of ${String(timeoutMs)}, which is not a finite ` +
+        "number of milliseconds. It is ignored, so this tool falls back to the default deadline.",
+    );
+    return undefined;
   }
 
-  logger.devWarn(
-    `Tool "${toolName}" declares a timeoutMs of ${String(timeoutMs)}, which is not a positive ` +
-      "integer number of milliseconds. It will not be sent to the daemon, so calls to this tool " +
-      "get the daemon's default 10s deadline; the app-side handler timeout is unaffected.",
-  );
+  const clamped = clampToolTimeoutMs(timeoutMs);
 
-  return undefined;
+  if (clamped !== timeoutMs) {
+    warnOnceAboutTimeout(
+      toolName,
+      `Tool "${toolName}" declares a timeoutMs of ${String(timeoutMs)}, outside the supported ` +
+        `range of ${String(MIN_TOOL_TIMEOUT_MS)}-${String(MAX_TOOL_TIMEOUT_MS)}ms. It is clamped ` +
+        `to ${String(clamped)}ms, which is what both this app's handler timeout and the daemon's ` +
+        "call deadline use.",
+    );
+  }
+
+  return clamped;
 };
 
 export const toToolDescriptor = (
@@ -525,7 +558,10 @@ export const toToolDescriptor = (
     "output",
     definition.name,
   );
-  const wireTimeoutMs = toWireTimeoutMs(definition.timeoutMs, definition.name);
+  const wireTimeoutMs = normalizeToolTimeoutMs(
+    definition.timeoutMs,
+    definition.name,
+  );
 
   if (inputSchema !== undefined && !isObjectRootedSchema(inputSchema)) {
     warnNonObjectRootedSchema(definition.name, "input", inputSchema);
@@ -545,7 +581,7 @@ export const toToolDescriptor = (
       : {}),
     // Only the tool's *explicit* `timeoutMs` travels on the wire — never the app-wide
     // `defaultToolTimeoutMs`, which stays a purely app-side fallback. Omitted entirely (no
-    // `timeoutMs: undefined` key) when the tool declares none, so the daemon keeps its own default.
-    ...(wireTimeoutMs !== undefined ? { timeoutMs: wireTimeoutMs } : {}),
+    // `timeout_ms: undefined` key) when the tool declares none, so the daemon keeps its default.
+    ...(wireTimeoutMs !== undefined ? { timeout_ms: wireTimeoutMs } : {}),
   };
 };

--- a/packages/react-native/src/schema.ts
+++ b/packages/react-native/src/schema.ts
@@ -512,5 +512,11 @@ export const toToolDescriptor = (
     ...(definition.annotations !== undefined
       ? { annotations: definition.annotations }
       : {}),
+    // Only the tool's *explicit* `timeoutMs` travels on the wire — never the app-wide
+    // `defaultToolTimeoutMs`, which stays a purely app-side fallback. Omitted entirely (no
+    // `timeoutMs: undefined` key) when the tool declares none, so the daemon keeps its own default.
+    ...(definition.timeoutMs !== undefined
+      ? { timeoutMs: definition.timeoutMs }
+      : {}),
   };
 };

--- a/packages/shared/src/__tests__/tool-descriptor.test.ts
+++ b/packages/shared/src/__tests__/tool-descriptor.test.ts
@@ -26,19 +26,13 @@ describe("isToolDescriptor", () => {
         ...valid(),
         input_schema: { type: "object" },
         output_schema: { type: "object", properties: {} },
-        annotations: {
-          readOnlyHint: true,
-          destructiveHint: false,
-          idempotentHint: true,
-        },
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
       }),
     ).toBe(true);
   });
 
   test("accepts partial annotations", () => {
-    expect(
-      isToolDescriptor({ ...valid(), annotations: { readOnlyHint: true } }),
-    ).toBe(true);
+    expect(isToolDescriptor({ ...valid(), annotations: { readOnlyHint: true } })).toBe(true);
   });
 
   test.each([
@@ -66,39 +60,25 @@ describe("isToolDescriptor", () => {
   });
 
   test("rejects an oversized description", () => {
-    expect(
-      isToolDescriptor({
-        ...valid(),
-        description: "a".repeat(MAX_TOOL_DESCRIPTION_LENGTH + 1),
-      }),
-    ).toBe(false);
+    expect(isToolDescriptor({ ...valid(), description: "a".repeat(MAX_TOOL_DESCRIPTION_LENGTH + 1) })).toBe(
+      false,
+    );
   });
 
   test("rejects a non-object input_schema", () => {
-    expect(
-      isToolDescriptor({ ...valid(), input_schema: "not-an-object" }),
-    ).toBe(false);
+    expect(isToolDescriptor({ ...valid(), input_schema: "not-an-object" })).toBe(false);
   });
 
   test("rejects a non-object output_schema", () => {
-    expect(
-      isToolDescriptor({ ...valid(), output_schema: ["not", "an", "object"] }),
-    ).toBe(false);
+    expect(isToolDescriptor({ ...valid(), output_schema: ["not", "an", "object"] })).toBe(false);
   });
 
   test("rejects annotation keys outside the three boolean hints", () => {
-    expect(
-      isToolDescriptor({
-        ...valid(),
-        annotations: { readOnlyHint: true, extra: true },
-      }),
-    ).toBe(false);
+    expect(isToolDescriptor({ ...valid(), annotations: { readOnlyHint: true, extra: true } })).toBe(false);
   });
 
   test("rejects a non-boolean annotation value", () => {
-    expect(
-      isToolDescriptor({ ...valid(), annotations: { readOnlyHint: "yes" } }),
-    ).toBe(false);
+    expect(isToolDescriptor({ ...valid(), annotations: { readOnlyHint: "yes" } })).toBe(false);
   });
 
   test("accepts a positive integer timeout_ms", () => {
@@ -171,13 +151,7 @@ describe("isObjectRootedSchema", () => {
   });
 
   test("accepts the shapes zod exports for a passthrough object and a record", () => {
-    expect(
-      isObjectRootedSchema({
-        type: "object",
-        properties: {},
-        additionalProperties: {},
-      }),
-    ).toBe(true);
+    expect(isObjectRootedSchema({ type: "object", properties: {}, additionalProperties: {} })).toBe(true);
     expect(
       isObjectRootedSchema({
         type: "object",
@@ -199,20 +173,11 @@ describe("isObjectRootedSchema", () => {
 
   test.each([
     ["union (anyOf)", { anyOf: [{ type: "object" }, { type: "object" }] }],
-    [
-      "discriminated union (oneOf)",
-      { oneOf: [{ type: "object" }, { type: "object" }] },
-    ],
-    [
-      "intersection (allOf)",
-      { allOf: [{ type: "object" }, { type: "object" }] },
-    ],
-  ])(
-    "rejects a %s schema even though every branch is an object",
-    (_label, schema) => {
-      expect(isObjectRootedSchema(schema)).toBe(false);
-    },
-  );
+    ["discriminated union (oneOf)", { oneOf: [{ type: "object" }, { type: "object" }] }],
+    ["intersection (allOf)", { allOf: [{ type: "object" }, { type: "object" }] }],
+  ])("rejects a %s schema even though every branch is an object", (_label, schema) => {
+    expect(isObjectRootedSchema(schema)).toBe(false);
+  });
 
   test('rejects a union type that merely includes "object"', () => {
     expect(isObjectRootedSchema({ type: ["object", "null"] })).toBe(false);
@@ -224,12 +189,8 @@ describe("isObjectRootedSchema", () => {
   });
 
   test("is only the root-type gate: object-rooted shapes MCP still rejects pass here", () => {
-    expect(
-      isObjectRootedSchema({ type: "object", properties: { a: true } }),
-    ).toBe(true);
-    expect(isObjectRootedSchema({ type: "object", required: "name" })).toBe(
-      true,
-    );
+    expect(isObjectRootedSchema({ type: "object", properties: { a: true } })).toBe(true);
+    expect(isObjectRootedSchema({ type: "object", required: "name" })).toBe(true);
   });
 });
 
@@ -244,9 +205,7 @@ describe("clampToolTimeoutMs", () => {
     expect(clampToolTimeoutMs(-1)).toBe(MIN_TOOL_TIMEOUT_MS);
     expect(clampToolTimeoutMs(999)).toBe(MIN_TOOL_TIMEOUT_MS);
     expect(clampToolTimeoutMs(900_000)).toBe(MAX_TOOL_TIMEOUT_MS);
-    expect(clampToolTimeoutMs(Number.MAX_SAFE_INTEGER)).toBe(
-      MAX_TOOL_TIMEOUT_MS,
-    );
+    expect(clampToolTimeoutMs(Number.MAX_SAFE_INTEGER)).toBe(MAX_TOOL_TIMEOUT_MS);
   });
 
   test("always returns a value the descriptor guard accepts", () => {

--- a/packages/shared/src/__tests__/tool-descriptor.test.ts
+++ b/packages/shared/src/__tests__/tool-descriptor.test.ts
@@ -78,6 +78,28 @@ describe("isToolDescriptor", () => {
     expect(isToolDescriptor({ ...valid(), annotations: { readOnlyHint: "yes" } })).toBe(false);
   });
 
+  test("accepts a positive integer timeoutMs", () => {
+    expect(isToolDescriptor({ ...valid(), timeoutMs: 60_000 })).toBe(true);
+    expect(isToolDescriptor({ ...valid(), timeoutMs: 1 })).toBe(true);
+  });
+
+  test("accepts a descriptor that omits timeoutMs (older apps keep the daemon default)", () => {
+    expect(isToolDescriptor(valid())).toBe(true);
+    expect(isToolDescriptor({ ...valid(), timeoutMs: undefined })).toBe(true);
+  });
+
+  test.each([
+    ["zero", 0],
+    ["negative", -1],
+    ["fractional", 1.5],
+    ["a numeric string", "60000"],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["null", null],
+  ])("rejects a timeoutMs that is %s", (_label, timeoutMs) => {
+    expect(isToolDescriptor({ ...valid(), timeoutMs })).toBe(false);
+  });
+
   test("rejects null", () => {
     expect(isToolDescriptor(null)).toBe(false);
   });

--- a/packages/shared/src/__tests__/tool-descriptor.test.ts
+++ b/packages/shared/src/__tests__/tool-descriptor.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  clampToolTimeoutMs,
   isObjectRootedSchema,
   isToolDescriptor,
   MAX_TOOL_DESCRIPTION_LENGTH,
+  MAX_TOOL_TIMEOUT_MS,
+  MIN_TOOL_TIMEOUT_MS,
   TOOL_NAME_PATTERN,
 } from "../domains/tool-descriptor.js";
 
@@ -23,13 +26,19 @@ describe("isToolDescriptor", () => {
         ...valid(),
         input_schema: { type: "object" },
         output_schema: { type: "object", properties: {} },
-        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+        },
       }),
     ).toBe(true);
   });
 
   test("accepts partial annotations", () => {
-    expect(isToolDescriptor({ ...valid(), annotations: { readOnlyHint: true } })).toBe(true);
+    expect(
+      isToolDescriptor({ ...valid(), annotations: { readOnlyHint: true } }),
+    ).toBe(true);
   });
 
   test.each([
@@ -57,35 +66,49 @@ describe("isToolDescriptor", () => {
   });
 
   test("rejects an oversized description", () => {
-    expect(isToolDescriptor({ ...valid(), description: "a".repeat(MAX_TOOL_DESCRIPTION_LENGTH + 1) })).toBe(
-      false,
-    );
+    expect(
+      isToolDescriptor({
+        ...valid(),
+        description: "a".repeat(MAX_TOOL_DESCRIPTION_LENGTH + 1),
+      }),
+    ).toBe(false);
   });
 
   test("rejects a non-object input_schema", () => {
-    expect(isToolDescriptor({ ...valid(), input_schema: "not-an-object" })).toBe(false);
+    expect(
+      isToolDescriptor({ ...valid(), input_schema: "not-an-object" }),
+    ).toBe(false);
   });
 
   test("rejects a non-object output_schema", () => {
-    expect(isToolDescriptor({ ...valid(), output_schema: ["not", "an", "object"] })).toBe(false);
+    expect(
+      isToolDescriptor({ ...valid(), output_schema: ["not", "an", "object"] }),
+    ).toBe(false);
   });
 
   test("rejects annotation keys outside the three boolean hints", () => {
-    expect(isToolDescriptor({ ...valid(), annotations: { readOnlyHint: true, extra: true } })).toBe(false);
+    expect(
+      isToolDescriptor({
+        ...valid(),
+        annotations: { readOnlyHint: true, extra: true },
+      }),
+    ).toBe(false);
   });
 
   test("rejects a non-boolean annotation value", () => {
-    expect(isToolDescriptor({ ...valid(), annotations: { readOnlyHint: "yes" } })).toBe(false);
+    expect(
+      isToolDescriptor({ ...valid(), annotations: { readOnlyHint: "yes" } }),
+    ).toBe(false);
   });
 
-  test("accepts a positive integer timeoutMs", () => {
-    expect(isToolDescriptor({ ...valid(), timeoutMs: 60_000 })).toBe(true);
-    expect(isToolDescriptor({ ...valid(), timeoutMs: 1 })).toBe(true);
+  test("accepts a positive integer timeout_ms", () => {
+    expect(isToolDescriptor({ ...valid(), timeout_ms: 60_000 })).toBe(true);
+    expect(isToolDescriptor({ ...valid(), timeout_ms: 1 })).toBe(true);
   });
 
-  test("accepts a descriptor that omits timeoutMs (older apps keep the daemon default)", () => {
+  test("accepts a descriptor that omits timeout_ms (older apps keep the daemon default)", () => {
     expect(isToolDescriptor(valid())).toBe(true);
-    expect(isToolDescriptor({ ...valid(), timeoutMs: undefined })).toBe(true);
+    expect(isToolDescriptor({ ...valid(), timeout_ms: undefined })).toBe(true);
   });
 
   test.each([
@@ -96,8 +119,24 @@ describe("isToolDescriptor", () => {
     ["NaN", Number.NaN],
     ["Infinity", Number.POSITIVE_INFINITY],
     ["null", null],
-  ])("rejects a timeoutMs that is %s", (_label, timeoutMs) => {
-    expect(isToolDescriptor({ ...valid(), timeoutMs })).toBe(false);
+  ])("rejects a timeout_ms that is %s", (_label, timeout_ms) => {
+    expect(isToolDescriptor({ ...valid(), timeout_ms })).toBe(false);
+  });
+
+  test("ignores a camelCase timeoutMs: it is not the wire field, so it is neither honoured nor validated", () => {
+    // Every protocol-defined descriptor field is snake_case. A camelCase key is just an unknown
+    // extra: the guard must not read a deadline out of it, and must not reject the descriptor for
+    // it either (an app is free to carry its own extras).
+    const descriptor: unknown = { ...valid(), timeoutMs: 60_000 };
+    expect(isToolDescriptor(descriptor)).toBe(true);
+
+    if (isToolDescriptor(descriptor)) {
+      expect(descriptor.timeout_ms).toBeUndefined();
+    }
+
+    // …not even when its value is one the snake_case field would have been rejected for.
+    expect(isToolDescriptor({ ...valid(), timeoutMs: -1 })).toBe(true);
+    expect(isToolDescriptor({ ...valid(), timeoutMs: "nonsense" })).toBe(true);
   });
 
   test("rejects null", () => {
@@ -132,7 +171,13 @@ describe("isObjectRootedSchema", () => {
   });
 
   test("accepts the shapes zod exports for a passthrough object and a record", () => {
-    expect(isObjectRootedSchema({ type: "object", properties: {}, additionalProperties: {} })).toBe(true);
+    expect(
+      isObjectRootedSchema({
+        type: "object",
+        properties: {},
+        additionalProperties: {},
+      }),
+    ).toBe(true);
     expect(
       isObjectRootedSchema({
         type: "object",
@@ -154,11 +199,20 @@ describe("isObjectRootedSchema", () => {
 
   test.each([
     ["union (anyOf)", { anyOf: [{ type: "object" }, { type: "object" }] }],
-    ["discriminated union (oneOf)", { oneOf: [{ type: "object" }, { type: "object" }] }],
-    ["intersection (allOf)", { allOf: [{ type: "object" }, { type: "object" }] }],
-  ])("rejects a %s schema even though every branch is an object", (_label, schema) => {
-    expect(isObjectRootedSchema(schema)).toBe(false);
-  });
+    [
+      "discriminated union (oneOf)",
+      { oneOf: [{ type: "object" }, { type: "object" }] },
+    ],
+    [
+      "intersection (allOf)",
+      { allOf: [{ type: "object" }, { type: "object" }] },
+    ],
+  ])(
+    "rejects a %s schema even though every branch is an object",
+    (_label, schema) => {
+      expect(isObjectRootedSchema(schema)).toBe(false);
+    },
+  );
 
   test('rejects a union type that merely includes "object"', () => {
     expect(isObjectRootedSchema({ type: ["object", "null"] })).toBe(false);
@@ -170,7 +224,40 @@ describe("isObjectRootedSchema", () => {
   });
 
   test("is only the root-type gate: object-rooted shapes MCP still rejects pass here", () => {
-    expect(isObjectRootedSchema({ type: "object", properties: { a: true } })).toBe(true);
-    expect(isObjectRootedSchema({ type: "object", required: "name" })).toBe(true);
+    expect(
+      isObjectRootedSchema({ type: "object", properties: { a: true } }),
+    ).toBe(true);
+    expect(isObjectRootedSchema({ type: "object", required: "name" })).toBe(
+      true,
+    );
+  });
+});
+
+describe("clampToolTimeoutMs", () => {
+  test("passes an in-range value through, truncated to whole milliseconds", () => {
+    expect(clampToolTimeoutMs(60_000)).toBe(60_000);
+    expect(clampToolTimeoutMs(1_500.9)).toBe(1_500);
+  });
+
+  test("clamps to the bounds the daemon enforces", () => {
+    expect(clampToolTimeoutMs(0)).toBe(MIN_TOOL_TIMEOUT_MS);
+    expect(clampToolTimeoutMs(-1)).toBe(MIN_TOOL_TIMEOUT_MS);
+    expect(clampToolTimeoutMs(999)).toBe(MIN_TOOL_TIMEOUT_MS);
+    expect(clampToolTimeoutMs(900_000)).toBe(MAX_TOOL_TIMEOUT_MS);
+    expect(clampToolTimeoutMs(Number.MAX_SAFE_INTEGER)).toBe(
+      MAX_TOOL_TIMEOUT_MS,
+    );
+  });
+
+  test("always returns a value the descriptor guard accepts", () => {
+    for (const raw of [0, -1, 999, 1_000, 1_500.9, 60_000, 600_000, 900_000]) {
+      expect(
+        isToolDescriptor({
+          name: "t",
+          description: "d",
+          timeout_ms: clampToolTimeoutMs(raw),
+        }),
+      ).toBe(true);
+    }
   });
 });

--- a/packages/shared/src/domains/tool-descriptor.ts
+++ b/packages/shared/src/domains/tool-descriptor.ts
@@ -14,6 +14,28 @@ export type ToolAnnotations = {
 
 const TOOL_ANNOTATION_KEYS = ["readOnlyHint", "destructiveHint", "idempotentHint"] as const;
 
+/**
+ * The bounds the daemon enforces on any `tools.call` deadline (`docs/ARCHITECTURE.md` §5), and the
+ * deadline it applies when neither the caller nor the tool declares one.
+ *
+ * These live here, in the shared wire vocabulary, rather than in the daemon: a tool's declared
+ * {@link ToolDescriptor.timeout_ms} now crosses the wire, so the app's own abort timer and the
+ * daemon's timer must be derived from the same numbers. Two copies would silently drift into a
+ * disagreement where one side gives up while the other is still waiting.
+ */
+export const DEFAULT_TOOL_TIMEOUT_MS = 10_000;
+export const MIN_TOOL_TIMEOUT_MS = 1_000;
+export const MAX_TOOL_TIMEOUT_MS = 600_000;
+
+/**
+ * Normalizes a declared or caller-supplied timeout to a whole number of milliseconds inside
+ * [{@link MIN_TOOL_TIMEOUT_MS}, {@link MAX_TOOL_TIMEOUT_MS}]. Callers must reject non-finite input
+ * before calling this — `Math.trunc(NaN)` is `NaN`, which no comparison would clamp.
+ */
+export const clampToolTimeoutMs = (timeoutMs: number): number => {
+  return Math.min(Math.max(Math.trunc(timeoutMs), MIN_TOOL_TIMEOUT_MS), MAX_TOOL_TIMEOUT_MS);
+};
+
 export type ToolDescriptor = {
   /** Required, unique per session, `[a-zA-Z0-9_-]{1,64}`. */
   name: string;
@@ -25,8 +47,12 @@ export type ToolDescriptor = {
    * The app-declared per-call deadline for this tool, in milliseconds (a positive integer). The
    * daemon uses it as the default `tools.call` timeout when the caller passes none; an explicit
    * caller `timeoutMs` still wins. Optional — older apps omit it and keep the daemon's default.
+   *
+   * snake_case like every other protocol-defined field on this descriptor; the camelCase
+   * `timeoutMs` spelling belongs to the RN `registerTool` option and the `tools.call` RPC param,
+   * which are camelCase layers. A camelCase key arriving here is not a timeout and is ignored.
    */
-  timeoutMs?: number;
+  timeout_ms?: number;
 };
 
 const isJsonObject = (value: unknown): value is Record<string, unknown> => {
@@ -89,7 +115,10 @@ export const isToolDescriptor = (value: unknown): value is ToolDescriptor => {
     return false;
   }
 
-  if (value.timeoutMs !== undefined && (!Number.isInteger(value.timeoutMs) || (value.timeoutMs as number) <= 0)) {
+  if (
+    value.timeout_ms !== undefined &&
+    (!Number.isInteger(value.timeout_ms) || (value.timeout_ms as number) <= 0)
+  ) {
     return false;
   }
 

--- a/packages/shared/src/domains/tool-descriptor.ts
+++ b/packages/shared/src/domains/tool-descriptor.ts
@@ -21,6 +21,12 @@ export type ToolDescriptor = {
   input_schema?: ToolSchemaDescriptor;
   output_schema?: ToolSchemaDescriptor;
   annotations?: ToolAnnotations;
+  /**
+   * The app-declared per-call deadline for this tool, in milliseconds (a positive integer). The
+   * daemon uses it as the default `tools.call` timeout when the caller passes none; an explicit
+   * caller `timeoutMs` still wins. Optional — older apps omit it and keep the daemon's default.
+   */
+  timeoutMs?: number;
 };
 
 const isJsonObject = (value: unknown): value is Record<string, unknown> => {
@@ -80,6 +86,10 @@ export const isToolDescriptor = (value: unknown): value is ToolDescriptor => {
   }
 
   if (!isValidAnnotations(value.annotations)) {
+    return false;
+  }
+
+  if (value.timeoutMs !== undefined && (!Number.isInteger(value.timeoutMs) || (value.timeoutMs as number) <= 0)) {
     return false;
   }
 


### PR DESCRIPTION
## What changed and why

An agent calling an app tool over MCP could not run anything past 10 seconds, and no knob on the MCP path could change that. A tool's `timeoutMs` never left the app, so the daemon always fell back to `DEFAULT_CALL_TIMEOUT_MS`, and the MCP server's own daemon connection raced that timer at its own 10 s default.

**The tool's declared deadline now reaches the daemon.**

- `ToolDescriptor` gains an optional `timeout_ms`; `isToolDescriptor` requires a positive integer when present. Older apps omit it and keep the 10 s default. The field is snake_case like every other protocol-defined descriptor field; `timeoutMs` remains the spelling of the RN `registerTool` option and the `tools.call` RPC param, which are camelCase layers.
- `toToolDescriptor` forwards only the tool's *explicit* `timeoutMs` — never the client-wide `defaultToolTimeoutMs`, which would silently retune every tool in the app.
- The daemon's `tools.call` resolves its deadline as `timeoutMs ?? tool.timeout_ms`, then clamps as before.
- `mcp/tool-namespace.ts`'s explicit field pick carries the new field through; `toMcpTool` deliberately does not, so the MCP `Tool` JSON is unchanged.

**A caller can shorten the deadline but cannot extend it past the app's own timer.** The app runs an independent abort timer per call, set from the tool's declared `timeoutMs` (else `defaultToolTimeoutMs`), and stops the handler there regardless of what the caller asked for. So `--timeout 60000` against a tool that declares nothing still gets the app's 10 s. Raising a tool's budget is the app's decision, made by declaring `timeoutMs` on the registration. The docs, both READMEs and the `--timeout` help text say this explicitly.

**Both timers come from one number.** The bounds and the clamp live in `@cordierite/shared` (`MIN_TOOL_TIMEOUT_MS`, `MAX_TOOL_TIMEOUT_MS`, `DEFAULT_TOOL_TIMEOUT_MS`, `clampToolTimeoutMs`), and the RN SDK clamps a declared timeout from that source before it reaches either the wire or the app-side abort timer. `daemon/calls.ts` re-exports its historical names over those values, and `client/app-client.ts` imports the shared clamp rather than keeping a hand copy.

**Transport watchdogs are sized for the deadline that will actually be enforced.** `deriveCallTransportTimeoutMs` (clamp + 5 s slack) is exported from `daemon/calls.ts` and used by both MCP `tools.call` sites and `cordierite invoke` — the latter was already broken before this change, dying at 10 s regardless of `--timeout`. Callers that pass no timeout of their own (`invoke` with no flag, `AppClient.call` with no `timeoutMs`) cannot know the tool's declared deadline, so they size the watchdog from `MAX_TOOL_TIMEOUT_MS`; that backstop is only reachable by a daemon that accepts a request and answers nothing, since a dropped socket already rejects pending calls immediately.

Docs: `PROTOCOL.md` §4/§5, `ARCHITECTURE.md` §5/§9/§11, plus `timeoutMs` documented in the RN README for the first time and a note on `--timeout` in the CLI README.

## Validation

Run at the repo root on the final commit:

- `pnpm build` — 3/3 tasks successful
- `pnpm typecheck` — 3/3 tasks successful
- `pnpm lint` — 0 errors, 194 warnings, **exactly the pre-existing baseline** (verified by diffing per-file warning counts against `origin/main`; the prettier and import-order warnings this branch initially introduced were fixed)
- `pnpm test`:
  - `@cordierite/shared` — 4 files, **135 passed**
  - `@cordierite/react-native` — 20 files, **224 passed**
  - `cordierite` — 45 files, **334 passed / 1 failed**

The single failure is `packages/cordierite/src/__tests__/e2e/daemon-restart.e2e.test.ts`, which fails identically on unmodified `main` in this environment and is untouched here.

Both headline tests were verified to actually discriminate by temporarily reverting the fix each covers: the MCP acceptance test fails without `timeoutMs ?? tool.timeout_ms`, and the caller test failed with `Timed out waiting for a response to "tools.call"` without the watchdog sizing. An earlier draft of the latter used a 12 s delay and passed either way (12 s sat under the 15 s pre-fix watchdog); that gap is now covered by exact unit assertions instead.

## Review findings

An adversarial review of the branch against the issue returned six findings. All six were fixed; none were dismissed.

1. **A declared `timeoutMs` outside `[1000, 600000]` went on the wire unclamped, leaving the app timer and the daemon timer disagreeing** (declare 900 000 → the daemon rejects at ten minutes while the handler runs five minutes longer). Fixed: the bounds and `clampToolTimeoutMs` moved into `@cordierite/shared` so the two sides cannot drift, `toToolDescriptor` clamps from that source with a deduped dev warning, and `registry.ts` reads the abort timer's value back off the descriptor so it is the same number by construction. Tested at both ends.
2. **`--timeout`'s help still said "default: 10000".** Reworded (and corrected again in the second round, below).
3. **`cordierite tools <name>` did not show a declared timeout.** `renderToolDetail` now renders a `Timeout (ms)` row; `renderFields` already drops undefined rows, so a tool on the daemon's default shows no line rather than a number it never declared. Covered by a test asserting both directions; the existing snapshot is unchanged because its fixture declares no timeout.
4. **The MCP watchdog was derived from a `tools/list` snapshot while the daemon reads its live registry**, so a re-registration in between could leave the watchdog sized for the old deadline and mask the real `tool_timeout`. The proxied `tools.call` now sends the clamped tool timeout explicitly, and both numbers come from that one value.
5. **No guard against a future spread leaking the timeout into the MCP `Tool`.** Added a `toMcpTool` unit test asserting the key is absent (and that a tool declaring one maps identically to one that does not), plus a `tools/list` assertion in the integration acceptance test.
6. **The new integration tests slept ~30 s of real time.** Cut to ~11 s each by asserting the watchdog arithmetic exactly and instantly at unit level (`call-timeouts.test.ts`) and keeping the integration cases just past the 10 s default.

Two further problems were found and fixed before that review, both introduced by making the tool's timeout the daemon's default:

- Callers that pass no timeout still derived a 15 s watchdog from the old 10 s default, so a tool declaring 60 s would newly fail at 15 s with a generic transport error.
- An app-side `timeoutMs` was never validated, so a tool declaring something the wire guard rejects would take the whole registry snapshot down as `invalid_registry` rather than degrading.

## Second-round review

A second review returned eight items. All eight were applied.

1. **Wire naming was camelCase among snake_case fields.** The descriptor field is now `timeout_ms` throughout — `ToolDescriptor`, `isToolDescriptor`, `toToolDescriptor`, `tool-namespace.ts`, PROTOCOL §5, and every doc and test. `timeoutMs` is kept for the RN `registerTool` option and the `tools.call` RPC param. A guard test asserts a camelCase `timeoutMs` key on the wire is ignored: not read as a deadline, and not grounds for rejecting the descriptor either (an app may carry its own extras), including when its value is one the real field would have been rejected for.
2. **Docs claimed a caller's `--timeout` "wins".** It cannot — the app aborts at its own timer regardless. ARCHITECTURE §5 and §11, both READMEs and the `--timeout` help text now say a caller can shorten the deadline but cannot extend it past the app's own timer, and state the consequence for an undeclared tool (the app's 10 s default still applies). The integration case that proved this is retitled "shortens a longer declared deadline".
3. **The MCP server clamped conditionally.** Now `clampTimeout(tool.descriptor.timeout_ms)` unconditionally, folding the 10 s default into the same value, so the watchdog and the daemon deadline can never come from different reads.
4. **`app-client.ts` kept a hand copy of the clamp.** It now imports `MAX_TOOL_TIMEOUT_MS` and `clampToolTimeoutMs` from `@cordierite/shared`; only the transport slack stays local, since that is a property of this transport rather than of the protocol. The "duplicated clamp agrees" test is deleted, as there is no longer a duplicate to agree with.
5. **RN README said "clamped daemon-side".** It now says the SDK clamps to `[1_000, 600_000]` before either timer is set, so the handler's abort timer and the daemon's deadline are the same number.
6. **A timeout-only re-registration fired a spurious `list_changed`.** `namespacedToolsSnapshotKey` now excludes the deadline, which never reaches the MCP `Tool` JSON — so nothing a client can observe changed. Two tests cover it: the key is stable across differing timeouts, and still reacts to a change a client can see.
7. **Integration margins were tight.** Both cases now declare 20 000 ms against an ~11 s reply, leaving nine seconds of headroom, so a slow runner cannot turn them into a hard `tool_timeout`. Total added wall-clock is unchanged (the reply delay is the same 11 s; only the declared ceiling moved).
8. **ARCHITECTURE §9** now notes that the MCP client's own per-request timeout is a further ceiling outside the daemon's control, and that a genuinely long tool should report progress rather than rely on the deadline alone.

The review's separate suggestion to key the dev-warning dedupe by more than tool name was left as-is, as directed: it matches the existing `warnMissingSchemaExporter` pattern.

## Noted, not fixed here

`packages/cordierite/src/__tests__/e2e/client.e2e.test.ts` has a pre-existing load-sensitive race: `daemon/audit.ts` enqueues writes and returns immediately, while the test reads the audit file straight after the calls. It failed twice during an early full-suite run on this branch, then passed 4/4 in isolation and in every later full-suite run, and passes on unmodified `main`. It is out of scope here and worth its own issue.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkzpDHexc8EuFfsFf8yQyh