### PR TITLE
chore(ci): use iPhone 17 for iOS tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -274,7 +274,7 @@ jobs:
           ruby playground/scripts/create-cordierite-test-scheme.rb playground/ios/Pods/Pods.xcodeproj
           cd playground/ios
           xcodebuild test -workspace playground.xcworkspace -scheme Cordierite-Native-Tests \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,name=iPhone 17' \
             -derivedDataPath build-included \
             C_COMPILER_LAUNCHER="$CCACHE_BIN" \
             CLANG_ENABLE_EXPLICIT_MODULES_WITH_COMPILER_LAUNCHER=YES \


### PR DESCRIPTION
## What is this?

This PR switches the iOS CI test simulator from iPhone 16 to iPhone 17. Several PRs fail before tests start because Xcode cannot find the requested iPhone 16 destination.

## How does it work?

Changes the simulator name passed to `xcodebuild test` in the shared test workflow. The branch starts from main and contains only this one-line change.

## Why is this useful?

Lets CI test whether choosing iPhone 17 is enough to resolve the destination failure. This is an experiment; it does not assume the simulator name is the confirmed root cause.
