### PR TITLE
ci: run the iOS job on macos-latest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -172,7 +172,7 @@ jobs:
           --assert-absent
 
   ios:
-    runs-on: macos-15
+    runs-on: macos-latest
     timeout-minutes: 45
     env:
       # Deliberately NOT USE_CCACHE=1. That makes react_native_post_install override CC/CXX/LD with


### PR DESCRIPTION
## Why

#46 pinned the iOS test destination to `iPhone 17`, but the `ios` job runs on `macos-15`. Those runners land on images whose default Xcode is 16.4 with only the iOS 18.5 runtime, so whether an `iPhone 17` simulator exists depends on which image the job draws. Three PR runs today (#37, #41, #44) failed at the "Test Cordierite native library" step with:

```
xcodebuild: error: Unable to find a device matching the provided destination specifier:
    { platform:iOS Simulator, OS:latest, name:iPhone 17 }
```

while identical steps on other runners (still Xcode 16.4, image `macos-15-arm64/20260829.0321.1` vs. others) passed. Main's own run of #46 happened to pass.

## What

`runs-on: macos-15` → `runs-on: macos-latest` for the `ios` job only. Per actions/runner-images, `macos-latest` currently resolves to macOS 26 arm64, which ships Xcode 26 and the iOS 26 simulators, so `iPhone 17` exists on every image. The Linux jobs already use `ubuntu-latest`.

## Validation

Workflow-only change; the proof is the `ios` job on this PR. If Xcode 26 turns out to need any adjustment for RN 0.81 or the ccache launcher flags, it will show up here rather than on the nine feature PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkzpDHexc8EuFfsFf8yQyh

---
_Generated by [Claude Code](https://claude.ai/code/session_01BkzpDHexc8EuFfsFf8yQyh)_